### PR TITLE
fix: put the player back in their own trainer when they leave a game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this mod are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the version
 here must match `manifest.version`.
 
+## [Unreleased]
+
+### Fixed
+
+- **Leaving a game left you wearing the character you picked for it.** The
+  chosen look is re-worn whenever the world may have rebuilt the player, and
+  that path used to throw away the stashed trainer sheet first — but the
+  overworld hands back the *same* player object across an ordinary map
+  change, so what got stashed the second time was this mod's own renderer.
+  One doorway was enough: leaving then "restored" you to the hub character,
+  in your own single-player game, permanently. The original is now pinned to
+  the entity it was taken from, so re-wearing cannot overwrite it and a
+  player the engine genuinely rebuilt is left with its own sheet.
+- **A dropped connection never gave the trainer back at all.** A timeout, a
+  socket error or a hub hanging up tore down the roster and the avatars but
+  nothing else, so a player who was disconnected rather than leaving stayed
+  dressed as their hub character — and any trade session stayed open on a
+  socket that was gone. An unasked-for leave now runs the same teardown a
+  deliberate one does.
+
 ## [0.2.0] - 2026-08-03
 
 Hosting software for the standalone hub, and a **six-character passcode**,

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -344,7 +344,17 @@ end
 -- once the player exists -- the renderer has to be swapped on the live
 -- object. The original is kept so leaving a game puts your own trainer
 -- back, rather than leaving you dressed as a Rocket grunt in single-player.
+--
+-- It is kept *against the entity it was taken from*. The overworld reuses
+-- one player object across map changes -- OverworldController:setMap only
+-- calls Player.new when it has none -- so re-wearing the look on map.entered
+-- reads back the renderer this mod installed a moment ago. Stashing that as
+-- "the original" is what used to hand a leaving player their hub character
+-- instead of their trainer; the owner is what tells a genuinely rebuilt
+-- player, from a new save or a new controller, apart from the same one
+-- walking through a door.
 local originalLook = nil
+local lookOwner = nil
 
 local function playerEntity()
   local world = mod.world
@@ -367,15 +377,40 @@ function M.applyLook(game)
     mod.log:warn("could not wear %s; staying as you are", tostring(id))
     return false
   end
-  if originalLook == nil then originalLook = player.sprite end
+  if lookOwner ~= player then
+    originalLook = player.sprite
+    lookOwner = player
+  end
   player.sprite = renderer
   return true
 end
 
+-- Entering a map can rebuild the player, taking the chosen look with it, so
+-- the look is re-worn from map.entered rather than watched for.
+--
+-- It is a named function and not a line inside that listener because this is
+-- where the bug was: the listener used to clear the stashed original first,
+-- and since the overworld usually hands back the *same* player object, what
+-- applyLook then stashed was the mod's own renderer. One door and the real
+-- trainer was gone. applyLook re-reads the original only when the entity
+-- really changed, so the re-wear is safe now -- and the suite can say so.
+--
+-- The gate is "already wearing one, or in a game and meant to be": the
+-- second half keeps a look that failed to apply at connect time retrying on
+-- the next map, which is what the transport check here used to do alone.
+function M.refreshLook()
+  if lookOwner == nil and not transport:isReady() then return false end
+  return M.applyLook(ctx.game)
+end
+
 function M.restoreLook()
-  local player = playerEntity()
-  if player and originalLook ~= nil then player.sprite = originalLook end
-  originalLook = nil
+  -- Only onto the entity the original was taken from: a player rebuilt
+  -- since then is already wearing its own sheet, and writing a stale
+  -- renderer over it would be this same bug pointing the other way.
+  if lookOwner and originalLook ~= nil and playerEntity() == lookOwner then
+    lookOwner.sprite = originalLook
+  end
+  originalLook, lookOwner = nil, nil
 end
 
 -- ------- connect / disconnect
