### PR TITLE
fix: join-code.txt went stale, and the CLI advised init when it shouldn't

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -155,18 +155,30 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # it onward to wherever it collects logs. That is durable, replicated storage
 # for a credential, sitting outside the 0600 config file that exists to hold
 # it, and it is exactly what lib/cli.js:29-34 refuses to do when it keeps join
-# codes away from the logger. So `init`'s output is redirected into
-# /data/join-code.txt (created under `umask 077`, so 0600 before a byte of it
-# exists, on the 0700 volume beside config.json), and the log gets one line
-# saying a code was made and how to read it back.
+# codes away from the logger. So the code goes to /data/join-code.txt (created
+# under `umask 077`, so 0600 before a byte of it exists, on the 0700 volume
+# beside config.json), and the log gets one line saying a code was made and how
+# to read it back.
+#
+# **The code, and nothing else.** This file used to hold `init`'s whole output,
+# which included its summary of the settings -- port, player cap, log level --
+# as they were at first boot. Nothing ever rewrites the file, so the moment
+# somebody ran `config set maxPlayers 16` that summary became a lie sitting on
+# disk, in the file the README tells people to read. It was read, it said 4,
+# and a working hub looked broken. A snapshot of settings has no reader; the
+# passcode does. So only the passcode is written, under two comment lines
+# saying what would make even that stale (a rotation) and what is authoritative
+# when it is (`invite list --reveal`, which reads the live config).
 #
 # On failure the captured output *is* printed, to stderr, and the file is
 # removed -- a first run that cannot write its config must say why, and the
-# thing it failed to write holds no secret.
+# thing it failed to write holds no secret. That capture goes to /tmp rather
+# than /data now: it exists only to be shown on the failure path, and /tmp is
+# a tmpfs under compose, so it cannot outlive the boot that produced it.
 #
 # CMD stays overridable, so every other verb still works:
 #   docker compose exec hub rby-mmo-hub invite
 #   docker run --rm -v rby-mmo-data:/data rby-mmo-hub doctor
 # ---------------------------------------------------------------------------
-ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "-c", "if [ ! -f \"$RBY_MMO_CONFIG\" ]; then code=\"$(dirname \"$RBY_MMO_CONFIG\")/join-code.txt\"; (umask 077; : > \"$code\") || { echo \"cannot write $code -- is /data writable?\" >&2; exit 1; }; if node /app/bin/rby-mmo-hub.js init --yes > \"$code\" 2>&1; then chmod 0600 \"$code\"; echo \"first run: a join code was generated, and is deliberately not in this log.\"; echo \"  read it:  docker compose exec hub rby-mmo-hub invite list --reveal\"; echo \"  or:       docker compose exec hub cat $code\"; else cat \"$code\" >&2; rm -f \"$code\"; exit 1; fi; fi; exec node /app/bin/rby-mmo-hub.js \"$@\"", "rby-mmo-hub"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "-c", "if [ ! -f \"$RBY_MMO_CONFIG\" ]; then code=\"$(dirname \"$RBY_MMO_CONFIG\")/join-code.txt\"; out=\"/tmp/rby-init.$$\"; (umask 077; : > \"$code\") || { echo \"cannot write $code -- is /data writable?\" >&2; exit 1; }; if node /app/bin/rby-mmo-hub.js init --yes > \"$out\" 2>&1; then { echo '# The join code this hub was created with, and nothing else -- the'; echo '# settings that used to be in this file went stale the first time one'; echo '# of them was changed. Nothing rewrites this, so if the code has been'; echo '# rotated since, the live one is: rby-mmo-hub invite list --reveal'; node /app/bin/rby-mmo-hub.js invite list --reveal | awk '$NF ~ /^[0-9A-HJKMNP-TV-Z]{6}$/ { print $NF; exit }'; } > \"$code\"; chmod 0600 \"$code\"; rm -f \"$out\"; echo \"first run: a join code was generated, and is deliberately not in this log.\"; echo \"  read it:  docker compose exec hub rby-mmo-hub invite list --reveal\"; echo \"  or:       docker compose exec hub cat $code\"; else cat \"$out\" >&2; rm -f \"$out\" \"$code\"; exit 1; fi; fi; exec node /app/bin/rby-mmo-hub.js \"$@\"", "rby-mmo-hub"]
 CMD ["start"]

--- a/server/README.md
+++ b/server/README.md
@@ -764,10 +764,19 @@ records this terminal now holds them.
 Without `--reveal` the `CODE` column is `******`, which is what makes
 `invite list` safe to leave on screen while somebody is watching.
 
