### PR TITLE
fix: keep the co-op e2e drivers out of the distributed archive, and bump to 0.7.2

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -26,6 +26,14 @@ tests/drivers/run-mmo-e2e.sh
 # nothing -- see the note at the top of this file.
 tests/drivers/mmo_guest.lua
 tests/drivers/run-hub-e2e.sh
+# The co-op scenario: four instances driven through a 2-on-2 battle. Same two
+# reasons as every driver above -- they reach tests/drivers/util.lua and mean
+# nothing outside a checkout. Both arrived with co-op battles and missed this
+# list, so `pack` put them in the v0.7.1 archive; it is the same trap
+# my-profile.png and rank.png document further down, and nothing mechanical
+# catches it, which is why each driver is named here one per line.
+tests/drivers/mmo_quad.lua
+tests/drivers/run-quad-e2e.sh
 
 # Working notes for whoever picks this up next; not mod content. The two
 # machine-readable ones describe how coding agents are driven in this
@@ -79,6 +87,17 @@ docs/plans/in-game-hosting.md
 docs/plans/self-hosting-server-app.md
 docs/plans/fix-taken-nick-on-ranking.md
 docs/plans/running-system.md
+docs/plans/submit-to-mod-index.md
+# Six more plans had accumulated without entries here -- the same gap this
+# list already documents for my-profile.png and rank.png, just in prose form.
+# The release workflow drops docs/ wholesale so no GitHub release ever shipped
+# them, but a locally built `modkit pack` archive did. Listed by name now.
+docs/plans/coop-battle-hp-sequencing.md
+docs/plans/coop-battle-status-and-timeout.md
+docs/plans/coop-battle-ux-findings.md
+docs/plans/coop-run-consent-and-blackout.md
+docs/plans/nire-back-sprite-pixel-ratio.md
+docs/plans/non-blocking-avatars.md
 # The upstream RFC behind co-op battles. It is a proposal against the *engine*,
 # not mod content -- a player unpacking this archive has no use for a document
 # arguing about BattleState's battler slots. Listed by name for the same reason
@@ -134,6 +153,23 @@ docs/screenshots/join-connected.png
 docs/screenshots/party-map.png
 docs/screenshots/party-townmap.png
 docs/screenshots/party-members.png
+# The rest of the party's shots, from the same driver and under the same rule.
+# party-ask.png and party-battle.png are text boxes and a menu over the
+# overworld, party-spectating.png is a battle frame watched from the outside,
+# and two-parties.png is four characters standing on a composited map -- every
+# one of them ROM tiles, ROM font, or both.
+docs/screenshots/party-ask.png
+docs/screenshots/party-battle.png
+docs/screenshots/party-spectating.png
+docs/screenshots/two-parties.png
+#
+# The co-op battle's three, captured by tests/drivers/run-quad-e2e.sh. All
+# three are the battle screen itself -- the box, the font, the four monsters --
+# which is decoded from the player's ROM top to bottom, so they are the
+# clearest case this block has and they are listed like the rest.
+docs/screenshots/coop-battle.png
+docs/screenshots/coop-item.png
+docs/screenshots/coop-switch.png
 #
 # my-profile.png arrived on main without a line here, and `pack` duly put it
 # in the archive -- 45 files instead of 44, with a composited frame inside.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this mod are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the version
 here must match `manifest.version`.
 
