### PR TITLE
fix: the co-op joiner no longer refights the trainer they just beat

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -98,6 +98,7 @@ docs/plans/coop-battle-ux-findings.md
 docs/plans/coop-run-consent-and-blackout.md
 docs/plans/nire-back-sprite-pixel-ratio.md
 docs/plans/non-blocking-avatars.md
+docs/plans/coop-joiner-refights-the-trainer.md
 # The upstream RFC behind co-op battles. It is a proposal against the *engine*,
 # not mod content -- a player unpacking this archive has no use for a document
 # arguing about BattleState's battler slots. Listed by name for the same reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this mod are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the version
 here must match `manifest.version`.
 
+## [0.7.4] - 2026-08-06
+
+### Fixed
+
+- **The player who *joined* a co-op trainer battle no longer has to fight that
+  trainer a second time, alone.** Both players walk into the trainer, so the
+  engine builds a real battle on both machines; the co-op battle stands in for
+  it and hands it the result afterwards. That handoff only ever worked for the
+  player who pressed WAIT. Their battle rides across as `waiting.engine` and
+  `startBattle` takes it off the stack before the 2-on-2 goes on — the comment
+  there says why in one line: *"Left there it would resume the moment the co-op
+  battle popped, and the player would fight the same trainer twice."* The
+  player who pressed yes arrives through a different door (`onBattle`, the
+  message the hub sends the joiner) and that door built its plan with no engine
+  battle in it at all, so the unwind was skipped and their own battle spent the
+  whole fight buried under the co-op screen. It came back the instant that
+  screen popped: the trainer they had just beaten alongside a friend, standing
+  in front of them again, with the friend gone. The reference is client-local
+  and could never have crossed the wire — it was sitting in `self.encounter`
+  the entire time, unread. It is picked up now, keyed on the battle the hub
+  named so that the two ways into a co-op battle that never walked into
+  anything — a party-versus-party fight, and a join from the ACTIONS menu —
+  keep answering nil, which for them is correct.
+- **A joined trainer now shows the joiner their entrance and their parting
+  line.** Three things hang off that same reference: the trainer's picture, the
+  text they say on the way down, and the AI allowance the engine had already
+  computed. The joining player got none of them, which read as a small
+  graphical inconsistency and was really the same missing reference. Both
+  players walked into this trainer; both see them.
+- **A trainer somebody was standing in front of is no longer marked beaten by a
+  battle they were not in.** A player can be at a trainer, prompt up, when a
+  party-versus-party ask arrives and is answered. A party battle displaces
+  nothing, so nothing cleared the encounter that trainer was held in — and when
+  the 2-on-2 ended, the trainer was handed the *party* battle's result: marked
+  beaten by a fight they never took part in, with their prize money paid out
+  for it. Their own battle was still on the stack underneath, so it came back
+  anyway. The encounter slot is emptied when a co-op battle starts whatever is
+  in it now; a trainer this battle did not fight is simply left to be fought.
+- **Unwinding the screen stack no longer goes looking for something that is not
+  there.** `unwindTo` pops by identity, and its only other stopping condition
+  is a guard of sixteen — so a target that had already left the stack did not
+  fail to find it, it took sixteen screens down hunting for it, which mid-battle
+  is the battle and the world underneath. A held reference outliving its state
+  is ordinary (a battle that finishes itself pops itself), so it is checked now
+  rather than assumed, and a stale target does nothing at all. The same check
+  is what stops a co-op battle adopting an encounter whose battle has already
+  ended — reachable when a join is dropped by the hub, the player fights that
+  trainer alone, and a later fight against the same class on the same map with
+  the same lead produces the same key.
+
 ## [0.7.3] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `0.7.3` and it ships flagged `experimental` on purpose. The full list
+It's `0.7.4` and it ships flagged `experimental` on purpose. The full list
 lives in `mod.card` under `differences.known`. The ones that'll actually bite
 you:
 