-`/data/join-code.txt` is the other one the signpost names: the first run's
-output, captured verbatim at mode `0600` on the volume beside `config.json`.
-It is a convenience for the first boot and nothing reads it back — deleting it
-costs you nothing, and is tidy if you would rather one fewer copy existed.
+`/data/join-code.txt` is the other one the signpost names: the passcode the
+hub was created with, at mode `0600` on the volume beside `config.json`, under
+two comment lines. It is a convenience for the first boot and nothing reads it
+back — deleting it costs you nothing, and is tidy if you would rather one fewer
+copy existed.
+
+It holds the code **and nothing else**, deliberately. It used to hold the whole
+of `init`'s output, settings summary included, and since nothing ever rewrites
+it, the first `config set maxPlayers 16` turned it into a stale file claiming
+`players up to 4` — in the file this README tells you to read. If you are
+looking at a hub whose settings you have changed, `status` is the answer and
+this file is not; the only thing here that can still go stale is the code
+itself, if you rotate it, which is what its comment lines say.
 
 The passcode is also in `/data/config.json` in plaintext, because the hub has
 to compute an HMAC with it. That file is `0600` in a `0700` directory owned by

--- a/server/cli.test.js
+++ b/server/cli.test.js
@@ -338,6 +338,50 @@ async function initScenarios() {
 // a passcode is required: init cannot be talked into an open hub
 // =====================================================================
 
+// A verb that edits a config which is not there must not answer "run init".
+//
+// This is a regression test for a real incident, not a hypothetical. A host set
+// maxPlayers on a hub running in Docker, from the host shell rather than inside
+// the container; the config was not there, the CLI said to run `init`, they
+// did, and `init` minted a second config with a fresh passcode and the default
+// cap. The hub they cared about never changed, so the setting "did not stick"
+// and a healthy hub looked broken. `init` is the last resort here, never the
+// opening suggestion.
+async function missingConfigAdviceScenario() {
+  const dir = scratchDir('missing-config');
+  const absent = path.join(dir, 'nope.json');
+
+  const bare = await runCli(['config', 'set', 'maxPlayers', '16', '--config', absent], { cwd: dir });
+  ok(bare.code !== cli.OK, 'editing a config that is not there fails');
+  ok(new RegExp(absent.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).test(bare.stderr),
+    'and says which path it looked at, so a wrong --config is visible');
+  ok(/docker compose exec/.test(bare.stderr),
+    'it raises the container case, which is how most people arrive here');
+  const initAt = bare.stderr.indexOf('init');
+  const dockerAt = bare.stderr.indexOf('docker compose exec');
+  ok(dockerAt !== -1 && (initAt === -1 || dockerAt < initAt),
+    'and it never leads with init -- that is what mints a duplicate hub');
+  ok(/fresh passcode|new passcode/i.test(bare.stderr),
+    'when init is mentioned at all, it says it mints a passcode nobody has');
+
+  // --- a config that exists somewhere obvious is named, and init is not
+  //     suggested at all: there is nothing to create.
+  const real = path.join(dir, 'config.json');
+  const made = await runCli(['init', '--yes', '--config', real], { cwd: dir });
+  ok(made.code === cli.OK, 'a real config exists to be found');
+
+  const elsewhere = path.join(dir, 'elsewhere.json');
+  const found = await runCli(['config', 'set', 'maxPlayers', '16', '--config', elsewhere],
+    { cwd: dir, env: { RBY_MMO_CONFIG: real } });
+  ok(found.code !== cli.OK, 'still refuses to edit the file that is not there');
+  ok(found.stderr.includes(real),
+    'but names the config it can actually see, by full path');
+  ok(/--config/.test(found.stderr),
+    'and says how to point at it');
+  ok(!/\binit\b/.test(found.stderr),
+    'and does not mention init at all -- there is nothing to create');
+}
+
 async function authIsMandatoryScenario() {
   const dir = scratchDir('auth-required');
 
@@ -1094,6 +1138,7 @@ async function main() {
     await startSurvivesAnUnreachableRouterScenario();
     await throttleVisibilityScenario();
     await doctorScenario();
+    await missingConfigAdviceScenario();
     await exitCodesScenario();
     await spawnExitCodeScenario();
   } finally {

--- a/server/lib/cli.js
+++ b/server/lib/cli.js
@@ -534,11 +534,65 @@ function loadForEdit(ctx) {
   return config.load({ path: ctx.file, env: {}, flags: {}, cwd: ctx.cwd });
 }
 
+/**
+ * The other places a config plausibly is, when it is not where we looked.
+ *
+ * Only paths that exist and are not the one already tried, so this can only
+ * ever name a real file. `/data/config.json` is on the list because it is
+ * where the container image puts one, and the commonest way to arrive here is
+ * running a verb on the host that belongs inside the container.
+ */
+function configsElsewhere(ctx) {
+  const candidates = [
+    ctx.env.RBY_MMO_CONFIG,
+    path.join(ctx.cwd, 'config.json'),
+    '/data/config.json',
+  ];
+  const seen = new Set([path.resolve(ctx.file)]);
+  const found = [];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const full = path.resolve(candidate);
+    if (seen.has(full)) continue;
+    seen.add(full);
+    try {
+      if (fs.statSync(full).isFile()) found.push(full);
+    } catch { /* not there, or not ours to read -- either way, not a lead */ }
+  }
+  return found;
+}
+
+/**
+ * Refuse a verb that edits a config which is not there -- and, crucially, do
+ * not answer with "run init".
+ *
+ * That advice used to be the first line, and it is the wrong first move
+ * roughly whenever it is read. Standing in the wrong directory, or running a
+ * verb on the host that belongs inside a container, lands here with a perfectly
+ * good hub a few metres away; `init` then mints a *second* config with a *new
+ * passcode*, and the hub the host actually cares about carries on unchanged
+ * with the old one. They then change a setting, restart, and watch nothing
+ * happen -- which is exactly the report that produced this comment.
+ *
+ * So: say where we looked, name any config we can actually see, and mention
+ * `init` last and only when there is nothing to find -- with what it costs.
+ */
 function requireExistingConfig(ctx) {
   const loaded = loadForEdit(ctx);
   if (!loaded.exists) {
     ctx.warn(`No configuration at ${ctx.file}.`);
-    ctx.warn(`Run \`${PROGRAM} init\` first, or point at another file with --config.`);
+    const elsewhere = configsElsewhere(ctx);
+    if (elsewhere.length) {
+      ctx.warn('There is one here, though:');
+      for (const other of elsewhere) ctx.warn(`    ${other}`);
+      ctx.warn(`Point at it with \`--config <path>\`, or run from its directory.`);
+    } else {
+      ctx.warn('If this hub runs in Docker, its config is inside the container');
+      ctx.warn('and not on this machine at all:');
+      ctx.warn(`    docker compose exec hub ${PROGRAM} <command>`);
+      ctx.warn(`Only if this is a brand new hub, \`${PROGRAM} init\` writes one --`);
+      ctx.warn('it mints a fresh passcode, which nobody you play with has yet.');
+    }
     return null;
   }
   return loaded;


### PR DESCRIPTION
## The report

A host set `maxPlayers` to 16 on a hub running in Docker, restarted it, and read back `players up to 4`.

The hub was correct the entire time — `config.json` said 16 and the running hub used 16. What said 4 was **`/data/join-code.txt`**, which held the whole of `init`'s first-boot output, settings summary included, and which nothing has ever rewritten. `server/README.md` points people at that file to read their passcode, so they read it, got a snapshot from the day the volume was created, and concluded a healthy hub was broken.

## Two fixes

**`join-code.txt` holds the passcode and nothing else.** Under two comment lines naming the one thing that can still date it — a rotation — and what is authoritative when it does (`invite list --reveal`, which reads the live config). A frozen settings summary had no reader; the passcode does. `init`'s full transcript still exists for the failure path, but in `/tmp`, which is a tmpfs under compose and so cannot outlive the boot that produced it.

**The CLI no longer opens with "run `init`".** Editing a config that isn't there used to answer:

> `No configuration at <path>.`
> ``Run `rby-mmo-hub init` first, or point at another file with --config.``

That is the wrong first move almost every time it's read — you're in the wrong directory, or on the host rather than inside the container, with a working hub a few metres away. Taking the advice mints a *second* config with a *new passcode* while the real hub carries on unchanged, which is a plausible route to the report above. It now names any config it can actually see (`$RBY_MMO_CONFIG`, `./config.json`, `/data/config.json`), raises the container case first, and mentions `init` last with what it costs.

## Verification

- `cli.test.js` 318 → **328**, and the new scenario was confirmed to **fail against the old message** before passing against the new one.
- Full suite green: auth 122, cli 328, config 262, hub 37, limits 507, server 85.
- Container rebuilt and run: `join-code.txt` now contains four comment lines and the code; after `config set maxPlayers 16` + restart it contains **zero** stale `players` lines, and the code in it still matches `invite list --reveal`. Hub healthy.
- Failure path re-checked: an unwritable data directory still exits with `cannot write ... -- is /data writable?`.