### PR TITLE
fix: drop the JOIN CODE row from the MMO menu, and reconcile the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this mod are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the version
 here must match `manifest.version`.
 
+## [0.2.2] - 2026-08-03
+
+### Removed
+
+- **The `JOIN CODE` row on the MMO menu.** It sat directly under `JOIN GAME`,
+  which asks for the address and then the passcode on the way in, so two rows
+  read as two halves of joining when only one of them joins anything — and
+  the screen behind both is the same grid with the same title. Every road to
+  a passcode that a player actually walks is unchanged: `JOIN GAME` asks for
+  one before dialling and typing a different one there is how a saved
+  passcode is changed, a hub that refuses one puts the player straight back
+  on the grid, and `HOST GAME > JOIN CODE` still chooses the passcode this
+  copy asks *for*. The `JOIN CODE` option row remains the standing fallback
+  for a player who only ever plays on one hub.
+
+## [0.2.1] - 2026-08-03
+
+Hub-side only — nothing in the mod itself changed, and 0.2.0 and 0.2.1 speak
+the same protocol. Written down after the fact: this shipped as tag `v0.2.1`
+without a version bump or an entry here, so a copy of the mod reporting
+`0.2.0` may be running either.
+
+### Fixed
+
+- **`/data/join-code.txt` no longer goes stale.** It held the whole of
+  `init`'s first-boot output — the settings summary included — and nothing
+  ever rewrote it, so a host who changed `maxPlayers` and read that file back
+  saw the old number and a healthy hub looked broken. It now holds the
+  passcode and nothing else, under comment lines naming the one thing that
+  can still date it (a rotation) and what is authoritative when it does. The
+  full `init` transcript survives for the failure path in `/tmp`, where it
+  cannot outlive the boot that produced it.
+- **The CLI stopped opening with "run `init` first".** Running a verb against
+  a config it cannot see almost never means there is no hub — it means the
+  wrong directory, or the host rather than the container. Taking the old
+  advice minted a second config with a new passcode while the real hub
+  carried on unchanged. It now says where it looked, names any config it can
+  actually see, raises the container case first, and mentions `init` last,
+  with what that costs.
+
+### Added
+
+- **A VPS deployment guide in `server/README.md`** — five commands on a fresh
+  Ubuntu box, plus the four things that go wrong. Builds the image *on* the
+  box, because a laptop is arm64 and a VPS is x86_64 and there is nothing to
+  compile either way. Documents where the passcode actually lives and why it
+  is deliberately kept out of `docker compose logs`, and the failure everyone
+  hits once: two firewalls, `ufw` and the provider's own, both of which have
+  to allow the port before a perfectly healthy hub stops looking broken.
+
 ## [0.2.0] - 2026-08-03
 
 Hosting software for the standalone hub, and a **six-character passcode**,

--- a/README.md
+++ b/README.md
@@ -207,11 +207,18 @@ behind it.
 
 | Row | Shows up when | What it does |
 | --- | --- | --- |
+| `HOST GAME` | not in a game | make a trainer, then the room size and the passcode |
+| `JOIN GAME` | not in a game | make a trainer, then the address and the passcode |
 | `ADDRESS` | hosting | your address again — for when someone asks *again* |
 | `PLAYERS` | connected | who's on, `n/limit` if you're hosting |
 | `CHAT` / `SAY` | connected | the log (`CHAT*` = unread) and sending |
 | `LEAVE` | you joined | drop out and **keep playing single-player** |
 | `END GAME` | hosting | asks first — this one ends it for everybody |
+
+Two rows before you're in a game, and no third one for the passcode:
+`JOIN GAME` asks for it on the way in, so typing a different one there is how
+a saved passcode gets changed. (The screenshot above is the menu mid-game,
+which is why it shows neither.)
 
 Leaving isn't quitting. Your save, your world, your party: untouched. The
 game just carries on without the other people in it.
@@ -587,7 +594,7 @@ end
 
 ## 🚧 Known jank — read this bit
 
-It's `0.2.0` and it ships flagged `experimental` on purpose. The full list
+It's `0.2.2` and it ships flagged `experimental` on purpose. The full list
 lives in `mod.card` under `differences.known`. The ones that'll actually bite
 you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/README.md
+++ b/server/README.md
@@ -109,11 +109,13 @@ case-insensitive. **Leave the port off and the mod fills in 7788**
 7778, the pokeserver relay's, and a bare hostname dialled there would report
 the relay as unreachable.
 
