### PR TITLE
Feature: add always-visible official server

### DIFF
--- a/docs/plans/featured-official-server.md
+++ b/docs/plans/featured-official-server.md
@@ -1,0 +1,125 @@
+# Plan — Featured Official Server
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-07 |
+| Source | `/implement` request: add an always-first featured RBY MMO official server |
+| Config | `AGENTS_CONFIG.yml` (quality) |
+| Branch | feature/rby-mmo-official-server |
+| Base SHA | f81c4db7e569a4cd23660394c7f7b97ba79b2089 |
+
+## 1. Objective & success criteria
+
+Make `SERVERS` available to every disconnected, non-hosting player. Its first
+entry is the built-in official RBY MMO server:
+
+- label: `RBY MMO OFFICIAL`
+- host: `play.rbymmo.com:7788`
+- join code: `QG0251`
+
+The entry is always first, including when the player has no saved recents. It
+connects through the same address/code path as a remembered server, cannot be
+deleted or edited, does not consume the saved-server cap, and never appears
+twice after connecting to it. Saved/favourited servers remain below it.
+
+## 2. Context & constraints
+
+- The disconnected MMO menu currently adds `SERVERS` only when
+  `#serverList() > 0` (`src/Ui.lua:1107-1125`); hosting and connected states
+  intentionally omit it (`src/Ui.lua:997-1106`).
+- `Servers:list()` is the ordered source for the list UI
+  (`src/Servers.lua:305-316`, `src/Ui.lua:1712-1735`). Persisted rows are
+  favourites first, then descending address.
+- Server action screens currently expect every row to be a mutable saved row
+  (`src/Ui.lua:1739-1875`). The featured row must therefore expose only
+  `CONNECT`, rather than passing through saved-row mutators.
+- `CONNECT` already supplies a row's `address` and `code` to the normal join
+  flow (`src/Ui.lua:1791-1812`), so no client protocol change is required.
+- Successful welcome records a dialled server (`src/Client.lua:1429-1464`),
+  so presentation must deduplicate the official address against the persisted
+  store rather than pre-seed it in persistent data.
+
+## 3. Approach & key decisions
+
+1. Put the official server's canonical metadata in `Config`, keeping it
+   explicit about port `7788` so normal default-port configuration cannot
+   change its identity.
+2. Build a synthetic `featured` entry in `Servers:list()` and prepend it
+   before all persisted rows. Filter any persisted row with the same normalized
+   key. This guarantees ordering, avoids persistence/cap/eviction effects,
+   and keeps the entry after a user deletes all recents.
+3. Keep the list title as `SERVERS`; the first row's canonical label identifies
+   the official feature without extending the shared list-menu component with
+   selectable section headings.
+4. Give featured entries a CONNECT-only action screen. The server address,
+   code, name, ordering, and presence are product-owned, so no favorite,
+   rename, host/code edit, or delete action is offered.
+5. Preserve `SERVERS` visibility only while offline/not hosting; the existing
+   connected and hosting exclusions remain unchanged.
+
+## 4. Work breakdown — implementation
+
+### Wave 1
+
+**I1 — featured-server model and menu wiring**
+
+- Owns: `src/Config.lua`, `src/Servers.lua`, `src/Ui.lua`
+- Add canonical official-server configuration and list projection with
+  synthetic featured entry, fixed first ordering, and persisted-key dedupe.
+- Change the disconnected MMO menu to always show `SERVERS`.
+- Render the featured entry normally and provide CONNECT-only actions; route
+  through existing connection/code machinery.
+- Acceptance: the player can select and connect to the official entry on a
+  new install; it stays at index one before favourites and recents; it cannot
+  be removed or altered; hosting/connected behavior is unchanged.
+
+## 5. Work breakdown — tests
+
+### Wave 2
+
+**T1 — Lua store and UI coverage**
+
+- Owns: `tests/rby_mmo_test.lua`
+- Assert featured metadata, first ordering, empty-persistence visibility,
+  dedupe after recording the official address, recents/favourites below it,
+  CONNECT-only actions, and always-visible offline menu behavior.
+
+**T2 — end-to-end driver expectation update**
+
+- Owns: `tests/drivers/mmo_join.lua`
+- Update the existing delete-to-empty-recents assertion: deleting the final
+  remembered server leaves the built-in featured server and the `SERVERS`
+  menu reachable. Do not dial the production official host in CI.
+
+**E2E applicability:** applicable because this changes a player-visible menu
+flow. Extend the existing deterministic driver assertion; it must not depend
+on the live official server.
+
+## 6. Execution waves
+
+1. Implement I1.
+2. Review the production diff.
+3. Create T1 and T2 in parallel (disjoint files).
+4. Run the Lua suite; run the MMO e2e driver when its engine/ROM prerequisites
+   are available.
+
+## 7. Blast radius & risks
+
+- Existing store tests that count or index `list()` rows must account for the
+  synthetic entry.
+- Existing delete e2e expects `SERVERS` to disappear after the last saved row;
+  that behavior intentionally changes.
+- External `mod.exports.servers()` currently exposes stored recents. The
+  feature will not change that persistence-facing API unless inspection during
+  I1 proves UI and export must share the same projected list; this protects
+  callers that rely on exports to mean saved history.
+- The official server's success must not create a second visible entry; list
+  projection handles this by normalized key.
+
+## 8. Open questions / assumptions
+
+- Assumed canonical display label: `RBY MMO OFFICIAL`.
+- Assumed feature ownership: the official row is CONNECT-only and cannot be
+  customized or deleted. This is the safest interpretation of “always.”
+- No release-note or version bump is included: this is a focused behavioral
+  change, not a requested release preparation.

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -531,6 +531,14 @@ M.RANK_REPORT_GRACE = 60
 -- src/Servers.lua keeps the list behind START > MMO > SERVERS; the argument
 -- for what it is and where it is written is in that file's header.
 