--- a/docs/plans/coop-joiner-refights-the-trainer.md
+++ b/docs/plans/coop-joiner-refights-the-trainer.md
@@ -1,0 +1,181 @@
+# Plan — the co-op joiner refights the trainer
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-06 |
+| Source | player bug report via `/implement` |
+| Config | AGENTS_CONFIG.yml (quality) |
+| Branch | `fix/consequent-battle-for-second-player-afte` |
+| Base SHA | `37fcc2fe29afecc59b5d29a8cc58102b9923e617` |
+
+## 1. Objective & success criteria
+
+Two players in a party walk into the same trainer. The first picks **WAIT**; the
+second is asked to join and says yes; the 2-on-2 runs and ends. Today the second
+player is dropped straight back into a 1-on-1 against the trainer they just beat.
+
+Done when:
+
+1. After a co-op battle against an NPC, **both** players are returned to the
+   overworld. Neither is put back into a battle against that trainer.
+2. Both players' own engine `BattleState` is handed the result exactly once —
+   the defeated-trainer flag, the rewards, the whiteout on a wipe and the
+   suspended map script all run on both clients, as they do today for the
+   waiter.
+3. Nothing changes for the menu-join path (a player who joins from `ACTIONS`
+   without walking into a trainer), for party-vs-party battles, or for
+   `BATTLE ALONE`.
+4. The mod's Lua suite, T4, the node hub suite, `modkit validate/lint/pack`, and
+   both e2e drivers (`run-mmo-e2e.sh`, `run-hub-e2e.sh`) are green.
+
+## 2. Context & constraints
+
+The co-op battle does not reimplement a trainer fight. It **displaces** the real
+`BattleState` the engine pushed when the player walked into the trainer, holds
+it, and hands it the result afterwards (`src/Coop.lua:147-226`). Both clients
+build their own local `BattleState` — the engine pushes one on each machine when
+each player interacts with the NPC — and each holds its own in
+`self.encounter.engine` (`src/Coop.lua:519-526`).
+
+- **The waiter** promotes that reference `encounter → self.waiting` in
+  `M:beginWait` (`src/Coop.lua:590-600`) and `M:onJoined` threads it into the
+  plan as `engine = waiting.engine` (`src/Coop.lua:899`).
+- **The joiner** goes through `M:onBattle` instead (`src/Coop.lua:912-935`),
+  whose plan table has **no `engine` field at all**. The joiner's own reference
+  is still sitting in `self.encounter`, untouched — `askToJoin`'s "yes" branch
+  never calls `release()`/`consume()` (`src/Coop.lua:661-685`).
+- `M:startBattle` reads `battle.plan.engine` (`src/Coop.lua:1353`) and gates the
+  unwind on it (`src/Coop.lua:1439-1442`). Its own comment states the bug:
+  *"Left there it would resume the moment the co-op battle popped, and the
+  player would fight the same trainer twice."*
+- `CoopBattle:finish` pops only the co-op screen (`src/CoopBattle.lua:2200-2205`);
+  `StateStack:pop` is synchronous and immediately exposes whatever is beneath
+  (`gen1recomp/src/core/StateStack.lua:24-31`).
+- `M:onBattleOver` only refreshes `self.encounter` from `self.engineBattle`
+  (`src/Coop.lua:1488-1499`), which is nil for the joiner — so `M:consume` calls
+  `onFinish` on a battle that is **still on the stack**, whereas the engine's own
+  `BattleState:finish` pops first and only then calls `onFinish`.
+
+Both hubs already send the battle key to the joiner: `src/Hub.lua:1446` and
+`server/lib/relay.js:464` both put `battle` in the `mmo.coop_battle` payload, and
+`Wire.battleKey` sanitises it (`src/Wire.lua:570-576`). No wire change is needed
+— the engine reference is client-local and could never cross the wire anyway.
+
+Related history: `docs/plans/coop-run-consent-and-blackout.md:135-138` already
+flagged "drop the `if engine then` asymmetry", but what shipped was only the
+unconditional `closeAskBox()` at `src/Coop.lua:1449` — the party-vs-party ask
+box. The NPC path's real `BattleState` never got the same treatment.
+
+## 3. Approach & key decisions
+
+**Give the joiner's plan the engine battle the joiner already holds, keyed by the
+battle the hub named.** `plan.engine` then means one thing on every path: *the
+local trainer battle this client walked into, if any*.
+
+- **Keyed, not unconditional.** `M:onBattle` adopts `self.encounter.engine` only
+  when `self.encounter.battle` equals `Wire.battleKey(msg.battle)`. That is what
+  keeps the menu-join path (no encounter → nil, correct) and party-vs-party
+  (`foes` present → never adopted) untouched, and what stops a stale encounter
+  for a *different* trainer being handed the wrong result.
+- **Accept the three fields that come with it** (confirmed with the owner):
+  `trainerPic`, `endBattleText` and `aiUses` are all derived from `plan.engine`
+  (`src/Coop.lua:1359-1420`). The joiner walked into this trainer, so they should
+  see the entrance picture and the defeat line exactly as the waiter does. All
+  three are local-display/AI-allowance values — `trainerPic` is draw-only
+  (`src/CoopBattle.lua:2463`, `3849`), `endBattleText` prints local message boxes
+  after the result is already settled (`src/CoopBattle.lua:1915-1920`), and
+  `aiUses` is only read by the simulating host (`src/CoopSim.lua:1468-1480`), so
+  the joiner's copy now *matches* the host's instead of defaulting to 0. None can
+  desync a host-authoritative replay. The "joined by invitation opens straight on
+  the monsters" comment (`src/Coop.lua:1360-1366`) stays true — that is the
+  menu-join path, which still has no encounter.
+- **Hand ownership over cleanly.** When `startBattle` takes the engine battle off
+  the stack into `self.engineBattle`, drop `self.encounter`. It now names a state
+  that is no longer on the stack, and `M:release()` → `unwindTo(game, engine,
+  false)` would pop up to 16 live states looking for it (`src/Coop.lua:139-145`,
+  `542-552`). `M:reset` calls `release()` on a dropped connection
+  (`src/Coop.lua:113-117`), so that window is reachable. This is a latent hazard
+  on the waiter's path today, not something the joiner fix introduces.
+
+Alternative rejected: keeping two separate engine references (one to unwind, one
+for display) so the joiner's visuals stay byte-identical. It fixes the bug but
+leaves two meanings for one thing in a file written as prose, and needs a
+paragraph to explain why the player who walked into the trainer is shown no
+trainer.
+
+## 4. Work breakdown — implementation tasks
+
+Single wave, single owner — the change is two hunks in one file plus the release
+files. No parallel fan-out: the tasks are not file-disjoint in any useful way.
+
+| ID | Goal | Files owned | Acceptance |
+| --- | --- | --- | --- |
+| I1 | `M:onBattle` adopts the joiner's own encounter engine for the NPC branch, keyed on the hub-named battle key. | `src/Coop.lua` | `plan.engine` non-nil for a joiner who walked into the trainer; nil for a menu join and for any party battle. |
+| I2 | `M:startBattle` clears `self.encounter` when it takes ownership into `self.engineBattle`. | `src/Coop.lua` | No path can `unwindTo` a battle already off the stack. |
+| I3 | Version bump + CHANGELOG entry. | `manifest.json`, `CHANGELOG.md` | 0.7.4; heading matches `manifest.version`; `affects_link` untouched. |
+
+## 5. Work breakdown — test tasks
+
+| ID | Goal | Files owned |
+| --- | --- | --- |
+| T1 | Headless: the joiner's plan carries an engine, and the joiner's own displaced battle gets its result back. Mirror of the existing waiter-only block at `tests/rby_mmo_test.lua:4941-4969`, plus an assertion on `bob.coop.lastPlan.engine` at the handoff block (`:4818-4838`), plus a negative case — a menu join / different-trainer encounter is **not** adopted. | `tests/rby_mmo_test.lua` |
+| T2 | e2e: after the co-op battle ends, the joiner is back in the overworld and the state they staged is not on top of the stack. Both drivers already stage a real trainer on the joiner (`mmo_guest.lua:897`, `mmo_join.lua:698`) and already assert `handed` (`mmo_guest.lua:1092`, `mmo_join.lua:734`) — add the "not dropped back into the battle" check next to it. | `tests/drivers/mmo_guest.lua`, `tests/drivers/mmo_join.lua`, `tests/drivers/mmo_host.lua` |
+
+**E2e applies** and is the layer that actually proves this: the headless suite
+cannot reach `M:startBattle` (no LOVE engine under luajit — it `abandon()`s
+first, per the comment at `tests/rby_mmo_test.lua:4830-4836`), so it can only pin
+the plan and handoff halves.
+
+**Run recipe.** `export PATH="/opt/homebrew/bin:$PATH"` first. From a **private**
+engine view (never repoint the shared `~/Projects/alamops/gen1recomp/mods/rby_mmo`
+symlink — other agents share it):
+
+```sh
+luajit mods/rby_mmo/tests/rby_mmo_test.lua
+luajit tests/run_modkit.lua
+python3 tools/modkit.py validate mods/rby_mmo
+python3 tools/modkit.py lint mods/rby_mmo
+python3 tools/modkit.py pack mods/rby_mmo
+node <mod>/server/hub.test.js
+MMO_ADDR_FILE=<unique> bash mods/rby_mmo/tests/drivers/run-mmo-e2e.sh
+bash mods/rby_mmo/tests/drivers/run-hub-e2e.sh
+```
+
+`MMO_SKIP_COOP` must be unset. `MMO_ADDR_FILE` must be unique per run — it
+defaults to the shared `/tmp/rby_mmo_addr.txt` (`run-mmo-e2e.sh:42`) and a
+collision reads as three unexplained failures. E2e needs a ROM imported.
+
+## 6. Execution waves
+
+One wave: I1 + I2 + I3 (same file for I1/I2), then T1 + T2, then run. Review
+between implementation and tests, per the pipeline.
+
+## 7. Blast radius & risks
+
+- **`M:onBattle` is the single entry point for both "we joined theirs" and "all
+  four agreed"** (`src/Coop.lua:909-911`). The party branch must keep `engine =
+  nil`; the `not foes` guard is what enforces that, and T1 asserts it.
+- **A joiner whose encounter is for a different trainer** must not have it
+  adopted. The battle-key match is the guard; the case is believed unreachable
+  today (a waiting player cannot reach the ACTIONS menu) but is defended anyway.
+- **Clearing `self.encounter` in `startBattle`** — verify nothing between
+  `startBattle` and `onBattleOver` reads it. `onBattleOver` re-populates it from
+  `self.engineBattle` before `consume()`, which is the only reader that matters.
+- **The joiner's new trainer picture and defeat text** are visible behaviour
+  changes. Screenshots in `docs/` taken from the co-op e2e leg may go stale
+  (fleet memory: captures are cropped 1024x768 → 800x720); recheck after the run.
+- No wire, hub, schema or link-registry change. `affects_link` stays `false`.
+- Rollback is a one-file revert.
+
+## 8. Open questions / assumptions
+
+- `M:onJoined` reads `waiting.trainer` (`src/Coop.lua:900`) but `beginWait` never
+  sets a `.trainer` field (`src/Coop.lua:590-600`), so `plan.trainer` is always
+  nil on that path. Looks like dead code, unrelated to this bug — **not touched**,
+  noted for a follow-up.
+- The hub comments describing the joiner as the one who "has never seen the
+  trainer" (`src/Hub.lua:1442-1444`, `server/lib/relay.js:462-463`) are inaccurate
+  for the walk-in case. The host choice itself is fine; the comments are worth a
+  later correction, out of scope here.
+- Assumed the coop e2e drivers are currently **red** on this bug rather than
+  green — to be confirmed by the first run.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/README.md
+++ b/server/README.md
@@ -748,7 +748,7 @@ are the same five commands. Run them as `root`:
 curl -fsSL https://get.docker.com | sh
 
 # 2. The code
-git clone --depth 1 --branch v0.7.3 https://github.com/alamops/RBYMMOMod.git
+git clone --depth 1 --branch v0.7.4 https://github.com/alamops/RBYMMOMod.git
 cd RBYMMOMod/server
 
 # 3. Build and run

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -460,7 +460,9 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
 
   relay.send(host, 'mmo.coop_joined', { id: client.id, name: client.name });
   // `host` names the client that simulates: the player who was already standing
-  // at the fight, since they have the trainer the joiner has never seen.
+  // at the fight, since they are the one guaranteed to have walked into the
+  // trainer -- the joiner usually has too, but a join taken from the ACTIONS
+  // menu never went near them.
   relay.send(client, 'mmo.coop_battle',
     { id: battleId, side: 'a', allies: members, battle, host: host.id });
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -533,6 +533,23 @@ function M:onTrainerBattle(game, state, mapId)
   return true
 end
 
+-- Is this state still on the stack at all?
+--
+-- Three answers, not two: true, false, and *nil* for "this stack cannot say".
+-- A caller that treats "cannot say" as "no" would refuse to unwind anything at
+-- all against a stack that only offers a top, and a caller that treats it as
+-- "yes" is exactly as safe as it was before this existed. Both readings are
+-- used below.
+function M:onStack(game, target)
+  local stack = game and game.stack
+  local states = stack and stack.states
+  if not (target and type(states) == "table") then return nil end
+  for i = #states, 1, -1 do
+    if states[i] == target then return true end
+  end
+  return false
+end
+
 -- Take everything above `target` off the stack, and optionally `target` too.
 --
 -- The prompt is one or two widget states deep depending on how far the player
@@ -542,6 +559,18 @@ end
 function M:unwindTo(game, target, alsoPop)
   local stack = game and game.stack
   if not (stack and target) then return false end
+  -- Never go looking for something that is not there.
+  --
+  -- The loop below stops on identity or on a guard of sixteen, and there is no
+  -- third way out -- so a target that has already left the stack does not fail
+  -- to find it, it takes sixteen screens down with it hunting for it. Mid-
+  -- battle that is the battle and the world underneath.
+  --
+  -- A held reference outliving its state is not an exotic condition: a battle
+  -- that finishes itself pops itself, and every reference anybody kept to it
+  -- is stale from that instant. So this is checked rather than assumed, and
+  -- the answer to a stale target is to do nothing at all.
+  if self:onStack(game, target) == false then return false end
   local guard = 0
   while stack:top() and stack:top() ~= target and guard < 16 do
     stack:pop()
@@ -906,6 +935,48 @@ function M:onJoined(game, msg)
   })
 end
 
+-- The engine's battle *this* client walked into, when the fight it is being
+-- sent into is the one it is standing in front of.
+--
+-- The player who waited hands their own battle over through `waiting.engine`
+-- (see M:onJoined).  This is the other half of that, and it was missing for a
+-- long time.  Both players trigger the trainer, so the engine builds a real
+-- BattleState on *both* machines -- the reference is client-local and could
+-- never have crossed the wire, which is exactly why it has to be picked up
+-- here rather than read off the message.  Without it, startBattle's unwind
+-- never ran for the player who joined: their own battle sat under the co-op
+-- screen for the whole fight and resurfaced the moment it popped, so the
+-- trainer they had just beaten alongside a friend was put in front of them
+-- again, alone.  See the comment on the unwind in M:startBattle, which
+-- describes this exact failure and only ever prevented half of it.
+--
+-- Keyed on the battle the hub named rather than taken on trust, and that is
+-- the whole of the safety here.  `self.encounter` is whatever trainer this
+-- client last walked into, and two ways into a co-op battle have nothing to do
+-- with it: a party-versus-party fight, which has foes and for which no
+-- encounter is ever the right answer, and a join from the ACTIONS menu, where
+-- nobody walked into anything and nil is the correct answer.  Matching the key
+-- adopts the encounter only when it is demonstrably the same fight, and leaves
+-- a mismatched one alone rather than handing it somebody else's result.
+--
+-- Matching the key is not quite enough on its own, because an encounter can
+-- outlive its battle: a player who says yes keeps theirs deliberately (see
+-- M:askToJoin) and the hub can still drop that join -- the partner pressing
+-- STOP in the same tick is enough -- in which case they fight the trainer
+-- alone, that battle finishes itself, and the reference left behind names
+-- nothing. The key would still match a later fight against the same class on
+-- the same map, and the same lead. So the state has to still be *there*, which
+-- is the one question the stack can answer for certain.
+function M:joinedEngine(game, msg, foes)
+  if foes then return nil end
+  local encounter = self.encounter
+  if not encounter then return nil end
+  local key = Wire.battleKey(msg and msg.battle)
+  if not (key and encounter.battle == key) then return nil end
+  if self:onStack(game, encounter.engine) == false then return nil end
+  return encounter.engine
+end
+
 -- We joined theirs, or all four agreed.  One entry point for both, because
 -- from here on they are the same thing: a set of fighters the hub has just
 -- confirmed are all still connected.
@@ -927,6 +998,10 @@ function M:onBattle(game, msg)
     side = side,
     allies = allies,
     foes = foes,
+    -- The battle this client is standing in front of, so the co-op one can
+    -- stand in for it and hand it its result.  Nil on both paths that were
+    -- never standing in front of anything -- see M:joinedEngine.
+    engine = self:joinedEngine(game, msg, foes),
     -- Derived from the id the hub named rather than assumed, so exactly one of
     -- the four believes it is the host.
     host = hostId ~= nil and self.party:isSelf(hostId),
@@ -1361,8 +1436,11 @@ function M:startBattle(game, field)
   -- through its own cache, with the trainer's palette and the padding the
   -- draw offsets assume; loading the file directly would give a differently
   -- coloured, differently placed copy. So the entrance is shown by whoever
-  -- walked into them, and a client that joined by invitation opens straight
-  -- on the monsters rather than on a picture that is subtly wrong.
+  -- walked into them -- which is *both* players on the wait-and-join path,
+  -- since each of them triggered the trainer and each holds their own battle.
+  -- It is nil only for somebody who walked into nothing: a party-versus-party
+  -- fight, and a join taken from the ACTIONS menu. Those open straight on the
+  -- monsters rather than on a picture that is subtly wrong.
   local trainerPic = engine and engine.trainerPic
   for i, slot in ipairs(field.slots or {}) do
     local built = {
@@ -1440,6 +1518,25 @@ function M:startBattle(game, field)
     self:unwindTo(game, engine, true)
     self.engineBattle = engine
   end
+  -- The encounter slot is emptied here whatever was in it, and the two cases
+  -- it empties are different.
+  --
+  -- The battle we just displaced is now held in `engineBattle`, and one slot
+  -- for one battle is the whole point: `release()` unwinds *to* whatever the
+  -- encounter names, and what it named is no longer on the stack.  M:reset
+  -- takes that path on a dropped connection, mid-battle.  onBattleOver puts
+  -- the battle back in this slot when there is finally a result to hand it.
+  --
+  -- Anything *else* in the slot is a trainer this battle did not fight, and
+  -- must not be told it did.  A player can be standing at a trainer, prompt
+  -- up, when a party-versus-party ask arrives and is answered -- and a party
+  -- battle displaces nothing, so nothing here would have cleared it.  Left
+  -- there, consume() would hand that trainer the *party* battle's result:
+  -- marked beaten by a fight they were not in, and their prize money paid.
+  -- Dropped instead, their battle is still sitting on the stack and comes back
+  -- when this screen pops -- so the trainer is fought, for real, which is rule
+  -- 2 and the honest outcome.
+  self.encounter = nil
   -- And on the challenge path there is no engine battle to unwind to, which
   -- is exactly how the asker's "Asked NAME for a 2-on-2 battle." box used to
   -- get buried: nothing took it down, the battle screen went on top of it, a

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -1441,8 +1441,9 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
 
   send(host, Wire.COOP_JOINED, { id = client.id, name = client.name })
   -- `host` names the client that simulates. It is the player who was already
-  -- standing at the fight: they have the trainer in front of them, which is the
-  -- one thing the joiner does not have.
+  -- standing at the fight, because they are the one *guaranteed* to have
+  -- walked into the trainer -- the joiner usually has too, but a join taken
+  -- from the ACTIONS menu never went near them.
   send(client, Wire.COOP_BATTLE,
     { id = id, side = "a", allies = members, battle = battle, host = host.id })
 end

--- a/tests/drivers/mmo_guest.lua
+++ b/tests/drivers/mmo_guest.lua
@@ -1089,11 +1089,41 @@ return function(game)
 
     -- ...and the battle it displaced is told how it went, which is what runs
     -- the whole post-battle flow in a real game.
-    local handed = H.waitSeconds(game, function()
+    --
+    -- Frames, not seconds, and deliberately so -- this is not a wait on the
+    -- other process the way a PHASE barrier is (see "phase barriers" in
+    -- mmo_util.lua). CoopBattle:finish pops its own screen; StateStack:pop
+    -- removes it and only then calls exit(), which is what reaches
+    -- M:onBattleOver and, through M:consume, `engine.onFinish` -- all inside
+    -- the one synchronous call that took the co-op screen off the stack. If
+    -- `finished` is ever going to be set, it already is by the time `over`
+    -- above went true, so a 30-second budget here only meant a genuinely
+    -- broken handoff took 30 real seconds to report as broken.
+    local handed = H.waitFor(game, function()
       return finished ~= nil
-    end, 30, "the engine's battle to be finished off")
+    end, 10, "the engine's battle to be finished off")
     check(handed, "the displaced trainer battle got its result back")
     log("co-op result handed back:", tostring(finished))
+
+    -- The bug this leg exists to catch, and why `handed` above is not enough
+    -- by itself: CoopBattle:finish only ever pops its *own* screen. Before
+    -- the fix, the trainer battle the joining player staged (`staged` above)
+    -- was never unwound off the stack -- it sat there the whole fight,
+    -- underneath the co-op screen, one slot down and invisible to a check
+    -- that only ever asks what is on top. `finished` could come back
+    -- non-nil, a real handoff, while a second, real fight against the same
+    -- trainer was still sitting on the stack waiting for input.
+    --
+    -- Checked here, before the drivePrompts below presses a single button:
+    -- that drive answers whatever is on top with A, and a real trainer
+    -- battle is itself a sequence of prompts -- FIGHT, a move, a target --
+    -- so a leaked one would be fought through in total silence and still end
+    -- up back in the overworld, reporting `settled` true below. That is
+    -- exactly how this bug could pass a check that only looked at the end
+    -- state.
+    check(not H.onStack(game, staged),
+          "the trainer battle this side staged is off the stack, not merely "
+          .. "buried under the co-op screen")
 
     -- Back to the world *properly* before anybody signals. Winning queues the
     -- engine's own aftermath -- exp boxes, any level-up, the evolution offer
@@ -1105,6 +1135,15 @@ return function(game)
       return now == nil or now == game.overworld or now.isOverworld
     end, 120)
     check(settled, "the world comes back after the 2-on-2")
+
+    -- And the overworld that came back is genuinely the overworld -- the
+    -- other half of the same claim, now that nothing is left buried for it
+    -- to be hiding under (checked above, before anything here got a chance
+    -- to fight it through).
+    local top = H.top(game)
+    check(top == game.overworld or (top and top.isOverworld) == true,
+          "and the overworld -- not a leaked trainer battle -- is what's "
+          .. "actually on top")
 
     -- Put the party back the way this leg found it.
     --

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -637,8 +637,13 @@ return function(game)
 
     -- Walk into the trainer, and wait rather than fight alone.
     local coopFinished = nil
+    -- The real BattleState this side staged, held onto (not just the result
+    -- callback above) so it can be checked for gone-from-the-stack rather
+    -- than merely told-its-result once the co-op leg is over -- see the
+    -- comment on the `handed`/onStack pair below for why both matter.
+    local staged = nil
     if coopClass then
-      H.stageTrainer(game, coopClass, function(result) coopFinished = result end)
+      staged = H.stageTrainer(game, coopClass, function(result) coopFinished = result end)
       local asked = H.waitFor(game, function()
         for _, label in ipairs(H.menuLabels(game)) do
           if label == "WAIT" then return true end
@@ -687,15 +692,52 @@ return function(game)
     check(sync.desyncs == 0, "and no drift between the two copies")
     check(sync.resyncs == 0, "and never needing the field re-sent")
 
-    local handed = H.waitSeconds(game, function()
+    -- Frames, not seconds, and deliberately so -- this is not a wait on the
+    -- guest the way a PHASE barrier is (see "phase barriers" in
+    -- mmo_util.lua). CoopBattle:finish pops its own screen; StateStack:pop
+    -- removes it and only then calls exit(), which is what reaches
+    -- M:onBattleOver and, through M:consume, `engine.onFinish` -- all inside
+    -- the one synchronous call that took the co-op screen off the stack. If
+    -- `coopFinished` is ever going to be set, it already is by the time
+    -- `over` above went true, so a 60-second budget here only meant a
+    -- genuinely broken handoff took a minute to report as broken.
+    local handed = H.waitFor(game, function()
       return coopFinished ~= nil
-    end, 60, "the engine's battle to be finished off")
+    end, 10, "the engine's battle to be finished off")
     check(handed, "and the trainer battle it displaced got its result back")
     log("co-op result:", tostring(coopFinished))
+
+    -- The bug this leg exists to catch, and why `handed` above is not enough
+    -- by itself: CoopBattle:finish only ever pops its *own* screen. Before
+    -- the fix, the trainer battle staged above was never unwound off the
+    -- stack for the player who joined -- it sat there the whole fight,
+    -- underneath the co-op screen, one slot down and invisible to a check
+    -- that only ever asks what is on top. `coopFinished` could come back
+    -- non-nil, a real handoff, while a second, real fight against the same
+    -- trainer was still sitting on the stack waiting for input.
+    --
+    -- Checked here, before the drivePrompts below presses a single button:
+    -- that drive answers whatever is on top with A, and a real trainer
+    -- battle is itself a sequence of prompts -- FIGHT, a move, a target --
+    -- so a leaked one would be fought through in total silence and still end
+    -- up back in the overworld. That is exactly how this bug could pass a
+    -- check that only looked at the end state.
+    check(not H.onStack(game, staged),
+          "the trainer battle this side staged is off the stack, not merely "
+          .. "buried under the co-op screen")
+
     H.drivePrompts(game, function()
       local top = H.top(game)
       return top == nil or top == game.overworld or top.isOverworld
     end, 120)
+    -- And the overworld that drive reached for is genuinely the overworld --
+    -- the other half of the same claim, now that nothing is left buried for
+    -- it to be hiding under (checked above, before anything here got a
+    -- chance to fight it through).
+    local top = H.top(game)
+    check(top == game.overworld or (top and top.isOverworld) == true,
+          "and the overworld -- not a leaked trainer battle -- is what's "
+          .. "actually on top, over the in-game hub too")
     H.closeToOverworld(game)
     U.shot(game, SHOT_DIR .. "/host-coop-after.png")
     H.signal("host_coop_done")

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -693,10 +693,19 @@ return function(game)
         -- joining one you are not standing at is exactly what the hub refuses.
         local coopClass = H.coopTrainer(game.data)
         local coopFinished = nil
+        -- The real BattleState this side staged, held onto (not just the
+        -- result callback above) so it can be checked for gone-from-the-stack
+        -- rather than merely told-its-result once the co-op leg is over --
+        -- see the comment on the `handed`/onStack pair below for why both
+        -- matter. This is the joining side, the role the leaked-screen bug
+        -- actually hit: `self.encounter` for a join never carried this
+        -- battle's engine reference until the fix, so this is the instance
+        -- that would have caught it.
+        local staged = nil
         H.await(game, "host_coop_waiting")
         if coopClass then
-          H.stageTrainer(game, coopClass,
-                         function(result) coopFinished = result end)
+          staged = H.stageTrainer(game, coopClass,
+                                   function(result) coopFinished = result end)
           -- Walking into the same trainer is how the offer is met: the prompt
           -- this side gets is the join, not the wait/alone.
           local offered = H.waitSeconds(game, function()
@@ -731,15 +740,53 @@ return function(game)
         check(sync.desyncs == 0, "and no drift from the host's copy")
         check(sync.resyncs == 0, "and never needing the field re-sent")
 
-        local handed = H.waitSeconds(game, function()
+        -- Frames, not seconds, and deliberately so -- this is not a wait on
+        -- the host the way a PHASE barrier is (see "phase barriers" in
+        -- mmo_util.lua). CoopBattle:finish pops its own screen; StateStack:pop
+        -- removes it and only then calls exit(), which is what reaches
+        -- M:onBattleOver and, through M:consume, `engine.onFinish` -- all
+        -- inside the one synchronous call that took the co-op screen off the
+        -- stack. If `coopFinished` is ever going to be set, it already is by
+        -- the time `over` above went true, so a 60-second budget here only
+        -- meant a genuinely broken handoff took a minute to report as broken.
+        local handed = H.waitFor(game, function()
           return coopFinished ~= nil
-        end, 60, "the engine's battle to be finished off")
+        end, 10, "the engine's battle to be finished off")
         check(handed, "and the trainer battle it displaced got its result back")
         log("co-op result:", tostring(coopFinished))
+
+        -- The bug this leg exists to catch, and why `handed` above is not
+        -- enough by itself: CoopBattle:finish only ever pops its *own*
+        -- screen. Before the fix, the trainer battle staged above -- this is
+        -- the joining side, exactly the role the bug hit -- was never
+        -- unwound off the stack. It sat there the whole fight, underneath
+        -- the co-op screen, one slot down and invisible to a check that only
+        -- ever asks what is on top. `coopFinished` could come back non-nil,
+        -- a real handoff, while a second, real fight against the same
+        -- trainer was still sitting on the stack waiting for input.
+        --
+        -- Checked here, before the drivePrompts below presses a single
+        -- button: that drive answers whatever is on top with A, and a real
+        -- trainer battle is itself a sequence of prompts -- FIGHT, a move, a
+        -- target -- so a leaked one would be fought through in total silence
+        -- and still end up back in the overworld. That is exactly how this
+        -- bug could pass a check that only looked at the end state.
+        check(not H.onStack(game, staged),
+              "the trainer battle this side staged is off the stack, not "
+              .. "merely buried under the co-op screen")
+
         H.drivePrompts(game, function()
           local top = H.top(game)
           return top == nil or top == game.overworld or top.isOverworld
         end, 120)
+        -- And the overworld that drive reached for is genuinely the
+        -- overworld -- the other half of the same claim, now that nothing is
+        -- left buried for it to be hiding under (checked above, before
+        -- anything here got a chance to fight it through).
+        local top = H.top(game)
+        check(top == game.overworld or (top and top.isOverworld) == true,
+              "and the overworld -- not a leaked trainer battle -- is what's "
+              .. "actually on top, over the in-game hub too")
         H.closeToOverworld(game)
         U.shot(game, SHOT_DIR .. "/join-coop-after.png")
         H.signal("guest_coop_done")

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -22,6 +22,25 @@ function M.top(game)
   return game.stack and game.stack:top() or nil
 end
 
+-- Is `target` anywhere in the state stack, not only on top?
+--
+-- StateStack:pop only ever removes the entry at the very end of the array, so
+-- a state that got skipped past rather than unwound does not vanish -- it
+-- stays exactly where it was, one slot down, waiting for whatever now sits
+-- above it to clear. M.top alone cannot see that: it reads only the last
+-- element, and a state buried one slot down looks identical to "gone" from up
+-- there. A co-op leg needs the stronger claim -- that the real trainer battle
+-- it displaced is off the stack *entirely*, not merely off the top -- because
+-- the bug it exists to catch is exactly a battle that survived buried, and
+-- every check that only ever asked what was on top would have missed it.
+function M.onStack(game, target)
+  if target == nil then return false end
+  for _, state in ipairs((game.stack and game.stack.states) or {}) do
+    if state == target then return true end
+  end
+  return false
+end
+
 -- Spin until `predicate` is true, or give up. Returns whether it happened,
 -- so a driver can log a real failure instead of walking on and producing a
 -- confusing error three steps later.

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -4824,6 +4824,15 @@ pump(ann); pump(bob)
 eq(ann.coop:isWaiting(), false, "a yes ends the wait")
 check(ann.coop.lastPlan ~= nil, "and the waiting player reaches the handoff")
 check(bob.coop.lastPlan ~= nil, "as does the one who joined")
+-- The bug this pins: M:onBattle used to build the joiner's plan with no
+-- `engine` field at all, so M:startBattle's unwind never ran for BOB -- his
+-- own trainer battle sat under the co-op screen for the whole fight and came
+-- straight back the moment it popped, dropping him into the same trainer
+-- again, alone. M:joinedEngine is the fix; this is its direct pin, checked by
+-- identity and not merely by non-nil, so a version that handed back the
+-- *wrong* battle would still fail here.
+check(bob.coop.lastPlan.engine == bob.engine,
+      "and BOB's own trainer battle rides along on his plan too")
 eq(ann.coop.lastPlan.kind, "npc", "as a co-op fight against an NPC")
 eq(#ann.coop.lastPlan.allies, 2, "with both of them on the same side")
 
@@ -4966,6 +4975,125 @@ check(not fightsAlone(ann), "the prompt is on top of the battle")
 pressB(ann)
 check(fightsAlone(ann), "B closes the prompt and the engine's battle resumes")
 eq(ann.finished, nil, "with nothing finished off behind its back")
+
+-- ------- BOB's own displaced battle gets its result back too
+--
+-- The block above pins the waiter's half, which already worked before the
+-- fix. This is the half that did not: before M:joinedEngine existed, a
+-- player who *joined* was never handed their own engine battle at all, so
+-- nothing was ever there for onBattleOver to find. Mirrored here to show the
+-- mechanism -- once BOB's own battle is held in engineBattle, onBattleOver
+-- hands it its result exactly as it does for a waiter -- is not itself
+-- role-specific; only getting the battle into that slot in the first place
+-- was ever the problem, and that half is pinned by the identity check on
+-- bob.coop.lastPlan.engine above.
+--
+-- bob.coop.offer is cleared first so this reaches the ordinary WAIT/ALONE
+-- choice rather than a join prompt left over from an earlier scenario in this
+-- same suite -- the fight this test cares about is BOB's own, not ANN's.
+
+bob.coop.running = false
+bob.coop.offer = nil
+engage(bob)
+pick(bob, "WAIT")
+check(bob.coop.encounter ~= nil, "BOB's own encounter is held while he waits too")
+eq(bob.finished, nil, "and his own engine battle has not been told anything yet")
+
+bob.coop.engineBattle = bob.engine
+bob.coop:onBattleOver("win")
+eq(bob.finished, "win",
+   "a finished co-op battle hands its result back to BOB's own battle too")
+eq(bob.coop.encounter, nil, "and BOB's encounter is spent as well")
+
+-- ------- ownership transfer only happens for a genuine match
+--
+-- M:startBattle is where the encounter slot is emptied, and reaching it needs
+-- a running CoopBattle, which needs the real engine's link modules -- out of
+-- reach under plain luajit, same as the abandoned four-slot field above.
+-- What *is* reachable is M:joinedEngine, which decides what that slot is
+-- emptied *of*: a call that adopts nothing must also disturb nothing. An
+-- encounter quietly cleared out from under a fight nobody joined would be the
+-- mirror bug -- release() later unwinding to a battle that is no longer on the
+-- stack, hunting for something that is not there.
+
+local ownership = { battle = FIGHT, engine = bob.engine, game = bob.game }
+bob.coop.encounter = ownership
+eq(bob.coop:joinedEngine(bob.game, { battle = OTHER }, nil), nil,
+   "a mismatched battle key adopts nothing")
+check(bob.coop.encounter == ownership,
+      "...and leaves BOB's own encounter exactly where it was")
+eq(bob.coop:joinedEngine(bob.game, { battle = FIGHT },
+                         { { id = "x", name = "X" } }), nil,
+   "and neither does a party-vs-party message, even naming the right key")
+check(bob.coop.encounter == ownership, "still untouched")
+
+-- ...and an encounter whose battle has already left the stack is not adopted
+-- either, however well its key matches. A join the hub drops leaves exactly
+-- that behind: the player fights the trainer alone, that battle pops itself,
+-- and the reference names nothing. unwindTo would then pop sixteen screens
+-- looking for it.
+local ghost = { name = "a battle that finished itself" }
+bob.coop.encounter = { battle = FIGHT, engine = ghost, game = bob.game }
+eq(bob.coop:joinedEngine(bob.game, { battle = FIGHT }, nil), nil,
+   "and neither does an encounter whose battle is already off the stack")
+eq(bob.coop:unwindTo(bob.game, ghost, true), false,
+   "unwinding to a state that is not on the stack does nothing at all")
+check(#bob.game.stack.states > 0,
+      "...rather than taking sixteen screens down hunting for it")
+bob.coop.encounter = nil
+
+-- ------- negative: a party-vs-party battle never adopts an encounter
+--
+-- foes on the plan means this is PARTY BATTLE, not an NPC fight, and no
+-- encounter is ever the right answer for one -- see M:joinedEngine's own
+-- comment. Exercised with a live encounter deliberately in place, and naming
+-- the very battle the message is about, so a guard that forgot to check
+-- `foes` first would still pass a "no encounter set" test and only fail here.
+
+bob.coop.running = false
+bob.coop.encounter = { battle = FIGHT, engine = bob.engine, game = bob.game }
+bob.coop:onBattle(bob.game, {
+  side = "a",
+  allies = { { id = bob.id, name = "BOB" } },
+  foes = { { id = ann.id, name = "ANN" } },
+  battle = FIGHT,
+})
+check(bob.coop.lastPlan ~= nil, "the party battle still reaches the handoff")
+eq(bob.coop.lastPlan.engine, nil,
+   "but never adopts BOB's own live encounter, even naming its own battle key")
+bob.coop.running, bob.coop.battle, bob.coop.encounter = false, nil, nil
+
+-- ------- negative: a different trainer, or none named at all, adopts nothing
+
+bob.coop.encounter = { battle = FIGHT, engine = bob.engine, game = bob.game }
+bob.coop:onBattle(bob.game, {
+  side = "a",
+  allies = { { id = bob.id, name = "BOB" } },
+  battle = OTHER,
+})
+eq(bob.coop.lastPlan.engine, nil,
+   "a battle naming someone else's trainer does not adopt BOB's encounter")
+bob.coop.running, bob.coop.battle, bob.coop.encounter = false, nil, nil
+
+bob.coop.encounter = { battle = FIGHT, engine = bob.engine, game = bob.game }
+bob.coop:onBattle(bob.game, {
+  side = "a",
+  allies = { { id = bob.id, name = "BOB" } },
+  -- no battle field at all -- the ACTIONS-menu join path, which never named one
+})
+eq(bob.coop.lastPlan.engine, nil,
+   "and a message with no battle key at all adopts nothing either")
+bob.coop.running, bob.coop.battle, bob.coop.encounter = false, nil, nil
+
+bob.coop.encounter = { battle = FIGHT, engine = bob.engine, game = bob.game }
+bob.coop:onBattle(bob.game, {
+  side = "a",
+  allies = { { id = bob.id, name = "BOB" } },
+  battle = "FIX|TOWN; DROP", -- fails Wire.battleKey's own sanitiser
+})
+eq(bob.coop.lastPlan.engine, nil,
+   "nor does a battle field too malformed for Wire.battleKey to accept")
+bob.coop.running, bob.coop.battle, bob.coop.encounter = false, nil, nil
 
 -- ------- a ranked 2-on-2 needs all four to agree
 --


### PR DESCRIPTION
## The bug

Two players in a party walk into the same trainer. The first picks **WAIT**, the second is asked to join and says yes, the co-op 2-on-2 runs and ends — and the second player is dropped straight back into a 1-on-1 against the trainer they had just beaten together.

## Why

A co-op battle *displaces* the real `BattleState` the engine pushes when a player walks into a trainer: it pops it off the stack, holds it, and hands it the result afterwards via `engine.onFinish(result)`. Both players trigger the trainer, so the engine builds one on **each** machine, and that reference is client-local — it could never cross the wire.

The waiting player's reference travelled `self.encounter` → `waiting.engine` → `plan.engine`. The joining player arrives through `M:onBattle` instead, which built its plan with **no `engine` field at all**, so this never ran for them:

```lua
-- src/Coop.lua, M:startBattle
-- The engine's battle comes off the stack now, and is held for its result.
-- Left there it would resume the moment the co-op battle popped, and the
-- player would fight the same trainer twice.
if engine then
  self:unwindTo(game, engine, true)
  self.engineBattle = engine
