### PR TITLE
fix: apply sprite palette to trainer card and ranking portraits

### DIFF
--- a/src/Chars.lua
+++ b/src/Chars.lua
@@ -106,31 +106,52 @@ end
 -- a party member's city.  Two copies of a cache would mean two copies of the
 -- image, and the second caller is a per-frame draw.
 --
--- Cached per sheet path, including the failures: a missing sheet is
--- remembered as `false` so a broken path is not retried on every frame.
+-- Cached per sprite id, including the failures: a missing sheet is remembered
+-- as `false` so a broken path is not retried on every frame. The key is the
+-- id rather than the sheet path because SpriteRenderer's palette bake depends
+-- on the record (paletteSource, trueColor, ...) and the seed together --
+-- blitting the raw PNG is what turned skin into lime green on the trainer
+-- card and the ranking list.
 local FRONT_FRAME = { 0, 0, 16, 16 }
-local sheets = {}
+local portraits = {}
+
+local function portraitQuad(img)
+  local iw, ih = img:getDimensions()
+  return love.graphics.newQuad(FRONT_FRAME[1], FRONT_FRAME[2],
+                              FRONT_FRAME[3], FRONT_FRAME[4],
+                              iw, ih)
+end
 
 function M.portrait(spriteId)
   local registry = mod.content and mod.content.sprites
   local ok, record = pcall(function() return registry and registry:get(spriteId) end)
-  local path = ok and type(record) == "table" and record.image or nil
-  if type(path) ~= "string" then return nil end
+  if not (ok and type(record) == "table" and type(record.image) == "string") then
+    return nil
+  end
 
-  local entry = sheets[path]
+  local entry = portraits[spriteId]
   if entry == nil then
-    local loaded, img = pcall(love.graphics.newImage, path)
-    if loaded and img then
-      entry = {
-        image = img,
-        quad = love.graphics.newQuad(FRONT_FRAME[1], FRONT_FRAME[2],
-                                     FRONT_FRAME[3], FRONT_FRAME[4],
-                                     img:getDimensions()),
-      }
+    local img
+    local built = pcall(function()
+      local SpriteRenderer = require("src.render.SpriteRenderer")
+      local renderer = SpriteRenderer.new(record, spriteId)
+      if type(renderer.resolveImage) == "function" then
+        img = renderer:resolveImage()
+      else
+        img = renderer.image
+      end
+    end)
+    if not (built and img) then
+      local loaded
+      loaded, img = pcall(love.graphics.newImage, record.image)
+      if not (loaded and img) then img = nil end
+    end
+    if img then
+      entry = { image = img, quad = portraitQuad(img) }
     else
       entry = false
     end
-    sheets[path] = entry
+    portraits[spriteId] = entry
   end
   return entry or nil
 end

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -574,6 +574,9 @@ return function(game)
               "with the trainer card they sent on joining")
       end
       U.shot(game, SHOT_DIR .. "/join-profile-card.png")
+      H.assertPortraitColors(game, SHOT_DIR .. "/join-profile-card.png",
+        116, 52, 32, 32, check,
+        "the remote trainer card portrait is palette-correct")
       U.tap(game, "b")     -- back to the interact menu
       U.wait(30)
       check(H.classify(H.top(game)) == "menu", "and B returns to the menu")

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -1369,10 +1369,40 @@ function M.shotRank(game, path, check)
   -- land before the picture is taken
   U.wait(60)
   U.shot(game, path)
+  if check then
+    -- First row's portrait column (src/Ui.lua RANK_ART_X, RANK_FIRST_Y).
+    M.assertPortraitColors(game, path, 26, 24, 16, 16, check,
+      "the ranking list portrait is palette-correct")
+  end
   check(M.top(game) ~= nil, "the RANK screen opened")
   U.tap(game, "b")
   U.wait(25)
   return true