+-- The product-owned row at the top of that list. Its port is explicit rather
+-- than derived from DEFAULT_PORT: changing the port used by a local host must
+-- not quietly point the official row at a different service. Servers projects
+-- this into the menu without putting it in either persistence mirror.
+M.FEATURED_SERVER_NAME = "RBY MMO OFFICIAL"
+M.FEATURED_SERVER_HOST = "play.rbymmo.com:7788"
+M.FEATURED_SERVER_CODE = "QG0251"
+
 -- How long a row's name may be. Sixteen is what the list menu has room for
 -- beside its favourite marker at Game Boy width, and it is COMPOSE_MAX's
 -- number for the same reason -- a label that overflows its row is worse than

--- a/src/Servers.lua
+++ b/src/Servers.lua
@@ -73,6 +73,24 @@ local function keyOf(address)
   return clean:lower()
 end
 
+-- The one row that belongs to the product rather than to the player's
+-- history. A fresh table is returned every time so a caller of the exported
+-- list cannot rename the canonical copy in memory. The key is made by the
+-- same normaliser as every remembered hub, which is what lets ingestion and
+-- presentation recognise an old saved copy as the same server.
+local FEATURED_KEY = keyOf(Config.FEATURED_SERVER_HOST)
+local function featuredEntry()
+  return {
+    key = FEATURED_KEY,
+    address = Config.FEATURED_SERVER_HOST,
+    name = Config.FEATURED_SERVER_NAME,
+    fav = false,
+    code = Wire.code(Config.FEATURED_SERVER_CODE),
+    last = 0,
+    featured = true,
+  }
+end
+
 -- What a hub is called before anybody names it.
 --
 -- Its own address, which is the only thing known about it at record time and
@@ -236,7 +254,10 @@ end
 function M:_ingest(rows, only)
   for _, raw in ipairs(rows or {}) do
     local entry = sanitise(raw)
-    if entry then
+    -- Older builds may already have remembered the official address after a
+    -- successful welcome. It is represented by the synthetic row now, so it
+    -- is neither loaded into the persisted store nor counted by eviction.
+    if entry and entry.key ~= FEATURED_KEY then
       local known = self.entries[entry.key] ~= nil or self.dropped[entry.key]
       if not (only and known) then self.entries[entry.key] = entry end
     end
@@ -302,10 +323,10 @@ function M:_load()
   evict(self)
 end
 