@@ -758,12 +793,16 @@ local function tick(game, dt)
     if handler then handler(game, msg) end
   end
 
-  -- a failure surfaced inside update (timeout, socket error) tears the
-  -- world state down so nothing is left drawn over a dead connection
+  -- A failure surfaced inside update (timeout, socket error, the hub
+  -- hanging up) is a leave the player did not choose, so it tears down
+  -- exactly what an asked-for leave does -- their own trainer back
+  -- included. Tearing down only part of it left a dropped player standing
+  -- in single-player wearing whoever they picked for the hub, and a trade
+  -- session still open on a socket that is gone.
   if not transport:isOpen() then
-    if transport.error then ui:say(tostring(transport.error)) end
-    ctx.avatars:clear()
-    ctx.roster:reset()
+    local reason = transport.error
+    M.disconnect()
+    if reason then ui:say(tostring(reason)) end
     return
   end
 
@@ -849,12 +888,7 @@ function M.install()
   mod.events:on("player.warped", function() pushPresence(true) end)
   mod.events:on("map.entered", function()
     pushPresence(true)
-    -- entering a map can rebuild the player, taking the chosen look with
-    -- it; re-wearing it here is cheaper than watching for that
-    if transport:isReady() then
-      originalLook = nil
-      M.applyLook(ctx.game)
-    end
+    M.refreshLook()
   end)
 
   -- Facing a remote player and pressing A opens the same menu the roster

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -61,6 +61,13 @@ return function(game)
     return
   end
 
+  -- The trainer this player owns, taken before anything is dialled. Joining
+  -- swaps the live renderer for the chosen character and leaving has to put
+  -- this exact object back -- so it is held by identity from here to the
+  -- LEAVE check at the end of the run.
+  local ownSheet = H.playerSheet(game)
+  check(ownSheet ~= nil, "the player is drawn with something to begin with")
+
   -- The host writes its address once the listener is up; that file is the
   -- start gun. This side still dials the default 127.0.0.1:7788, because
   -- both instances are on one machine.
@@ -328,6 +335,13 @@ return function(game)
   log("said hello")
   U.wait(60)
 
+  -- Joining changes what *this* player sees too, not just what the host
+  -- sees. Checked before the map change below so the restore check at the
+  -- end cannot pass vacuously on a look that was never worn.
+  local wornSheet = H.playerSheet(game)
+  check(wornSheet ~= nil and wornSheet ~= ownSheet,
+        "joining put the chosen character on this player")
+
   -- ------- 1. leave the map and come back
 
   local home = mod_current(game)
@@ -340,6 +354,14 @@ return function(game)
   U.teleport(game, home.mapId, home.x, home.y, "down")
   U.wait(60)
   log("back on " .. tostring(home.mapId))
+
+  -- A map change re-wears the look, and the overworld usually hands back the
+  -- same player object when it does. That is where the trainer sheet used to
+  -- be lost: it was replaced with the mod's own renderer, and leaving then
+  -- "restored" the player to the character they picked for the hub. Still
+  -- wearing it here, and still able to get back, is the pair that says so.
+  check(H.playerSheet(game) ~= ownSheet,
+        "still wearing the chosen character after a map change")
   H.signal("guest_back_on_map")
 
   -- ------- 4. interact with the host, and get the trade/battle menu