+end
+
+-- Sample a screenshot for the lime-green skin that raw DMG-shade blits show.
+-- Rect is in 160x144 game pixels, matching the mod UI layout.
+local PORTRAIT_PROBE = "mods/rby_mmo/tests/drivers/portrait_color_probe.py"
+
+function M.assertPortraitColors(game, path, x, y, w, h, check, what)
+  local cmd = ('python3 "%s" "%s" %d %d %d %d 2>&1'):format(
+    PORTRAIT_PROBE, path, x, y, w, h)
+  local out = ""
+  -- captureScreenshot lands asynchronously after U.shot returns; spin until
+  -- the probe can read a real PNG or the budget runs out.
+  for _ = 1, 40 do
+    local f = io.popen(cmd)
+    out = f and f:read("*a") or ""
+    if f then f:close() end
+    if out:match("^ok ") then break end
+    if game then U.wait(2) end
+  end
+  local passed = out:match("^ok ") ~= nil
+  if not passed then
+    U.log("portrait probe failed:", (out:gsub("%s+$", "")))
+  end
+  check(passed, what or ("portrait colours look right in " .. path))
+  return passed
 end
 
 -- Dial the same hub again, through the menus a player uses.

--- a/tests/drivers/portrait_color_probe.py
+++ b/tests/drivers/portrait_color_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Check a driver screenshot for the lime-green portrait palette bug.
+
+Chars.portrait used to blit raw DMG-shade sheets; skin reads as bright
+green instead of the OBP-baked flesh tone.  Samples the given rectangle and
+exits 0 when the portrait looks recoloured, 1 when it still looks broken.
+"""
+
+import sys
+from PIL import Image
+
+
+def lime_score(r: int, g: int, b: int) -> bool:
+    # The failure mode: neon green skin with g dominating r and b.
+    return g > 170 and g > r + 35 and g > b + 35
+
+
+def flesh_score(r: int, g: int, b: int) -> bool:
+    # Any mid-tone recolour that is not the lime failure mode: the OBP bake
+    # spreads pixels across several tans and greys depending on sprite and
+    # colour mode, so demanding peach skin rejects valid portraits (RED on a
+    # trainer card is mostly jacket).
+    return not lime_score(r, g, b) and (r + g + b) > 120
+
+
+def main() -> int:
+    if len(sys.argv) != 6:
+        print(
+            "usage: portrait_color_probe.py <png> <x> <y> <w> <h>",
+            file=sys.stderr,
+        )
+        return 2
+
+    path, x, y, w, h = sys.argv[1], *map(int, sys.argv[2:])
+    img = Image.open(path).convert("RGB")
+    iw, ih = img.size
+    # Driver screenshots are the window framebuffer; layout constants are in
+    # 160x144 game pixels (src/Ui.lua).
+    sx, sy = iw / 160, ih / 144
+    x = int(x * sx)
+    y = int(y * sy)
+    w = max(1, int(w * sx))
+    h = max(1, int(h * sy))
+
+    sprite_px = 0
+    lime_px = 0
+    flesh_px = 0
+    for py in range(y, y + h):
+        for px in range(x, x + w):
+            r, g, b = img.getpixel((px, py))
+            # skip paper white and glyph black; portrait pixels sit between.
+            if r > 230 and g > 230 and b > 230:
+                continue
+            if r < 25 and g < 25 and b < 25:
+                continue
+            sprite_px += 1
+            if lime_score(r, g, b):
+                lime_px += 1
+            if flesh_score(r, g, b):
+                flesh_px += 1
+
+    if sprite_px < 8:
+        print(f"too few portrait pixels in {path} ({sprite_px} in {x},{y}+{w}x{h})")
+        return 1
+
+    if lime_px > sprite_px // 4:
+        print(
+            f"lime portrait pixels in {path}: {lime_px}/{sprite_px} "
+            f"in {x},{y}+{w}x{h}"
+        )
+        return 1
+
+    if flesh_px < 8:
+        print(
+            f"portrait pixels look unrecoloured in {path}: {flesh_px}/{sprite_px} "
+            f"in {x},{y}+{w}x{h}"
+        )
+        return 1
+
+    print(f"ok {path} {sprite_px} sprite px, {lime_px} lime, {flesh_px} flesh")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -3257,6 +3257,64 @@ eq(Chars.resolve(nil), Config.DEFAULT_SPRITE, "as does nothing at all")
 eq(Chars.resolve("SPRITE_BOULDER"), Config.DEFAULT_SPRITE,
    "and so does a real sprite that is not a character")
 
+-- ------- portrait colours match the overworld
+--
+-- The trainer card, the ranking list and the character picker all crop frame
+-- 0 through Chars.portrait. Blitting the raw sheet skips SpriteRenderer's
+-- OBP bake and turns DMG shades into the wrong colours (lime-green skin on
+-- a gentleman, for instance). This pins the path through resolveImage.
+
+;(function()
+  local usedResolve = false
+  local mockImg = { getDimensions = function() return 16, 96 end }
+  local savedSR = package.loaded["src.render.SpriteRenderer"]
+  package.loaded["src.render.SpriteRenderer"] = {
+    new = function(record, seed)
+      check(record.image == "sprites/gentleman.png",
+            "portrait passes the sprite record through")
+      eq(seed, "SPRITE_GENTLEMAN",
+         "portrait uses the sprite id as the renderer seed")
+      return {
+        resolveImage = function(self)
+          usedResolve = true
+          return mockImg
+        end,
+      }
+    end,
+  }
+
+  _G.love = _G.love or {}
+  love.graphics = love.graphics or {}
+  local savedNewQuad = love.graphics.newQuad
+  love.graphics.newQuad = function(x, y, w, h, iw, ih)
+    return { x = x, y = y, w = w, h = h, iw = iw, ih = ih }
+  end
+
+  local portraitMod = {
+    content = {
+      sprites = {
+        get = function(_, id)
+          if id == "SPRITE_GENTLEMAN" then
+            return { image = "sprites/gentleman.png", frames = 6, walker = true }
+          end
+        end,
+      },
+    },
+  }
+  local portraitNeed = resolver(portraitMod)
+  local PortraitChars = portraitNeed("Chars")
+
+  local art = PortraitChars.portrait("SPRITE_GENTLEMAN")
+  check(usedResolve,
+        "portrait asks SpriteRenderer for a palette-correct image")
+  check(art ~= nil and art.image == mockImg,
+        "and hands back what resolveImage returned")
+  check(art.quad ~= nil, "with a quad for the front frame")
+
+  package.loaded["src.render.SpriteRenderer"] = savedSR
+  if savedNewQuad then love.graphics.newQuad = savedNewQuad end
+end)()
+
 -- ------- the trainer card fits the box it is drawn in
 --
 -- Wrapped for scope, like the look-bookkeeping section below: this file's


### PR DESCRIPTION
## Summary

- Route `Chars.portrait` through `SpriteRenderer:resolveImage()` instead of blitting raw overworld sheets, so trainer card, ranking list, character picker, and town-map marks use the same OBP palette bake as in-game sprites.
- Cache portraits per sprite id (not sheet path), since palette depends on the sprite record and seed.
- Add a unit test asserting the `resolveImage` path, plus an e2e portrait colour probe on PROFILE and RANK screenshots.

## Why

Raw DMG-shade sheets drawn without palette remapping showed wrong colours (e.g. lime-green skin on Gentleman) on mod UI screens, while the same character looked correct in the overworld.

## Test plan

- [x] `luajit mods/rby_mmo/tests/rby_mmo_test.lua` — 2515/2515 checks
- [x] `bash mods/rby_mmo/tests/drivers/run-mmo-e2e.sh` — full pass with portrait colour assertions on host RANK, guest PROFILE, and guest RANK