--- Sorted the way the menu draws them, so the array is also what gets written:
--- favourites first, and within each group the address descending. Descending
--- because that is what was asked for; the keys are unique, so there are no
--- ties to break.
+-- The persisted rows in their display order, and the exact array that gets
+-- written: favourites first, and within each group the address descending.
+-- The featured row is deliberately not made here, because this helper also
+-- feeds both persistence mirrors and that row must never consume saved space.
 function M:_rows()
   local out = {}
   for _, entry in pairs(self.entries) do out[#out + 1] = entry end
@@ -374,7 +395,11 @@ function M:_persist(keep)
   return true
 end
 
--- ------- the API the menus and Client use
+-- ------- persisted recents API
+--
+-- Client exposes list() through mod.exports.servers, so these two methods are
+-- deliberately only the player's recorded history. Product-owned rows belong
+-- to the menu projection below and must not leak into that existing API.
 
 function M:list()
   self:_load()
@@ -387,6 +412,31 @@ function M:get(key)
   self:_load()
   local id = keyOf(key)
   if not id then return nil end
+  return self.entries[id]
+end
+
+-- The SERVERS screen has one product-owned row in addition to persisted
+-- recents. Keep that projection separate from list/get so external callers
+-- still see exactly the history they saw before the featured server existed.
+function M:menuList()
+  self:_load()
+  local out = { featuredEntry() }
+  for _, entry in ipairs(self:_rows()) do
+    -- `_ingest` and `record` already keep this key out of entries. Retain the
+    -- guard at the projection boundary too: even a caller that has modified
+    -- the public entries table cannot make the official server appear twice.
+    if entry.key ~= FEATURED_KEY then out[#out + 1] = entry end
+  end
+  return out
+end
+
+-- Resolves keys handed back by menuList(), including its synthetic first row.
+-- Normal get() intentionally does not: it remains the persisted-recents API.
+function M:menuGet(key)
+  self:_load()
+  local id = keyOf(key)
+  if not id then return nil end
+  if id == FEATURED_KEY then return featuredEntry() end
   return self.entries[id]
 end
 
@@ -407,6 +457,13 @@ function M:record(address, code)
   end
 
   local key = clean:lower()
+  -- A welcome from the official hub proves the synthetic row works; it does
+  -- not turn product configuration into player history. In particular this
+  -- skips persistence and eviction, and keeps the configured code canonical.
+  if key == FEATURED_KEY then
+    self.entries[key] = nil
+    return featuredEntry()
+  end
   local entry = self.entries[key]
   if not entry then
     entry = { key = key, address = clean, name = defaultName(clean),
@@ -430,10 +487,18 @@ end
 -- refused when nothing printable survives -- a blank row is a row nobody can
 -- tell from the one above it.
 function M:rename(key, name)
+  if keyOf(key) == FEATURED_KEY then
+    self:_warn("the featured server is built in and cannot be renamed")
+    return nil
+  end
   local entry = self:get(key)
   if not entry then
     self:_warn("no server is stored for %s, so it cannot be renamed -- connect "
       .. "to it once from START > MMO > JOIN GAME", tostring(key))
+    return nil
+  end
+  if entry.featured then
+    self:_warn("the featured server is built in and cannot be renamed")
     return nil
   end
   local clean = Wire.text(name, Config.SERVER_NAME_MAX)
@@ -448,10 +513,18 @@ function M:rename(key, name)
 end
 
 function M:setFavorite(key, fav)
+  if keyOf(key) == FEATURED_KEY then
+    self:_warn("the featured server is already pinned and cannot be changed")
+    return nil
+  end
   local entry = self:get(key)
   if not entry then
     self:_warn("no server is stored for %s, so it cannot be favourited -- "
       .. "connect to it once from START > MMO > JOIN GAME", tostring(key))
+    return nil
+  end
+  if entry.featured then
+    self:_warn("the featured server is already pinned and cannot be changed")
     return nil
   end
   entry.fav = fav and true or false
@@ -468,6 +541,10 @@ end
 -- only answer that leaves one row per hub -- and the alternative, refusing the
 -- edit, would strand the player with two rows and no way to merge them.
 function M:setAddress(key, newAddress)
+  if keyOf(key) == FEATURED_KEY then
+    self:_warn("the featured server's address is built in and cannot be changed")
+    return nil
+  end
   local entry = self:get(key)
   if not entry then
     self:_warn("no server is stored for %s, so its address cannot be changed "
@@ -482,6 +559,10 @@ function M:setAddress(key, newAddress)
   end
 
   local id = clean:lower()
+  if entry.featured or id == FEATURED_KEY then
+    self:_warn("the featured server's address is built in and cannot be changed")
+    return nil
+  end
   if id ~= entry.key then
     self.entries[entry.key] = nil
     self.dropped[entry.key] = true
@@ -503,10 +584,18 @@ end
 -- through to the connect path and fail every challenge silently, which is the
 -- failure this validation exists to turn into a sentence.
 function M:setCode(key, code)
+  if keyOf(key) == FEATURED_KEY then
+    self:_warn("the featured server's join code is built in and cannot be changed")
+    return nil
+  end
   local entry = self:get(key)
   if not entry then
     self:_warn("no server is stored for %s, so its join code cannot be set -- "
       .. "connect to it once from START > MMO > JOIN GAME", tostring(key))
+    return nil
+  end
+  if entry.featured then
+    self:_warn("the featured server's join code is built in and cannot be changed")
     return nil
   end
   local clean = Wire.code(code)
@@ -533,11 +622,19 @@ end
 -- does: this is the one write that wants the list shorter, so the eviction
 -- that follows a fold-in has no row here to protect.
 function M:remove(key)
+  if keyOf(key) == FEATURED_KEY then
+    self:_warn("the featured server is built in and cannot be deleted")
+    return nil
+  end
   local entry = self:get(key)
   if not entry then
     self:_warn("no server is stored for %s, so there is nothing to delete -- "
       .. "open START > MMO > SERVERS and pick a row that is on the list",
       tostring(key))
+    return nil
+  end
+  if entry.featured then
+    self:_warn("the featured server is built in and cannot be deleted")
     return nil
   end
   self.entries[entry.key] = nil

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -953,10 +953,25 @@ function M:install()
     return store
   end
 
-  local function serverList()
+  local function serverMenuList()
     local store = serverStore()
-    local list = store and store.list and store:list()
+    local list
+    if store then
+      if store.menuList then
+        list = store:menuList()
+      elseif store.list then
+        list = store:list()
+      end
+    end
     return type(list) == "table" and list or {}
+  end
+
+  local function serverMenuGet(key)
+    local store = serverStore()
+    if not store then return nil end
+    if store.menuGet then return store:menuGet(key) end
+    if store.get then return store:get(key) end
+    return nil
   end
 
   -- The mark on a favourite row.
@@ -1105,24 +1120,15 @@ function M:install()
         end,
       }
     else
-      -- First on the menu, above HOST GAME, because for anyone who has
-      -- played before it is the row they came for: every hub on it answered
-      -- to this copy once, so its address and its code are known and CONNECT
-      -- is the whole flow -- the same errand as JOIN GAME with the typing
-      -- already done.
-      --
-      -- Absent while the list is empty, rather than opening a screen that
-      -- says "nothing yet": a first join has to go through JOIN GAME anyway,
-      -- and the row appears the moment there is something behind it. The
-      -- menu is also 8 rows at most, so a row that could say nothing is a
-      -- row the rows that can say something do not get -- and a first-timer's
-      -- menu still opens on HOST GAME.
-      if #serverList() > 0 then
-        items[#items + 1] = {
-          label = "SERVERS",
-          onSelect = function() mod.ui.push(game, SCREEN.SERVERS) end,
-        }
-      end
+      -- First on the menu, above HOST GAME, because it always has somewhere
+      -- useful to go: the official server is a product-owned first row even
+      -- on a new copy, and remembered hubs follow it with their address and
+      -- code already filled in. Hosting and connected states stay in the
+      -- branch above, where SERVERS is intentionally absent.
+      items[#items + 1] = {
+        label = "SERVERS",
+        onSelect = function() mod.ui.push(game, SCREEN.SERVERS) end,
+      }
       items[#items + 1] = {
         label = "HOST GAME",
         onSelect = function()
@@ -1708,22 +1714,17 @@ function M:install()
   -- PLAYERS is one: the length is not fixed and the row carries a second
   -- column. The order is the store's (favourites first, then by address);
   -- the rows are rebuilt on every push, so a rename, a re-address or a
-  -- favourite toggle is already in place by the time B lands back here.
+  -- favourite toggle is already in place by the time B lands back here. The
+  -- store prepends its synthetic official row before that saved ordering.
   screens:register(SCREEN.SERVERS, { new = function(game)
     local items = {}
-    for _, entry in ipairs(serverList()) do
+    for _, entry in ipairs(serverMenuList()) do
       items[#items + 1] = {
         label = entry.name,
         right = entry.fav and FAV_MARK or nil,
         value = entry.key,
       }
     end
-    -- Nothing is injected when there is nothing to show. The MMO menu hides
-    -- the row that opens this while the list is empty, so an empty list here
-    -- means the screen was re-entered while it was open and the last entry
-    -- went -- and ListMenu already draws "Nothing here." for exactly that.
-    -- A placeholder row would suppress that answer and put the cursor on a
-    -- row whose A press has to be swallowed.
     return mod.ui.ListMenu.new(game, "SERVERS", items, {
       pageJump = true,
       onChoose = function(item, menu)
@@ -1739,7 +1740,7 @@ function M:install()
   screens:register(SCREEN.SERVERACT, { new = function(game, opts)
     opts = opts or {}
     local store = serverStore()
-    local entry = store and store.get and store:get(opts.key)
+    local entry = serverMenuGet(opts.key)
     if not entry then
       -- The key is derived from the address rather than chosen, so EDIT HOST
       -- moves an entry to a different one -- and a menu still holding the old
@@ -1756,19 +1757,26 @@ function M:install()
       -- CONNECT first: it is what the list is for, and every other row is a
       -- correction to make before pressing it.
       { label = "CONNECT", connect = true },
+    }
+    -- The featured row is product-owned: its label, address, code and place
+    -- at the top are not player settings. CONNECT is therefore its complete
+    -- action screen. Remembered rows keep the six actions they had before.
+    if not entry.featured then
       -- The row says what pressing it does, not what the entry is -- the
       -- same rule the MMO menu's END GAME / LEAVE row follows.
-      { label = entry.fav and "UNFAVORITE" or "FAVORITE", fav = true },
-      { label = "EDIT HOST", field = "host" },
-      { label = "EDIT CODE", field = "code" },
-      { label = "RENAME", field = "name" },
+      items[#items + 1] = {
+        label = entry.fav and "UNFAVORITE" or "FAVORITE", fav = true,
+      }
+      items[#items + 1] = { label = "EDIT HOST", field = "host" }
+      items[#items + 1] = { label = "EDIT CODE", field = "code" }
+      items[#items + 1] = { label = "RENAME", field = "name" }
       -- Last, and last on purpose: it is the one row that cannot be undone
       -- by pressing it again, so it comes after the corrections rather than
       -- among them. Distance is not the guard, though -- Menu wraps, so row
       -- 6 is a single UP from where the cursor starts, which is why the
       -- confirm below has to open on NO.
-      { label = "DELETE", remove = true },
-    }
+      items[#items + 1] = { label = "DELETE", remove = true }
+    end
 
     -- Reopening is what "rebuilt" means here (see the favourite row below),
     -- and a rebuild that forgets where the cursor was is a rebuild that

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -1063,11 +1063,11 @@ return function(game)
               -- The same row the SERVERS leg above just dialled through,
               -- but this pass is destructive on purpose: reopen it, pick
               -- the entry, DELETE it, answer CONFIRM's box YES, and check
-              -- both halves of what that promises -- the store side
-              -- (mod.exports.servers() empty) and the menu side (the MMO
-              -- menu drops the SERVERS row once the list behind it is
-              -- empty, the same rule that keeps the row off the menu
-              -- before any hub has ever been recorded).
+              -- both halves of what that promises -- the saved-history side
+              -- (mod.exports.servers() empty) and the menu side (SERVERS
+              -- stays reachable, with only the product-owned official row
+              -- left behind). The featured row is deliberately outside the
+              -- exported recents, so these two answers are meant to differ.
               local deleteLabel = H.serverLabel(exports, dialled)
               if H.openMmo(game) and H.selectLabel(game, "SERVERS")
                  and H.selectLabel(game, deleteLabel) then
@@ -1104,7 +1104,7 @@ return function(game)
                   local afterDelete = (type(exports.servers) == "function"
                                         and exports.servers()) or nil
                   check(type(afterDelete) == "table" and #afterDelete == 0,
-                        "DELETE, confirmed, empties the SERVERS list "
+                        "DELETE, confirmed, empties the saved server list "
                           .. ("(got %d row(s))")
                             :format(type(afterDelete) == "table"
                                     and #afterDelete or -1))
@@ -1115,9 +1115,21 @@ return function(game)
                     for _, l in ipairs(H.menuLabels(game)) do
                       if H.labelMatches(l, "SERVERS") then stillThere = true end
                     end
-                    check(not stillThere,
-                          "and the MMO menu no longer offers a SERVERS row, "
-                            .. "the list behind it now empty")
+                    check(stillThere,
+                          "and the MMO menu still offers SERVERS after the "
+                            .. "last saved server is deleted")
+                    if stillThere then
+                      local reachable = H.selectLabel(game, "SERVERS")
+                      check(reachable,
+                            "and that SERVERS row remains reachable")
+                      if reachable then
+                        local remaining = H.menuLabels(game)
+                        check(#remaining == 1
+                              and H.labelMatches(remaining[1],
+                                                 "RBY MMO OFFICIAL"),
+                              "with only RBY MMO OFFICIAL left at the top")
+                      end
+                    end
                   end
                   H.closeToOverworld(game)
                 else
@@ -1157,7 +1169,8 @@ return function(game)
   --
   -- Everything above proves a chosen character survives a session; this
   -- proves there does not have to be one at all. The CHARACTER row is the
-  -- third one on the offline MMO menu, reachable only while disconnected
+  -- fourth one on the offline MMO menu, after the always-available SERVERS
+  -- row, reachable only while disconnected
   -- (src/Ui.lua's comment on the row explains why: the hub only learns a
   -- sprite at hello, so a mid-game swap would show everyone else the old
   -- one) -- and picking a character through it has to apply immediately,
@@ -1181,9 +1194,9 @@ return function(game)
     U.wait(20)
     local labels = H.menuLabels(game)
     log("offline MMO menu:", table.concat(labels, ","))
-    check(labels[1] == "HOST GAME" and labels[2] == "JOIN GAME"
-          and labels[3] == "CHARACTER",
-          "the offline menu offers HOST GAME, JOIN GAME, then CHARACTER")
+    check(labels[1] == "SERVERS" and labels[2] == "HOST GAME"
+          and labels[3] == "JOIN GAME" and labels[4] == "CHARACTER",
+          "the offline menu offers SERVERS, HOST GAME, JOIN GAME, then CHARACTER")
     U.shot(game, SHOT_DIR .. "/join-mmo-menu-offline.png")
 
     -- Cancelling out of the picker without choosing has to return to this
@@ -1198,7 +1211,7 @@ return function(game)
       U.tap(game, "b")
       U.wait(20)
       local backLabels = H.menuLabels(game)
-      check(backLabels[1] == "HOST GAME",
+      check(backLabels[1] == "SERVERS",
             "cancelling the picker returns to the MMO menu, not TRAINER")
 
       -- Now actually choose one -- NIRE, not the guest's own
@@ -1212,7 +1225,7 @@ return function(game)
         check(picked, "NIRE is a row in the offline picker")
         U.wait(20)
         check(H.classify(H.top(game)) == "menu"
-              and H.menuLabels(game)[1] == "HOST GAME",
+              and H.menuLabels(game)[1] == "SERVERS",
               "choosing a character returns to the MMO menu")
 
         local afterLook = exports.wornLook and exports.wornLook() or nil

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -12257,6 +12257,110 @@ do
   eq(withFav[3].key:sub(1, 1), "b", "with b last")
 end
 
+-- ------- featured: a synthetic menu row, never part of persisted recents
+
+do
+  stubSave = {}
+  local store = Servers.new()
+
+  eq(#store:list(), 0,
+     "the persisted-recents list stays empty on a fresh copy")
+  eq(store:get(Config.FEATURED_SERVER_HOST), nil,
+     "and normal get does not expose the product-owned server")
+
+  local menu = store:menuList()
+  eq(#menu, 1, "the menu projection still has the featured server")
+  local featured = menu[1]
+  eq(featured.name, "RBY MMO OFFICIAL", "under its canonical label")
+  eq(featured.address, "play.rbymmo.com:7788",
+     "with the official dial address")
+  eq(featured.code, "QG0251", "and the official join code")
+  eq(featured.key, Config.FEATURED_SERVER_HOST:lower(),
+     "filed under the same normalised key as a recent")
+  eq(featured.featured, true,
+     "marked so the UI can protect product-owned fields")
+
+  local resolved = store:menuGet(featured.key)
+  check(resolved ~= nil, "menuGet resolves the synthetic row")
+  eq(resolved and resolved.address, Config.FEATURED_SERVER_HOST,
+     "to the same official address")
+  eq(resolved and resolved.code, Config.FEATURED_SERVER_CODE,
+     "and the same official code")
+
+  local returned = store:record(Config.FEATURED_SERVER_HOST,
+                                Config.FEATURED_SERVER_CODE)
+  check(returned ~= nil and returned.featured == true,
+        "a welcome from the official hub returns the synthetic entry")
+  eq(#store:list(), 0,
+     "but does not turn the official hub into a persisted recent")
+  eq(store:get(Config.FEATURED_SERVER_HOST), nil,
+     "or make it visible through normal get")
+  eq(stubSave.servers, nil,
+     "and recording only the official hub performs no persistence write")
+end
+
+do
+  -- An older build may already have persisted the official address. Loading
+  -- it must collapse that stale row into the canonical synthetic one, even if
+  -- its user-editable fields disagree. A later ordinary write also cleans it
+  -- out of the mirror instead of writing the legacy copy back.
+  stubSave = { servers = {
+    { address = "PLAY.RBYMMO.COM:7788", name = "Old nickname",
+      fav = true, code = "A7K3P9", last = 99 },
+  } }
+  local store = Servers.new()
+
+  eq(#store:list(), 0,
+     "a saved copy of the official address is not counted as a recent")
+  local menu = store:menuList()
+  eq(#menu, 1, "the saved official address is deduped in the menu")
+  eq(menu[1].name, Config.FEATURED_SERVER_NAME,
+     "and the synthetic row keeps its canonical label")
+  eq(menu[1].code, Config.FEATURED_SERVER_CODE,
+     "rather than a code from the stale saved row")
+
+  store:record("ordinary-after-upgrade.example")
+  eq(#stubSave.servers, 1,
+     "the next persistence write contains only the ordinary recent")
+  eq(stubSave.servers[1].address,
+     ("ordinary-after-upgrade.example:%d"):format(Config.DEFAULT_PORT),
+     "so the legacy official row is not persisted again")
+  local updatedMenu = store:menuList()
+  eq(#updatedMenu, 2, "the menu has the featured row plus that one recent")
+  eq(updatedMenu[1].name, Config.FEATURED_SERVER_NAME,
+     "and the featured server stays above persisted rows")
+end
+
+do
+  stubSave = {}
+  local store = Servers.new()
+  local officialKey = Config.FEATURED_SERVER_HOST:lower()
+  local ordinary = store:record("mutable.example")
+
+  eq(store:rename(officialKey, "Renamed"), nil,
+     "the featured row cannot be renamed")
+  eq(store:setFavorite(officialKey, true), nil,
+     "the featured row cannot be favourited")
+  eq(store:setAddress(officialKey, "elsewhere.example:9191"), nil,
+     "the featured row's address cannot be edited")
+  eq(store:setCode(officialKey, "A7K3P9"), nil,
+     "the featured row's code cannot be edited")
+  eq(store:remove(officialKey), nil,
+     "the featured row cannot be deleted")
+  eq(store:setAddress(ordinary.key, Config.FEATURED_SERVER_HOST), nil,
+     "and an ordinary recent cannot be moved onto the featured address")
+
+  local featured = store:menuGet(officialKey)
+  eq(featured and featured.name, Config.FEATURED_SERVER_NAME,
+     "refused mutators leave the official label unchanged")
+  eq(featured and featured.address, Config.FEATURED_SERVER_HOST,
+     "and leave its address unchanged")
+  eq(featured and featured.code, Config.FEATURED_SERVER_CODE,
+     "and leave its code unchanged")
+  eq(#store:list(), 1,
+     "while the ordinary persisted recent remains the only counted row")
+end
+
 -- ------- eviction: the cap, LRU order, favourites, and the row just written
 
 do
@@ -12933,13 +13037,13 @@ local function hasLabel(list, label)
 end
 
 ctx.servers = storeWith({})
-eq(hasLabel(mainLabels(), "SERVERS"), false,
-   "an empty list means no SERVERS row at all")
+eq(hasLabel(mainLabels(), "SERVERS"), true,
+   "a disconnected fresh copy always has the SERVERS row")
 
 ctx.servers = storeWith({ "one.example" })
 local rows = mainLabels()
 eq(hasLabel(rows, "SERVERS"), true,
-   "a non-empty list adds the row while disconnected")
+   "remembered recents keep the row visible while disconnected")
 local hostIdx, serversIdx
 for i, label in ipairs(rows) do
   if label == "HOST GAME" then hostIdx = i end
@@ -12966,9 +13070,10 @@ check(serversDef ~= nil, "SCREEN.SERVERS registers")
 ctx.servers = storeWith({ "b-host", "a-host" })
 ctx.servers:setFavorite(ctx.servers:list()[2].key, true) -- a-host
 do
-  local expected = ctx.servers:list()
+  local expected = ctx.servers:menuList()
   local menu = serversDef.new({})
-  eq(#menu.items, #expected, "one row per stored server")
+  eq(#menu.items, #expected,
+     "one row per menu server, including the synthetic first row")
   for i, entry in ipairs(expected) do
     eq(menu.items[i].label, entry.name,
        "row " .. i .. " carries the entry's name")
@@ -12984,17 +13089,76 @@ end
 ctx.servers = storeWith({})
 do
   local menu = serversDef.new({})
-  -- No placeholder row. ListMenu already draws its own "Nothing here." for an
-  -- empty list, and a fake row would both suppress that answer and park the
-  -- cursor on something whose A press has to be swallowed.
-  eq(#menu.items, 0,
-     "an empty list injects no rows at all -- ListMenu says so itself")
+  eq(#menu.items, 1,
+     "zero recents still leaves one real, selectable featured row")
+  eq(menu.items[1].label, Config.FEATURED_SERVER_NAME,
+     "the featured row is first under its official name")
+  eq(menu.items[1].value, Config.FEATURED_SERVER_HOST:lower(),
+     "and selects the key for the official address")
 end
 
 -- ------- SCREEN.SERVERACT: the fixed row order, and the gone-entry case
 
 local actDef = screenRegistry[Ui.SCREEN.SERVERACT]
 check(actDef ~= nil, "SCREEN.SERVERACT registers")
+
+do
+  ctx.servers = storeWith({})
+  local featured = ctx.servers:menuList()[1]
+  local game = {}
+  local menu = actDef.new(game, { key = featured.key })
+  eq(#menu.items, 1,
+     "the featured server action screen contains only CONNECT")
+  eq(menu.items[1].label, "CONNECT", "and CONNECT is that sole action")
+
+  local calls = {}
+  local realClient = ctx.client
+  ctx.client = {
+    isHosting = function() return false end,
+    isConnected = function() return false end,
+    setJoinAddress = function(_, address)
+      calls[#calls + 1] = { name = "address", value = address }
+      return address
+    end,
+    setJoinCode = function(_, address, code)
+      calls[#calls + 1] = { name = "code", address = address, value = code }
+      return code
+    end,
+    connect = function(_, game)
+      calls[#calls + 1] = { name = "connect", game = game }
+      return true
+    end,
+  }
+
+  pushes = {}
+  menu.items[1].onSelect()
+  local setup = pushes[#pushes]
+  check(setup ~= nil and setup.id == Ui.SCREEN.CHARSET,
+        "featured CONNECT enters the regular character setup path")
+  eq(setup.opts and setup.opts.verb, "JOIN",
+     "using the same JOIN setup as a remembered server")
+  check(type(setup.opts and setup.opts.onReady) == "function",
+        "and waits for character setup before dialing")
+  setup.opts.onReady()
+
+  eq(calls[1] and calls[1].name, "address",
+     "the regular dial path sets the address first")
+  eq(calls[1] and calls[1].value, "play.rbymmo.com:7788",
+     "to the official host")
+  eq(calls[2] and calls[2].name, "code",
+     "then stores the featured join code")
+  eq(calls[2] and calls[2].address, "play.rbymmo.com:7788",
+     "under the address connect will dial")
+  eq(calls[2] and calls[2].value, "QG0251",
+     "with the official code")
+  eq(calls[3] and calls[3].name, "connect",
+     "and finally uses the existing connect call")
+  eq(calls[3] and calls[3].game, game,
+     "for the game that opened the action screen")
+
+  ctx.client = realClient
+  pushes = {}
+end
 
 ctx.servers = storeWith({ "act.example" })
 local actKey = ctx.servers:list()[1].key
@@ -13426,13 +13590,15 @@ end
 
 do
   local items = mainItems()
-  eq(#items, 3, "offline, the menu is HOST GAME / JOIN GAME / CHARACTER")
-  eq(items[1].label, "HOST GAME", "first")
-  eq(items[2].label, "JOIN GAME", "second")
-  eq(items[3].label, "CHARACTER", "and third, the new row")
+  eq(#items, 4,
+     "offline, the menu is SERVERS / HOST GAME / JOIN GAME / CHARACTER")
+  eq(items[1].label, "SERVERS", "the always-available server list is first")
+  eq(items[2].label, "HOST GAME", "HOST GAME is second")
+  eq(items[3].label, "JOIN GAME", "JOIN GAME is third")
+  eq(items[4].label, "CHARACTER", "and CHARACTER is fourth")
 
   pushed = nil
-  items[3].onSelect()
+  items[4].onSelect()
   eq(pushed and pushed.id, SCREEN.CHARPICK, "CHARACTER opens the picker")
   eq(pushed and pushed.opts and pushed.opts.backTo, SCREEN.MAIN,
      "and tells it to come straight back to the MMO menu, not the "


### PR DESCRIPTION
## What changed

- Adds a built-in `RBY MMO OFFICIAL` server at `play.rbymmo.com:7788` using join code `QG0251`.
- Keeps `SERVERS` visible whenever the player is offline.
- Pins the official server above favourites and recents.
- Makes the official entry connect-only, preventing edits, favourites, or deletion.
- Keeps the public saved-recents export limited to servers the player actually connected to.

## Why

Players can now discover and join the official RBY MMO server immediately, without first manually connecting to another host.

## Validation

- Lua suite: `2561/2561 checks passed`
- ROM-backed MMO end-to-end driver: passed with zero host and guest failures