+## [0.7.2] - 2026-08-06
+
+### Fixed
+
+- **The distributed archive no longer carries the co-op end-to-end drivers.**
+  `tests/drivers/mmo_quad.lua` and `tests/drivers/run-quad-e2e.sh` arrived with
+  co-op battles and never reached `.modkitignore`, so `pack` duly put both in
+  the v0.7.1 zip — two files that reach engine test infrastructure and mean
+  nothing to somebody who has just unpacked a mod. Nothing mechanical was going
+  to catch it: `lint` has no opinion about a driver script, and the file count
+  only looks wrong to a reader who already knows what it should be. That is the
+  trap `my-profile.png` and `rank.png` each fell into one release apart, and the
+  fix is the same one — name the files. Both drivers are listed now, along with
+  the seven screenshots taken since the block was last touched
+  (`coop-battle.png`, `coop-item.png`, `coop-switch.png`, `party-ask.png`,
+  `party-battle.png`, `party-spectating.png`, `two-parties.png`), so
+  `modkit pack` leaves all nine behind — the release workflow already dropped
+  `docs/` wholesale, so only the two drivers ever reached a published zip.
+  Seven plan files join them on the same footing as every other plan entry —
+  `submit-to-mod-index.md` plus the six that had accumulated without a line
+  (`coop-battle-hp-sequencing.md`, `coop-battle-status-and-timeout.md`,
+  `coop-battle-ux-findings.md`, `coop-run-consent-and-blackout.md`,
+  `nire-back-sprite-pixel-ratio.md`, `non-blocking-avatars.md`): working notes
+  for whoever picks this up next, not mod content.
+
+### Changed
+
+- **Two version numbers in the docs caught up with the mod.** `README.md`'s
+  known-jank section still opened by calling this `0.5.0`, and
+  `server/README.md`'s VPS walkthrough still cloned `--branch v0.2.2` — a tag
+  from before the hub that walkthrough then tells you to build existed at all.
+  Both now name the current release.
+
 ## [0.7.1] - 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `0.5.0` and it ships flagged `experimental` on purpose. The full list
+It's `0.7.2` and it ships flagged `experimental` on purpose. The full list
 lives in `mod.card` under `differences.known`. The ones that'll actually bite
 you:
 