@@ -543,6 +565,12 @@ return function(game)
                 and (after.x ~= before.x or after.y ~= before.y),
                 "and the world is still playable afterwards")
           check(#H.partySpecies(game) > 0, "with the party intact")
+          -- and as themselves. Walking out of someone else's game must not
+          -- leave this player wearing the character they picked for it --
+          -- the same object they were drawn with before dialling, not
+          -- merely something that is not the hub character.
+          check(H.playerSheet(game) == ownSheet,
+                "and back in their own trainer, not the hub character")
           U.shot(game, SHOT_DIR .. "/join-after-leaving.png")
         else
           check(false, "no LEAVE row while connected as a guest")

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -588,6 +588,23 @@ function M.playerCell(game)
   return { mapId = ow.map.id, x = ow.player.cellX, y = ow.player.cellY }
 end
 
+-- The renderer this game's own player is drawn with, by identity.
+--
+-- Not which sprite was *chosen* -- exports.myLook already answers that, and
+-- it kept answering correctly while the player was visibly wearing someone
+-- else. This is the live object on the entity, which is the only thing that
+-- says what is actually on screen, and comparing it to the one taken before
+-- connecting is how "leaving gives you your own trainer back" is checkable
+-- at all.
+function M.playerSheet(game)
+  local ow
+  for i = #game.stack.states, 1, -1 do
+    if game.stack.states[i].isOverworld then ow = game.stack.states[i] break end
+  end
+  ow = ow or game.overworld
+  return ow and ow.player and ow.player.sprite or nil
+end
+
 -- the other side's avatar, as this game sees it
 function M.avatarRow(exports, name)
   for _, row in ipairs(exports.avatarState() or {}) do

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -1772,4 +1772,108 @@ stubMod.log.warn = function() end
 
 end)()
 
+-- ------------------------------------------------------------------
+-- 9. Leaving gives the player their own trainer back
+-- ------------------------------------------------------------------
+--
+-- Wearing a hub character has to be undone on the way out, or a player who
+-- joins once is a Rocket grunt in their own single-player game forever.
+--
+-- The trap is that the overworld reuses one player object across map
+-- changes -- OverworldController:setMap calls Player.new only when it has
+-- none -- while this mod re-wears the look on every map.entered. Re-reading
+-- "the original" on each of those reads back the renderer the mod itself
+-- installed, so leaving restored the hub character. One door was enough to
+-- lose the real one, which is why the entity the original came from is
+-- pinned here alongside it.
+--
+-- Wrapped for scope, like section 8.
+
+;(function()
+
+local Client = need("Client")
+
+-- The real renderer needs a graphics context; the bookkeeping under test
+-- does not care what the object is, only which one is where.
+package.loaded["src.render.SpriteRenderer"] = {
+  new = function(record, kind) return { worn = record, kind = kind } end,
+}
+
+stubSprites.SPRITE_RED = { walker = true }
+stubSprites.SPRITE_ROCKET = { walker = true }
+stubSave.sprite = "SPRITE_ROCKET"
+eq(Client.spriteChoice(), "SPRITE_ROCKET", "the chosen character resolves")
+
+local overworld = { player = nil }
+stubMod.world = { overworld = function() return overworld end }
+
+local function newPlayer(name)
+  return { sprite = { vanilla = name } }
+end
+
+-- ------- one player object, walked through a door
+
+local red = newPlayer("red")
+overworld.player = red
+local redSheet = red.sprite
+
+check(Client.applyLook(), "joining wears the chosen character")
+check(red.sprite ~= redSheet, "which really does swap the live renderer")
+
+-- map.entered, twice, on the player object the overworld handed back
+check(Client.refreshLook(), "entering a map re-wears it")
+check(Client.refreshLook(), "and again, as a long session would")
+check(red.sprite ~= redSheet, "still wearing it")
+
+Client.restoreLook()
+eq(red.sprite, redSheet, "leaving gives the player their own trainer back")
+
+Client.restoreLook()
+eq(red.sprite, redSheet, "and leaving twice is not a second restore")
+
+-- ------- the same, through the client's own teardown
+--
+-- disconnect() is the one path both a deliberate leave and a dropped
+-- connection go through, so the restore is pinned on it and not only on
+-- restoreLook directly.
+
+check(Client.applyLook(), "wearing it again for the teardown")
+check(red.sprite ~= redSheet, "worn")
+Client.disconnect()
+eq(red.sprite, redSheet, "disconnecting puts the trainer back")
+
+-- ------- nothing worn, nothing to re-wear
+
+eq(Client.refreshLook(), false,
+   "a map change outside a game does not dress the player up")
+eq(red.sprite, redSheet, "and leaves the trainer alone")
+
+-- ------- a player the engine really did rebuild
+
+check(Client.applyLook(), "worn, and then the world rebuilds the player")
+local blue = newPlayer("blue")
+local blueSheet = blue.sprite
+overworld.player = blue
+
+-- the map that rebuilt the player re-wears on the new one, and the sheet it
+-- stashes is that one's own -- not the renderer left on the object that died
+check(Client.refreshLook(), "the rebuilt player wears the character")
+check(blue.sprite ~= blueSheet, "worn")
+Client.restoreLook()
+eq(blue.sprite, blueSheet, "and gets its own sheet back, not the old one's")
+
+-- and a restore aimed at an entity that is already gone stays its hand
+check(Client.applyLook(), "worn on the current player")
+local ghost = newPlayer("ghost")
+local ghostSheet = ghost.sprite
+overworld.player = ghost
+Client.restoreLook()
+eq(ghost.sprite, ghostSheet, "a player swapped in since is left exactly as it is")
+
+stubMod.world = nil
+stubSave.sprite = nil
+stubSprites.SPRITE_ROCKET = nil
+
+end)()
+
 T.finish("rby_mmo")


