### PR TITLE
fix: keep the address you type on the screen, port and all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,16 @@ in a sentence the game already renders rather than failing silently.
 
 ### Fixed
 
+- **The address you type ran off the right of the screen.** `NamingScreen`
+  lays its typed line out as `maxLen` slots of 8px from a fixed x=56, which
+  fits the vanilla seven-character name and nothing longer. Every grid this
+  mod opens is longer: at 32 the line ran to 312 on a 160-wide screen, so
+  `192.168.1.20:7788` lost its port off the edge — the half a player most
+  needs to check — and what was left sat hard against the right side instead
+  of centred. Chat (16) overflowed too and a join code (12) stopped exactly on
+  the edge. The mod now repaints that one row on its own grids: as many slots
+  as fit between the margins, centred, showing the end of the line once it is
+  longer than the window. No other screen is touched.
 - **Silent sockets could lock everyone out of the hub.** `hub.js` registered a
   connection in its client table on accept, so the player cap counted peers
   that had never said `hello` — four of them held a four-player hub shut for

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -83,6 +83,79 @@ local function ownTitle(title)
   return title
 end
 
+-- ------- the typed line, kept on the screen
+--
+-- NamingScreen draws the line it is typing into as `maxLen` slots of 8px
+-- starting at a fixed x=56 (src/ui/NamingScreen.lua) -- a layout sized for
+-- the vanilla seven-character name, which ends at 112 on a 160-wide screen
+-- and so never had to think about the right edge.
+--
+-- Every grid this mod opens is longer than seven. An address is 32, which
+-- runs the line out to 312: a player typing "192.168.1.20:7788" watches the
+-- port -- the half they most need to check -- disappear off the screen, and
+-- what is left sits hard against the right side rather than centred. Chat
+-- at 16 overflows too, and the 12 of a join code stops exactly on the edge.
+--
+-- So this mod repaints that one row on its own screens: as many slots as
+-- fit between the margins, centred, and -- once what is typed is longer
+-- than the window -- the *end* of it, because the characters just entered
+-- are the ones being checked. Nothing else on the page moves. The title
+-- sits at y=8 and the grid starts at y=48, so the 8px row at y=24 is the
+-- mod's to paint over.
+local SCREEN_W = 160
+local FIELD_Y = 24
+local SLOT_W = 8
+local FIELD_MARGIN = 8
+local FIELD_SLOTS = math.floor((SCREEN_W - FIELD_MARGIN * 2) / SLOT_W)
+
+-- Pure, and exported, so the arithmetic that decides "does this fit" is
+-- pinned by the suite rather than by looking at a screenshot.
+function M.fieldLayout(maxLen, glyphs)
+  maxLen = math.max(tonumber(maxLen) or 0, 0)
+  glyphs = type(glyphs) == "table" and glyphs or {}
+  local slots = math.min(maxLen, FIELD_SLOTS)
+  -- nothing scrolls until it has to: the window holds the whole line while
+  -- it fits, and its last `slots` characters once it does not
+  local skip = math.max(#glyphs - slots, 0)
+  local cells = {}
+  for i = 1, slots do
+    cells[i] = glyphs[skip + i] or "-"
+  end
+  return math.floor((SCREEN_W - slots * SLOT_W) / 2), cells
+end
+
+-- Every naming grid this mod opens, built here rather than at each call
+-- site so a screen added later cannot quietly get the off-screen version.
+local function namingScreen(game, opts)
+  local screen = mod.ui.NamingScreen.new(game, opts)
+  local baseDraw = screen.draw
+  if type(baseDraw) ~= "function" then
+    mod.log:warn("the naming screen is not the shape this mod wraps, so a "
+      .. "long address may run off the right edge -- update the mod for "
+      .. "this engine build")
+    return screen
+  end
+
+  screen.draw = function(self, ...)
+    local out = baseDraw(self, ...)
+    local Font = mod.ui.Font
+    if not (Font and Font.draw) then return out end
+    local x, cells = M.fieldLayout(self.maxLen, self.glyphs)
+    -- the widget paints its page white, so painting the row it drew back to
+    -- white is what erases it; then the same black the rest of the page uses
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.rectangle("fill", 0, FIELD_Y, SCREEN_W, SLOT_W)
+    love.graphics.setColor(0, 0, 0, 1)
+    for i = 1, #cells do
+      Font.draw(cells[i], x + (i - 1) * SLOT_W, FIELD_Y)
+    end
+    love.graphics.setColor(1, 1, 1, 1)
+    return out
+  end
+
+  return screen
+end
+
 -- A trainer card for somebody else.
 --
 -- The engine's own TrainerCard reads the local save, so it cannot be
@@ -722,7 +795,7 @@ function M:install()
 
   screens:register(SCREEN.JOINADDR, { new = function(game)
     local client = ctx.client
-    local screen = mod.ui.NamingScreen.new(game, {
+    local screen = namingScreen(game, {
       title = ownTitle("JOIN"),
       -- An address or a hostname: "255.255.255.255:65535" is 21, but
       -- "mybox.example.com:7788" is 22, and a name is what a host on a LAN
@@ -765,7 +838,7 @@ function M:install()
     opts = opts or {}
     local client = ctx.client
     local address = opts.address or client:joinAddress()
-    local screen = mod.ui.NamingScreen.new(game, {
+    local screen = namingScreen(game, {
       title = ownTitle("JOIN CODE"),
       -- the entry cap, not CODE_LEN: a code copied off a chat line or a
       -- screenshot arrives with spaces and stray punctuation around its six
@@ -998,7 +1071,7 @@ function M:install()
     -- length and what happens on confirm differ
     if opts.scope == "name" then
       local client = ctx.client
-      return mod.ui.NamingScreen.new(game, {
+      return namingScreen(game, {
         title = ownTitle("YOUR NAME"),
         maxLen = Config.NAME_MAX,
         default = client:playerName(game),
@@ -1012,7 +1085,7 @@ function M:install()
     local title = opts.scope == "private"
       and ("TO " .. tostring(opts.toName or "?"))
       or (opts.scope == "local" and "SAY NEARBY" or "SAY TO ALL")
-    return mod.ui.NamingScreen.new(game, {
+    return namingScreen(game, {
       title = ownTitle(title),
       maxLen = Config.COMPOSE_MAX,
       onDone = function(text)

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -147,19 +147,27 @@ return function(game)
     check(typed and table.concat(naming.glyphs) == naming.default,
           "and the line reads back what was typed: "
             .. table.concat(naming.glyphs))
-    -- What is on the line is not always what is on the screen. NamingScreen
-    -- draws the field from x=56 in 8px cells, so 13 of them fit across a
-    -- 160px screen while this screen's maxLen is 32 -- "127.0.0.1:7788" is
-    -- 14 characters and loses its last one off the right edge. Logged rather
-    -- than asserted: it is a drawing bug in a screen this file does not own,
-    -- and turning it into a failure here would stop the run reporting on the
-    -- things it does own.
-    local VISIBLE_CELLS = 13
-    if #naming.default > VISIBLE_CELLS then
-      log(("WARN the address field draws %d cells but holds %d characters, so "
-        .. "%q shows as %q"):format(VISIBLE_CELLS, #naming.default,
-        naming.default, naming.default:sub(1, VISIBLE_CELLS)))
-    end
+    -- What is on the line has to be what is on the screen, which is not the
+    -- same claim. NamingScreen draws its field from a fixed x=56 in 8px
+    -- cells, so only 13 fit across a 160px screen while this screen's maxLen
+    -- is 32: "127.0.0.1:7788" is 14 characters and used to lose its last one
+    -- -- part of the port, the half a player most needs to check -- off the
+    -- right edge, with the rest pushed hard against that edge rather than
+    -- centred. src/Ui.lua repaints the row now (M.fieldLayout), so 18 cells
+    -- fit between the margins and this is a real check rather than the WARN
+    -- it was while the bug belonged to a screen nothing here owned.
+    --
+    -- The port, specifically, is what is asserted. "Everything fits" would
+    -- be the wrong claim: maxLen is 32 precisely so a hostname can be typed,
+    -- and "mybox.example.com:7788" is 22 -- longer than the window on
+    -- purpose. What the fix guarantees for *any* length is that the window
+    -- holds the end of the line, so the port never scrolls away.
+    local VISIBLE_CELLS = 18
+    local shown = naming.default:sub(-VISIBLE_CELLS)
+    local port = naming.default:match(":(%d+)$")
+    check(port ~= nil and shown:find(":" .. port, 1, true) ~= nil,
+          ("the port is on screen, not cut off the right edge: %q shows as %q")
+            :format(naming.default, shown))
     check(H.clearGrid(game, naming), "B erases it back to an empty line")
 
     -- The other thing this field takes, and the one that fits: a hostname.

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -1435,7 +1435,60 @@ eq(overlay:worldIsFlat(gameWith({ voxel = 3, tiltshift = 1 })), false,
 stubPipelines = {}
 
 -- ------------------------------------------------------------------
--- 7. Settings the player changes in game
+-- 8. The typed line staying on a 160-wide screen
+-- ------------------------------------------------------------------
+--
+-- NamingScreen lays its field out from a fixed x=56 for maxLen slots of
+-- 8px, which was written for the vanilla seven-character name.  Every grid
+-- this mod opens is longer, and at 32 -- an address -- the line ran to 312
+-- on a 160-wide screen: "192.168.1.20:7788" typed in and the port gone off
+-- the right edge, with no way to check it.  The whole point of the layout
+-- below is that no length the mod uses can do that again, so the lengths
+-- are read out of Config rather than written down here.
+
+local Ui = need("Ui")
+
+local function fits(maxLen, typed)
+  local glyphs = {}
+  for i = 1, #(typed or "") do glyphs[i] = typed:sub(i, i) end
+  local x, cells = Ui.fieldLayout(maxLen, glyphs)
+  return x, cells, x + #cells * 8
+end
+
+for _, case in ipairs({
+  { "an address", 32 },
+  { "a chat line", Config.COMPOSE_MAX },
+  { "a join code", Config.CODE_ENTRY_MAX },
+  { "a trainer name", Config.NAME_MAX },
+}) do
+  local label, maxLen = case[1], case[2]
+  local x, cells, right = fits(maxLen)
+  check(x >= 0 and right <= 160, label .. " draws inside the screen")
+  eq(x, 160 - right, label .. " is centred, not pushed to one side")
+  check(#cells > 0, label .. " shows something to type into")
+end
+
+-- The case the screenshot was taken of: the whole address, readable.
+local addrX, addrCells = fits(32, "192.168.1.20:7788")
+eq(table.concat(addrCells):sub(1, 17), "192.168.1.20:7788",
+   "a full ip and port is on the line, port included")
+check(addrX + #addrCells * 8 <= 160, "and still inside the right edge")
+
+-- Longer than the window: the end is what is kept, because the characters
+-- just entered are the ones being checked.
+local _, longCells = fits(32, "averylonghostname.example.com:77")
+eq(#longCells, 18, "the window is as many slots as fit between the margins")
+eq(table.concat(longCells), "ame.example.com:77",
+   "and holds the end of a line too long to show whole")
+
+-- Short lines pad with dashes exactly as the vanilla field does.
+local _, codeCells = fits(Config.CODE_ENTRY_MAX, "AB")
+eq(#codeCells, Config.CODE_ENTRY_MAX, "a short field keeps all its slots")
+eq(table.concat(codeCells), "AB" .. ("-"):rep(Config.CODE_ENTRY_MAX - 2),
+   "with dashes standing in for what is not typed yet")
+
+-- ------------------------------------------------------------------
+-- 9. Settings the player changes in game
 -- ------------------------------------------------------------------
 --
 -- Menu code calls these as client:setMaxPlayers(n) -- the colon form, which
@@ -1469,7 +1522,7 @@ eq(Client.joinAddress(), "192.168.1.7:7788", "leaving the previous one intact")
 eq(Client.isHosting(), false, "a fresh client is not hosting")
 
 -- ------------------------------------------------------------------
--- 8. Trading, and the one invariant that matters
+-- 10. Trading, and the one invariant that matters
 -- ------------------------------------------------------------------
 --
 -- Either both sides of a trade apply it or neither does.  Nothing else in


### PR DESCRIPTION
## The bug

The JOIN address field pushed its text to the right and cut it off, so you could not read back the ip and port you had just typed.

`NamingScreen` lays its typed line out as `maxLen` slots of 8px from a **fixed `x = 56`** (`src/ui/NamingScreen.lua:181-183`) — a layout sized for the vanilla seven-character name, which ends at 112 on a 160-wide screen and so never had to think about the right edge.

Every grid this mod opens is longer than seven:

| screen | `maxLen` | line ended at |
|---|---|---|
| JOIN address | 32 | **312** — far off screen |
| chat compose | 16 | **176** — off screen |
| join code | 12 | 152 — exactly on the edge |
| trainer name | 10 | 128 |

So `192.168.1.20:7788` lost its port — the half a player most needs to check — and what remained sat hard against the right side instead of centred.

## The fix

It stays in the mod rather than becoming an upstream change, because it only has to hold for the screens the mod owns.

- **`Ui.fieldLayout(maxLen, glyphs)`** — pure: returns the centred left edge and the cells to draw. As many slots as fit between the margins (18), centred.
- **`namingScreen(game, opts)`** — repaints that one row (`y = 24`) after the engine's own draw. The title sits at `y = 8` and the grid starts at `y = 48`, so nothing else on the page moves and vanilla's naming screens are untouched.
- All four of the mod's grids are built through the wrapper, so a screen added later cannot quietly get the off-screen version.

Once a line is longer than the window it shows the **end** of it. `maxLen` is 32 precisely so a hostname can be typed, and `mybox.example.com:7788` is *meant* to scroll — but the port never does.

## Verification

**Headless suite** — 488/488, up from 470. The 18 new checks read the lengths out of `Config` rather than hardcoding them, so a future `maxLen` change cannot silently reintroduce this.

**End-to-end** — the real thing: two LÖVE instances, two windows, a real socket.

```
RESULT: end-to-end passed
```

Host published `192.168.1.125:7788`; the guest typed the address on the real grid, entered the passcode wrong once then right, traded a CHARIZARD, ran a link battle to a decision with `desync=0`, and left cleanly. 0 failures on both sides. The rendered frame now reads `MYPC.LAN:7788-----` — whole address, port included.

This matters because the headless suite pins `fieldLayout`'s arithmetic but **never executes the draw wrapper** — there is no `love.graphics` under `luajit`. A bad colour order or a broken `Font.draw` call would have passed 488/488.

`modkit validate` / `lint` / `pack` all green.

## A note on the driver

`tests/drivers/mmo_join.lua` had **already found this bug** and logged it as a deliberate `WARN`:

> *13 cells fit across a 160px screen while this screen's `maxLen` is 32 — `127.0.0.1:7788` is 14 characters and loses its last one off the right edge. Logged rather than asserted: it is a drawing bug in a screen this file does not own.*

It is owned now, so that becomes a real check. The check asserts the **port** survives the window rather than "everything fits" — the latter would fail a legitimate long-hostname config, which is supposed to scroll. Probed across address lengths from 13 to 34 characters.