--- a/docs/plans/submit-to-mod-index.md
+++ b/docs/plans/submit-to-mod-index.md
@@ -1,0 +1,130 @@
+# Plan — Submit RBY MMO to gen1recomp-mod-index
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-06 |
+| Source | /implement — "submit our mod to the gen1recomp mod index as a PR" |
+| Config | AGENTS_CONFIG.yml (quality preset) |
+| Branch | feature/submit-our-mod-to-mod-index |
+| Base SHA | b737dfd |
+| Mode | **Autonomous** — grill + plan-approval gates bypassed; assumptions logged in §8 |
+
+## 1. Objective & success criteria
+
+Get `RBY MMO` listed on https://github.com/bryanthaboi/gen1recomp-mod-index:
+a PR adding `mods/alamops@rby_mmo/{meta.json,description.md}` that passes the
+index's CI (`scripts/validate.mjs`, check-duplicates, check-links, build-index)
+and honestly satisfies its PR checklist. Secondary: leave our own repo's next
+release clean (no stray test drivers in the zip) via a hygiene PR on this branch.
+
+## 2. Context & constraints (verified)
+
+- Index submission = one folder `mods/<Author>@<id>/` with `meta.json`
+  (schema-validated, `additionalProperties: false`), `description.md` (≤64 KB),
+  optional single `thumbnail.png|jpg` ≤2 MB. No multi-screenshot support.
+- **Index policy: no ROM-derived content in the index repo.** All of our
+  `docs/screenshots/*.png` are ROM-composited frames → none may be committed
+  as thumbnail. (User asked for the co-op battle shot "if they accept
+  screenshots" — they don't, in the committed sense; see §8 A1.)
+- Distribution: `github: alamops/RBYMMOMod` + GitHub Releases with asset
+  `rby_mmo-<version>.zip`. **Verified live:** 16 releases exist; latest
+  v0.7.1 with `rby_mmo-0.7.1.zip`. Version bumps never need index PRs
+  (nightly re-read, `automatic_version_check` default true).
+- **Verified gates:** `modkit validate --strict` → ok; `modkit lint` → ok
+  (run 2026-08-06 from the engine checkout against this worktree; an earlier
+  agent-reported MK302 failure did not reproduce and is discarded).
+- **Verified zip contents (v0.7.1):** clean except `tests/drivers/mmo_quad.lua`
+  and `tests/drivers/run-quad-e2e.sh` — missing from `.modkitignore` since
+  PR #15. Also missing (affects local `modkit pack` only, since release.yml
+  drops `docs/` wholesale): 7 screenshots — coop-battle, coop-item,
+  coop-switch, party-ask, party-battle, party-spectating, two-parties.
+- Our `.github/workflows/release.yml` is **correct** (it strips
+  `.modkitignore` entries + docs/; it is ahead of the engine's template —
+  an agent's "drift" claim had the diff direction backwards).
+- Stale doc versions: `README.md:965` ("Known jank" says 0.5.0),
+  `server/README.md:751` (clone pin v0.2.2). Version truth: manifest /
+  CHANGELOG / server/package.json all 0.7.1; latest tag v0.7.1 == HEAD.
+- Release bump rule (fleet knowledge): a bump touches manifest.json,
+  server/package.json, README "Known jank" line, server/README clone pin,
+  + CHANGELOG heading.
+- PR mechanics: SSH push as alamops works (`github-alamops.com`); **no** gh
+  CLI, no API token, no fork of the index repo yet. PR creation needs the
+  user's browser session or a one-click handoff.
+
+## 3. Approach & key decisions
+
+- **Two deliverables, decoupled:** (a) index-entry PR against v0.7.1 as
+  currently released — the two stray test-driver files are inert Lua/shell,
+  not ROM-derived, so the entry is honest today; (b) hygiene fixes + bump to
+  0.7.2 on this branch so the *next* release zip is fully clean. Decision
+  rests on measured zip contents, not on the checklist claims.
+- **No thumbnail** in the index PR; instead `description.md` links the
+  co-op battle and two-parties screenshots hosted in our own repo (same
+  posture our repo already takes: ROM-composited shots illustrate a GitHub
+  page, never ship in an archive).
+- meta.json `version: 0.7.1` (the currently-released version); the nightly
+  index rebuild tracks future releases automatically.
+- Index PR authored in a scratchpad clone, validated with the index's own
+  `node scripts/validate.mjs mods/alamops@rby_mmo` before submission.
+
+## 4. Work breakdown — implementation
+
+- **T1 (agent, opus) — mod-repo hygiene, this worktree only.**
+  Files owned: `.modkitignore`, `manifest.json`, `server/package.json`,
+  `README.md`, `server/README.md`, `CHANGELOG.md`.
+  Add 9 missing `.modkitignore` entries (2 test drivers with rationale
+  comments matching file style, 7 screenshots in the screenshots block);
+  bump 0.7.1→0.7.2 in manifest + server/package.json; fix README:965 to
+  0.7.2; fix server/README:751 pin to v0.7.2; add CHANGELOG `## [0.7.2]`
+  entry (packaging fix). Acceptance: all five version sites agree at 0.7.2.
+- **T2 (orchestrator) — index entry.** Clone index repo to scratchpad, write
+  `mods/alamops@rby_mmo/meta.json` + `description.md`, run their validator.
+  Files owned: scratchpad clone only.
+
+T1 ∥ T2 — disjoint trees, one wave.
+
+## 5. Work breakdown — tests
+
+No new tests: no `src/` or `server/` code changes (metadata/docs/packaging
+only), so the e2e drivers are **not applicable** (their trigger is behavior
+changes; nothing here alters behavior). Existing gates to run:
+- **T3 (agent, haiku):** `luajit mods/rby_mmo/tests/rby_mmo_test.lua`,
+  `luajit tests/run_modkit.lua`, `modkit validate --strict`, `lint`, `pack`
+  from the engine checkout + verify the packed archive contains no
+  `tests/drivers/mmo_quad*`, no `run-quad-e2e.sh`, no `docs/screenshots/*`.
+- **T4 (orchestrator):** `node scripts/validate.mjs mods/alamops@rby_mmo` in
+  the index clone (already part of T2 acceptance).
+
+## 6. Execution waves
+
+Wave 1: T1 ∥ T2. Barrier. Wave 2: T3 (+ Phase 5 review of the mod-repo
+diff). Wave 3: delivery — push branch, create both PRs (browser-session
+path; else handoff URLs).
+
+## 7. Blast radius & risks
+
+- `.modkitignore` additions only shrink the packed/released archive; the
+  release workflow reads it at build time — next tag ships clean.
+- Version bump to 0.7.2: merging this branch to main auto-tags v0.7.2 and
+  publishes a release (workflow trigger). That is the *intended* effect and
+  is gated on the user merging.
+- Index PR: reviewed by the upstream maintainer; CI check-links hits our
+  v0.7.1 release asset (exists, verified).
+- Identity risk on browser path: must verify github.com session is
+  `alamops` before any fork/PR action; abort to handoff otherwise.
+
+## 8. Open questions / assumptions (autonomous mode)
+
+- **A1 — screenshots:** committing ROM-derived screenshots to the index is
+  prohibited by their policy and our repo's legal posture, so the user's
+  "send the COOP battle one" is honored as *links* in description.md, not
+  committed pixels. If the user disagrees, the only compliant alternative
+  is an original-art thumbnail (mod's own NIRE art on a neutral background).
+- **A2 — meta.json version** pinned to released 0.7.1 (not the in-flight
+  0.7.2) so the entry is truthful the moment the PR opens.
+- **A3 — categories** `["GAMEPLAY"]`, tags `mmo, multiplayer, online,
+  co-op, chat, trading` (index enum has no MECHANIC; GAMEPLAY is the fit).
+- **A4 — version bump to 0.7.2** treated as in-scope prep ("prepare it for
+  auto update"), since it is the only way the leaked test drivers leave the
+  distributed zip.
+- **A5 — both hard gates self-approved** per autonomous invocation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",
@@ -18,6 +18,6 @@
   "dependencies": [],
   "optional_dependencies": [],
   "conflicts": [],
-  "description": "Play Kanto with friends: shared overworld presence, nicknames and chat bubbles over other players' heads, a scoped chat box, parties of two with their own chat and marker, and trade or battle requests from anywhere in the world.",
+  "description": "Play Kanto with friends: shared overworld presence, nicknames and chat bubbles over other players' heads, a scoped chat box, parties of two, co-op 2-on-2 battles, ranked PVP scored by the hub, and trade or battle requests from anywhere in the world.",
   "github": "alamops/RBYMMOMod"
 }

--- a/server/README.md
+++ b/server/README.md
@@ -748,7 +748,7 @@ are the same five commands. Run them as `root`:
 curl -fsSL https://get.docker.com | sh
 
 # 2. The code
-git clone --depth 1 --branch v0.2.2 https://github.com/alamops/RBYMMOMod.git
+git clone --depth 1 --branch v0.7.2 https://github.com/alamops/RBYMMOMod.git
 cd RBYMMOMod/server
 
 # 3. Build and run

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## What

- **`.modkitignore` catches up with the tree — 16 new entries.** The v0.7.1 zip
  shipped `tests/drivers/mmo_quad.lua` and `tests/drivers/run-quad-e2e.sh`: the
  co-op 2-on-2 driver pair arrived with #15 and never got its lines here — the
  same trap `my-profile.png` and `rank.png` each fell into one release apart.
  Both drivers are listed now, along with the seven screenshots taken since the
  block was last touched (`coop-battle`, `coop-item`, `coop-switch`,
  `party-ask`, `party-battle`, `party-spectating`, `two-parties`) and seven
  plan files (`submit-to-mod-index.md` plus six that had accumulated without an
  entry). Only the two drivers ever reached a published zip — the release
  workflow already drops `docs/` wholesale; the rest were leaking into locally
  built `modkit pack` archives.
- **0.7.2 across every version site**: `manifest.json`, `server/package.json`,
  the CHANGELOG heading — and two stale docs caught up: `README.md`'s known-jank
  line still said 0.5.0, and `server/README.md`'s VPS clone pin still said
  v0.2.2 (that pin silently sends fresh hosts to old code).
- **Manifest `description` refreshed** to mention co-op 2-on-2 battles and
  ranked PVP, so the launcher's mod card describes the mod that's actually here.
- New working notes: `docs/plans/submit-to-mod-index.md` (the mod-index
  submission plan; excluded from the archive like every other plan).

## Why now

The mod is being submitted to `gen1recomp-mod-index` (entry prepared under
`mods/alamops@rby_mmo/`). The index's review checks that nothing distributed is
dev residue or ROM-derived, so the next release needs to be clean.

## Verification

- `luajit tests/rby_mmo_test.lua` — 2064/2064 checks pass
- `server: node --test` — 7/7 suites (incl. manifest↔package version parity)
- `modkit validate --strict`, `modkit lint` — ok
- `modkit pack` — 58 files; archive inspected: no `docs/`, no `tests/`, no
  `CLAUDE.md`/`AGENTS_CONFIG.yml`/`skills-lock.json`/`tools/env.sh`/`tools/play.sh`

## On merge

The release workflow tags `v0.7.2` and publishes `rby_mmo-0.7.2.zip` — the
first zip with no test drivers inside. The mod-index listing picks it up on its
nightly rebuild automatically.