### PR DESCRIPTION
## The bug

Joining a hub swaps the renderer on the live player object and stashes the trainer sheet it replaced, so leaving can put it back. That stash was being thrown away by the code that re-wears the look on `map.entered` — it cleared the stash first, then let `applyLook` take a fresh one.

The catch is that the overworld usually hands back the **same** player object across a map change: `OverworldController:setMap` only calls `Player.new` when it has none. So the "original" the second pass stashed was this mod's own renderer. One doorway was enough, and leaving then restored the player to the character they had picked for the hub — in their own single-player game, permanently.

Same symptom by a second route: a dropped connection. A timeout, a socket error or a hub hanging up cleared the roster and the avatars and nothing else, so a player who was disconnected rather than leaving stayed dressed as their hub character, with a trade session still open on a socket that was gone.

## The fix

- The stash is pinned to the entity it came from. `applyLook` re-reads it only when the player object genuinely changed, so re-wearing cannot overwrite it, and `restoreLook` declines to write a stale renderer onto a player swapped in since.
- The `map.entered` body became `M.refreshLook` — a line inside a listener is exactly the kind of thing no suite can reach, which is why this survived as long as it did.
- `tick`'s failure branch calls `M.disconnect()` instead of a hand-rolled partial teardown, so an unasked-for leave does everything a deliberate one does.

## Verification

Covered twice, and both covers were checked against the old code rather than assumed.

- **`tests/rby_mmo_test.lua`** gains a section on the look bookkeeping — the doorway, the client teardown, a genuinely rebuilt player, and a restore aimed at an entity that is already gone. 489/489. Reinstating the old stash-clearing turns 4 of them red, including *"leaving gives the player their own trainer back"*.
- **`tests/drivers/run-mmo-e2e.sh`** already walked off the map, came back and pressed LEAVE without ever looking at the player's own sprite. It gains `H.playerSheet` — the live `ow.player.sprite` by object identity, because `exports.myLook` reports the *choice* and went on answering correctly while the player was visibly wearing someone else — plus three checks: the look goes on at join, survives a map change, and the original object returns after LEAVE. A full two-instance run passes with 0 failures on both sides; against the pre-fix `Client.lua` it fails on exactly that one check, everything else still green.
- `modkit validate` / `lint` / `pack` (warnings fatal) clean. `tests/run_modkit.lua` reports 28/30 — the two failures are in `mods/dramatic_shape` and reproduce on `main`.

Player-visible, so `CHANGELOG.md` gains an Unreleased/Fixed entry for both routes.