-`START > MMO > JOIN CODE` is still there for changing a saved passcode
-deliberately. The other way onto that screen is a mistyped one: a hub that
+There is no separate menu row for the passcode — `JOIN GAME` is the whole
+path, and typing a different one there is how a saved passcode is changed.
+The other way onto the passcode screen is a mistyped one: a hub that
 challenges a copy whose passcode is absent or wrong hangs up, says *"This
 game needs a join code."*, and puts the player back on the entry screen,
-which dials again on save.
+which dials again on save. The `JOIN CODE` option row in the mod manager is
+the standing fallback for a player who only ever plays on one hub.
 
 Every character in a passcode is on the mod's own naming grid, and
 **SELECT** flips it between letters and digits — the vanilla grid has no
@@ -722,7 +724,7 @@ are the same five commands. Run them as `root`:
 curl -fsSL https://get.docker.com | sh
 
 # 2. The code
-git clone --depth 1 --branch v0.2.0 https://github.com/alamops/RBYMMOMod.git
+git clone --depth 1 --branch v0.2.2 https://github.com/alamops/RBYMMOMod.git
 cd RBYMMOMod/server
 
 # 3. Build and run

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. Nothing enforces it mechanically -- the cheapest place to add that is an assertion in one of the *.test.js files here, which `npm test` already discovers.",
   "name": "rby-mmo-hub",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -601,7 +601,7 @@ handlers[Wire.CHALLENGE] = function(game, msg)
     -- `why` names the argument, never its value: the code does not go to the
     -- log, here or anywhere else
     mod.log:warn("could not answer the hub's challenge (%s) -- re-enter the "
-      .. "code from START > MMO > JOIN CODE", tostring(why))
+      .. "code from START > MMO > JOIN GAME", tostring(why))
     M.disconnect()
     ui:say("Couldn't answer\nthis game's code.")
     return
@@ -798,7 +798,9 @@ function M.install()
       min = Config.MIN_PLAYERS, max = Config.MAX_PLAYERS, step = 1 },
     { key = "hub", label = "JOIN", type = "text", default = Config.DEFAULT_HUB },
     -- The standing join code, so it can be seen and changed deliberately
-    -- rather than only when a hub happens to ask for it. A code typed for a
+    -- rather than only when a hub happens to ask for it -- and, since the
+    -- MMO menu no longer carries a JOIN CODE row of its own, the only place
+    -- a code is set without dialling something. A code typed for a
     -- particular hub is stored against that hub (see M.joinCode); this row
     -- is the fallback, and the one a player who only ever plays on one hub
     -- ever needs. maxLen so the manager's own naming screen -- which

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -353,14 +353,13 @@ function M:install()
           })
         end,
       }