end
```

The comment had described this exact failure all along; the gate only ever prevented half of it. `CoopBattle:finish` pops only its own screen, so the joiner's battle — buried underneath for the whole fight — resurfaced the instant it popped.

## The fix

`M:joinedEngine` picks the joiner's own battle up, **keyed on the battle key both hubs already send** in `mmo.coop_battle`, plus a stack-liveness check. The key match is what keeps the two ways into a co-op fight that never walked into anything — a party-versus-party battle, and a join taken from the ACTIONS menu — correctly answering nil.

The joiner now also gets the trainer's entrance picture, their parting line, and the engine's AI allowance. All three hang off the same reference, and both players *did* walk into this trainer.

## Three more faults found while fixing it

- **A trainer could be marked beaten by a battle they were not in.** Answer a party-versus-party ask while standing at a trainer with the prompt up: a party battle displaces nothing, so nothing cleared the encounter, and `consume()` handed that trainer the *party* battle's result and paid out their prize money. The encounter slot is now emptied when a co-op battle starts, whatever is in it — the trainer is simply left to be fought for real.
- **`unwindTo` could take sixteen screens down.** It pops by identity with only a guard of sixteen as its other exit, so a target already off the stack did not fail to find it — it popped everything it could reach. Any held screen reference is stale the moment that screen pops itself, so membership is checked now rather than assumed.
- **Three files still said `0.7.3`** — `README.md`, `server/README.md`, `server/package.json`. The clone pin in particular sent installers at a tag without the fix.

Also added the new plan to `.modkitignore`; `pack` was otherwise shipping it in the archive, which is the leak 0.7.2 was released to fix.

No wire, hub, schema or link-registry change. `affects_link` stays `false`.

## Verification

| Check | Result |
|---|---|
| Lua suite | 2081/2081 (baseline 2064) |
| node hub | 122/122 |
| T4 | `rby_mmo` ok (28/30 — both failures in the unrelated `dramatic_shape` mod) |
| validate / lint / pack | ok / no ROM-derived content / 58 files |
| LAN e2e (`run-mmo-e2e.sh`) | 0 failures, both roles |
| dedicated-hub e2e (`run-hub-e2e.sh`) | 0 failures, both guests |

With the fix reverted and the new assertions kept, the drivers reproduce the asymmetry exactly:

```
MMO_HOST: ok   the trainer battle this side staged is off the stack…
MMO_JOIN: FAIL the trainer battle this side staged is off the stack…
RESULT: FAILED -- 0 host + 1 guest failure(s).
```

Worth noting for anyone reading the new e2e assertions: the pre-existing *"got its result back"* check passes on **both** roles even without the fix — `consume()` was calling `onFinish` on the never-cleared encounter, so the handoff always worked and only the stack pop was missing. *"The overworld is on top"* also passes unfixed, because `drivePrompts` mashes A and quietly fights *through* the leaked battle. Only the `H.onStack` check, placed before any button press, catches this — which is why it is where it is.

## Follow-ups left out of scope

- `M:onJoined` reads `waiting.trainer`, which `beginWait` never sets — always-nil dead code, unrelated to this bug.
- The joiner's new entrance picture and defeat line may make the co-op screenshots under `docs/` stale.