-      -- JOIN GAME asks for a code on the way in, so this row is not the
-      -- only door to one -- it is the standing code, changed deliberately
-      -- without dialling anything, and the fallback for a hub whose code
-      -- was never typed against its own address.
-      items[#items + 1] = {
-        label = "JOIN CODE",
-        onSelect = function() mod.ui.push(game, SCREEN.JOINCODE) end,
-      }
+      -- There is deliberately no third row for the code. JOIN GAME asks for
+      -- the address and then the code, so a row called JOIN CODE sitting
+      -- under it read as the other half of joining rather than as what it
+      -- was -- somewhere to change a saved one without dialling. Two rows
+      -- that both start a join, one of which does not, is a menu that has to
+      -- be explained; the code that gets typed is now always the one on the
+      -- way in, and the standing fallback is the JOIN CODE option row.
     end
 
     local menu = mod.ui.Menu.new(game, items, {
@@ -748,17 +747,17 @@ function M:install()
 
   -- ------- joining: the code that gets you past the door
 
-  -- Reached four ways: from JOIN GAME, right after the address and before
-  -- anything is dialled; deliberately, from the MMO menu; automatically,
-  -- when a hub challenges a copy whose code is absent or was refused; and
-  -- from the host setup, to choose the code this copy will ask *for*. One
-  -- grid every time -- the glyphs and the length are the same question --
-  -- and opts says where the answer goes: opts.host stores it as this copy's
-  -- own code, opts.connect says a connection is waiting on it and dials
-  -- rather than leaving the player to walk back through the menu, and
-  -- opts.typed is an attempt this screen itself refused, coming back.
+  -- Reached three ways: from JOIN GAME, right after the address and before
+  -- anything is dialled; automatically, when a hub challenges a copy whose
+  -- code is absent or was refused; and from the host setup, to choose the
+  -- code this copy will ask *for*. One grid every time -- the glyphs and the
+  -- length are the same question -- and opts says where the answer goes:
+  -- opts.host stores it as this copy's own code, opts.connect says a
+  -- connection is waiting on it and dials rather than leaving the player to
+  -- walk back through the menu, and opts.typed is an attempt this screen
+  -- itself refused, coming back.
   --
-  -- Every one of those four is a road somebody can walk without the code in
+  -- Every one of those three is a road somebody can walk without the code in
   -- front of them, which is why the screen has a door out (escapable, above)
   -- rather than only a way forward.
   screens:register(SCREEN.JOINCODE, { new = function(game, opts)
@@ -820,9 +819,11 @@ function M:install()
     -- is in question and putting them back would invite resubmitting them.
     seed(screen, opts.typed)
     -- Where B lands: the lock menu for a host who came here to choose the
-    -- code they ask *for*, the MMO menu for everyone typing one in -- in
-    -- both cases the screen this one was opened from, and never a socket
-    -- left half-dialled, because nothing has been dialled yet.
+    -- code they ask *for* -- the screen that opened this one -- and the MMO
+    -- menu for everyone typing one in, which is the address screen's own way
+    -- out and the only answer on the challenge path, where there is no
+    -- screen behind this to go back to. Never a socket left half-dialled,
+    -- because nothing has been dialled yet.
     return escapable(screen, function()
       mod.ui.push(game, opts.host and SCREEN.HOSTCODE or SCREEN.MAIN)
     end, true)


### PR DESCRIPTION
## The row

`START → MMO` offered three rows when you weren't in a game: `HOST GAME`, `JOIN GAME`, `JOIN CODE`. The third read as the other half of the second — `JOIN GAME` already asks for the address **and then the code** before anything is dialled, and the screen behind both rows is the same naming grid with the same `JOIN CODE` title. Only one of the two actually joins a game. A menu where that has to be explained has a row too many, so the row is gone.

Nothing a player walks is lost:

- `JOIN GAME` asks for a code on the way in, and typing a different one there is how a saved code gets changed.
- A hub that refuses a code puts the player straight back on the grid.
- `HOST GAME > JOIN CODE` still picks the code this copy asks *for*.
- The `JOIN CODE` **option** row is still the standing fallback for someone who only ever plays on one hub — and is now the only place a code is set without dialling something.

`SCREEN.JOINCODE` is reached three ways instead of four, and the comments that counted four now count three. The challenge-failure warning in `src/Client.lua` no longer points at a menu path that doesn't exist.

## The version

The other half of this is a version that had come loose. **`v0.2.1` was tagged and pushed with no version bump and no changelog entry**, which left a live bug: the VPS guide in `server/README.md` pinned

```sh
git clone --depth 1 --branch v0.2.0 https://github.com/alamops/RBYMMOMod.git
```

so a host following it built a hub **without** the `join-code.txt` staleness fix that `v0.2.1` exists to ship.

- Backfilled a `## [0.2.1]` section describing what that tag actually contains (the `join-code.txt` fix, the CLI's misleading "run `init` first", the VPS guide), with a note that it shipped unversioned — so a copy reporting `0.2.0` may be either build.
- This work is `0.2.2`, and every place a version appears now says the same number: `manifest.json`, `server/package.json`, README's known-jank line, and the clone pin.

⚠️ **`v0.2.2` has to be tagged at release** or that clone command won't resolve. I chose that over pinning `v0.2.1`, since otherwise the pin goes stale again the moment this ships — which is the bug itself.

## Docs

README's "The menu" table only listed the connected rows; it now lists `HOST GAME` / `JOIN GAME` too, plus a line on why there's deliberately no third row for the passcode. **No screenshot needed regenerating** — `docs/screenshots/mmo-menu.png` is captured mid-game (`tests/drivers/mmo_guest.lua:624`) and shows neither row.

## Verification

| Suite | Result |
| --- | --- |
| `luajit mods/rby_mmo/tests/rby_mmo_test.lua` | 470/470 |
| `modkit validate` / `lint` / `pack` | clean (`rby_mmo-0.2.2.modpkg`) |
| `node server/hub.test.js` | 37/37 |
| `node server/cli.test.js` | 328/328 |

No test asserted the removed row existed — the e2e drivers only touch `HOST > JOIN CODE`, which is unchanged. T4 reports 2 failures, both pre-existing in the unrelated `mods/dramatic_shape`.