### PR TITLE
fix: battle invite wait/cancel, mid-fight refuse, and link-compat battles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@
 # missing and the import is actually needed.
 ROM_PATH=/path/to/Pokemon Red.gb
 
+# Optional second cartridge, used by the Red-vs-Yellow battle-compat check
+# (tests/drivers/run-red-yellow-battle-compat.sh). Point at Yellow (or Blue)
+# when you want that assertion to run; leave unset and the driver skips.
+SECONDARY_ROM_PATH=/path/to/Pokemon Yellow.gb
+
 # red | blue | yellow -- which game ROM_PATH is.
 #
 # This is not cosmetic. scripts/setup.sh never passes --version through to
@@ -26,6 +31,7 @@ ROM_PATH=/path/to/Pokemon Red.gb
 # with "unsupported ROM SHA-1 ... expected ea9bcae..." even though the ROM is
 # perfectly valid. The runner calls the extractor directly and passes this.
 ROM_VERSION=red
+SECONDARY_ROM_VERSION=yellow
 
 # --- multiplayer -------------------------------------------------------
 # Address the joining instance dials. Both instances run on this machine, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ here must match `manifest.version`.
 
 ### Added
 
+- **Waiting / cancel on a PVP battle request.** Asking somebody to battle
+  holds `Waiting for <name>...` until they answer. **B** (or CANCEL) opens a
+  yes/no confirm; No drops back onto the wait, Yes withdraws the ask and
+  tells them `<name> cancelled the invite.` A refuse comes back as
+  `<name> refused to battle.` rather than leaving the asker busy with
+  nothing on screen. New wire type `mmo.request_cancel`; **`PROTOCOL` 8 → 9**
+  in `src/Config.lua` and `server/lib/relay.js` together — a protocol-8 hub
+  would clear the local wait while still holding `pendingTo`, so a late
+  accept could pull the asker into a session they thought they had left.
 - **Notifications in the corner, for the things that happen while you are
   doing something else.** Somebody says something, somebody arrives, your
   party member wins a fight — none of it is worth taking the screen for, and
@@ -86,6 +95,23 @@ here must match `manifest.version`.
   in front of you and a toast only when something happened, so the switch that
   used to gate them was a switch for turning off the only evidence that anyone
   else is in the game.
+
+### Fixed
+
+- **Battle handshake refusal names the mods that differ**, via the engine's
+  `Handshake.describe` report (and a clear line when the lists match but one
+  side still claims a modified link surface).
+- **MMO battles are only blocked when a side has touched lockstep rules.**
+  A fingerprint mismatch with `linkModified` false on both hellos — Red vs
+  Blue, two ROM dumps, this mod alone — is allowed, the way cable club was.
+  An `affects_link` mod (or a link-registry write) on either side still
+  refuses, and the refusal names the mods. Covered by synthetic hellos in
+  `tests/rby_mmo_test.lua`, and by a real Red/Yellow extract when
+  `SECONDARY_ROM_PATH` is set (`tests/drivers/run-red-yellow-battle-compat.sh`).
+- **Battle invites no longer open over a live fight.** A 1v1 request or a
+  PARTY BATTLE ask that arrives during a wild, trainer, link, or co-op
+  battle is auto-refused instead of putting a yes/no on top of the fight
+  (including when a menu sits above the battle screen).
 
 ## [0.9.0] - 2026-08-07
 

--- a/server/hub.test.js
+++ b/server/hub.test.js
@@ -308,11 +308,29 @@ async function main() {
     const declined = await cal.expect('mmo.decline');
     ok(declined.name === 'BOB', 'a busy player auto-declines');
 
-    // ------- teardown
+    // ------- teardown of the live session, then cancel an unanswered ask
+    //
+    // The asker takes a fresh request back before Bob answers. pendingTo
+    // clears on the hub, Bob is told, and a late accept must not open a
+    // session.
 
     ann.send('mmo.session_leave', {});
     const ended = await bob.expect('mmo.session_end');
     ok(ended.reason === 'peer_left', 'leaving ends the session for both');
+
+    ann.send('mmo.request', { to: bobWelcome.id, kind: 'battle' });
+    const battleAsk = await bob.expect('mmo.request');
+    ok(battleAsk.kind === 'battle' && battleAsk.name === 'ANN',
+      'a battle request is forwarded');
+
+    ann.send('mmo.request_cancel', {});
+    const cancelled = await bob.expect('mmo.request_cancel');
+    ok(cancelled.from === annWelcome.id, 'cancel names the asker');
+    ok(cancelled.name === 'ANN', 'by the nick on their connection');
+
+    bob.send('mmo.respond', { to: annWelcome.id, kind: 'battle', accept: true });
+    await ann.expectSilence('mmo.session');
+    ok(true, 'accepting a cancelled ask starts no session');
 
     // ------- parties
     //

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -65,10 +65,14 @@ const DEFAULT_SPRITE = 'SPRITE_RED';
 // fanned out from here to the party and to nobody else -- and a protocol-7 hub
 // has never heard the type, so a player would watch their partner fight all
 // evening and never be told a thing, which neither end can tell apart from an
-// ordinary quiet route. The rule every bump follows is unchanged: bump
-// whenever a client can send something a hub silently ignores. Kept in step
-// with Config.PROTOCOL on the mod side.
-const PROTOCOL = 8;
+// ordinary quiet route. 9 is mmo.request_cancel -- the asker withdrawing a
+// trade/battle request before it is answered -- and a protocol-8 hub would
+// clear the asker's local wait while still holding pendingTo, so the other
+// player could accept into a session the asker thought they had left. The
+// rule every bump follows is unchanged: bump whenever a client can send
+// something a hub silently ignores. Kept in step with Config.PROTOCOL on the
+// mod side.
+const PROTOCOL = 9;
 
 // How long a four-way PARTY BATTLE ask waits for its three answers. Mirrors
 // Config.COOP_ASK_TIMEOUT: every one of the four is looking at a box right
@@ -437,6 +441,22 @@ handlers['mmo.respond'] = (relay, client, msg) => {
     return relay.send(asker, 'mmo.decline', { name: client.name, kind });
   }
   relay.startSession(asker, client, kind);
+};
+
+// The asker takes the request back before it is answered. Only they can:
+// pendingTo lives on their connection, and a forged cancel from somebody
+// else has nothing to clear. The player holding the yes/no box is told, so
+// they are not left answering an ask nobody is waiting on any more.
+handlers['mmo.request_cancel'] = (relay, client) => {
+  if (!client.ready) return;
+  const targetId = client.pendingTo;
+  if (!targetId) return;
+  client.pendingTo = null;
+  const target = relay.clients.get(targetId);
+  if (target && target.ready) {
+    relay.send(target, 'mmo.request_cancel',
+      { from: client.id, name: client.name });
+  }
 };
 
 // The invite, and the two answers to it.

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -63,6 +63,12 @@ local toast = Toast.new(ctx)
 local sessions = Sessions.new(transport, ui)
 local party = Party.new(transport, ui, ctx.chat)
 local coop = Coop.new(transport, ui, party, ctx.roster, ctx.chat)
+-- Co-op can be mid-handoff with no screen yet (running/state set, stack
+-- still overworld). Sessions asks this so a 1v1 invite is refused there
+-- the same way a wild battle on the stack is.
+sessions.fighting = function()
+  return coop.running == true or coop.state ~= nil
+end
 
 ctx.client = M
 ctx.ui = ui
@@ -1670,6 +1676,10 @@ handlers[Wire.PART] = function(_, msg)
   -- Same shape, one feature along: an offer from somebody who is gone can
   -- never be joined, and a four-way ask is short a player.
   coop:onPeerGone(id)
+  -- And the same again for a trade/battle ask: without this the asker stays
+  -- busy forever after the person they asked disconnects, because the hub
+  -- clears pendingTo in silence and never sends a decline.
+  sessions:onPeerGone(id)
 end
 
 handlers[Wire.MOVE] = function(_, msg)
@@ -1807,6 +1817,7 @@ end
 
 handlers[Wire.REQUEST] = function(game, msg) sessions:onRequest(game, msg) end
 handlers[Wire.DECLINE] = function(_, msg) sessions:onDecline(msg) end
+handlers[Wire.REQUEST_CANCEL] = function(_, msg) sessions:onCancel(msg) end
 handlers[Wire.SESSION] = function(game, msg) sessions:onSession(game, msg) end
 handlers[Wire.RELAY] = function(_, msg) sessions:onRelay(msg) end
 
@@ -2310,6 +2321,19 @@ function M.install()
   -- A copy of the lines, never the queue itself -- a reader that held the
   -- live list could age or empty it by accident.
   mod.exports.toasts = function() return ctx.toast:state() end
+  -- Whether a trade/battle ask is sitting unanswered on this client, and
+  -- whether a fight is on screen (or a co-op handoff is in flight). The
+  -- invite-refuse e2e reads both: a request that arrived mid-fight must
+  -- leave neither an incoming prompt nor a held ask.
+  mod.exports.hasIncomingRequest = function()
+    return sessions.incoming ~= nil
+  end
+  mod.exports.isFighting = function()
+    return sessions:inFight(ctx.game)
+  end
+  mod.exports.isSessionBusy = function()
+    return sessions:isBusy()
+  end
   -- what this player looks like in their own game, for tests and for a mod
   -- that wants to know
   mod.exports.myLook = function() return M.spriteChoice() end

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -49,7 +49,14 @@ M.MOD_ID = "rby_mmo"
 -- end could tell that from an ordinary quiet route, which is exactly the
 -- silence this number exists to turn into a sentence.  This number lives here
 -- and in server/lib/relay.js -- bump them together.
-M.PROTOCOL = 8
+--
+-- 9 is mmo.request_cancel -- the asker withdrawing a trade/battle request
+-- before it is answered.  A protocol-8 hub has never heard the type, so
+-- cancelling would clear the asker's local wait while the hub still held
+-- pendingTo: the other player could still accept and pull them into a
+-- session they thought they had walked away from.  Silence is worse than a
+-- refusal that names both versions, so the number moved.
+M.PROTOCOL = 9
 
 -- The port an in-game host binds, and the one a bare address is completed
 -- with.

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -745,6 +745,11 @@ function M:challenge(game, peer, myMap)
   if not (peer and peer.id) then return false end
   if not self.transport:isReady() then return false end
 
+  if self:inFight(game) then
+    self.ui:say("Finish your battle\nfirst.")
+    return false
+  end
+
   if not self.party:has() then
     self.ui:say("You need a party\nfor that.")
     return false
@@ -836,6 +841,38 @@ function M:closeAskBox()
   return self:unwindTo(held.game, held.box, true)
 end
 
+-- True while this client is mid-fight: a co-op battle already handed off,
+-- or a wild / trainer / link / co-op screen still on the stack (including
+-- under a menu).  Mirrored in Sessions:inFight -- same rule, two call
+-- sites, so a PARTY BATTLE ask and a 1v1 request both stay off a live fight.
+function M.isFightState(state)
+  if type(state) ~= "table" then return false end
+  local kind = state.kind
+  if kind == "wild" or kind == "trainer" or kind == "link" then return true end
+  if state.sim ~= nil then return true end
+  return false
+end
+
+function M.stackHasFight(game)
+  local stack = game and game.stack
+  if not stack then return false end
+  local states = stack.states
+  if type(states) == "table" then
+    for i = #states, 1, -1 do
+      if M.isFightState(states[i]) then return true end
+    end
+    return false
+  end
+  local top = stack.top and stack:top()
+  return M.isFightState(top)
+end
+
+function M:inFight(game)
+  if self.running or self.state then return true end
+  if self.fighting and self.fighting(game) then return true end
+  return M.stackHasFight(game)
+end
+
 -- The ask, as it reaches the other three.  All four have to agree, so this is
 -- put to each of them and any one no ends it -- which the hub enforces and
 -- says out loud to everyone still holding a box.
@@ -846,10 +883,10 @@ function M:onAsk(game, msg)
   local side = Wire.side(msg.side)
   if not (id and from and name and side) then return end
 
-  -- Already committed elsewhere.  Answered immediately rather than queued, for
-  -- the same reason a trade request is: a box that surfaces minutes later over
-  -- whatever the player is doing by then is worse than a no they can act on.
-  if self.ask or self.running then
+  -- Already committed elsewhere, or mid-fight.  Answered immediately rather
+  -- than queued: a box over a wild encounter or a live 2-on-2 is worse than
+  -- a no the asker can act on now.
+  if self.ask or self:inFight(game) then
     self.transport:send(Wire.COOP_ANSWER, { id = id, accept = false })
     return
   end

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -1374,6 +1374,21 @@ handlers[Wire.RESPOND] = function(self, client, msg)
   self:startSession(asker, client, kind)
 end
 
+-- The asker takes the request back before it is answered.  Only they can:
+-- pendingTo lives on their connection, and a forged cancel from somebody
+-- else has nothing to clear.  The player holding the yes/no box is told,
+-- so they are not left answering an ask nobody is waiting on any more.
+handlers[Wire.REQUEST_CANCEL] = function(self, client)
+  if not client.ready then return end
+  local targetId = client.pendingTo
+  if not targetId then return end
+  client.pendingTo = nil
+  local target = self.clients[targetId]
+  if target and target.ready then
+    send(target, Wire.REQUEST_CANCEL, { from = client.id, name = client.name })
+  end
+end
+
 -- The invite, and the two answers to it.
 --
 -- Deliberately the same shape as the trade/battle request above -- one

--- a/src/Sessions.lua
+++ b/src/Sessions.lua
@@ -79,8 +79,10 @@ function M.new(transport, ui)
     transport = transport,
     ui = ui,
     active = nil,      -- the one live session; two at once is never valid
-    outgoing = nil,    -- { to, kind } while waiting for an answer
+    outgoing = nil,    -- { to, kind, name } while waiting for an answer
     incoming = nil,    -- { from, name, kind } while the prompt is up
+    waitBox = nil,     -- held "Waiting for NAME..." box for a battle ask
+    incomingBox = nil, -- held yes/no box on the asked side
     drops = 0,         -- relays refused since the current session began
   }, M)
 end
@@ -89,17 +91,146 @@ function M:isBusy()
   return self.active ~= nil or self.outgoing ~= nil
 end
 
+-- A state on the engine stack that means "this player is in a fight".
+-- Wild / trainer / link are BattleState.kind; a co-op 2-on-2 carries `.sim`
+-- and has no kind of its own.  Scanned anywhere on the stack, not only the
+-- top: a menu or co-op prompt can sit above a live battle, and an invite
+-- popping over either is the bug this exists to stop.
+function M.isFightState(state)
+  if type(state) ~= "table" then return false end
+  local kind = state.kind
+  if kind == "wild" or kind == "trainer" or kind == "link" then return true end
+  if state.sim ~= nil then return true end
+  return false
+end
+
+function M.stackHasFight(game)
+  local stack = game and game.stack
+  if not stack then return false end
+  local states = stack.states
+  if type(states) == "table" then
+    for i = #states, 1, -1 do
+      if M.isFightState(states[i]) then return true end
+    end
+    return false
+  end
+  local top = stack.top and stack:top()
+  return M.isFightState(top)
+end
+
+-- True while this client is mid-fight: an optional `fighting` callback
+-- (Client wires co-op running/state through it) or a battle still on the
+-- stack.  Trade/PVP sessions are already covered by isBusy.
+function M:inFight(game)
+  if self.fighting and self.fighting(game) then return true end
+  return M.stackHasFight(game)
+end
+
+-- ------- prompt stack helpers
+--
+-- The waiting box and the incoming confirm are screens on the engine's
+-- stack.  An answer that arrives while they are up -- a refuse, a cancel,
+-- a peer going offline, the session actually starting -- has to take them
+-- down rather than leave them buried under whatever comes next.  Same shape
+-- as Coop:closeAskBox / unwindTo: only pop when the held box is still on
+-- the stack, and never hunt blindly.
+
+function M:onStack(game, target)
+  local stack = game and game.stack
+  local states = stack and stack.states
+  if not (states and target) then return nil end
+  for i = #states, 1, -1 do
+    if states[i] == target then return true end
+  end
+  return false
+end
+
+function M:unwindTo(game, target, alsoPop)
+  local stack = game and game.stack
+  if not (stack and target) then return false end
+  if self:onStack(game, target) == false then return false end
+  local guard = 0
+  while stack:top() and stack:top() ~= target and guard < 16 do
+    stack:pop()
+    guard = guard + 1
+  end
+  if alsoPop and stack:top() == target then stack:pop() end
+  return true
+end
+
+function M:closeWaitBox()
+  local held = self.waitBox
+  self.waitBox = nil
+  if not (held and held.box) then return false end
+  return self:unwindTo(held.game, held.box, true)
+end
+
+function M:closeIncomingBox()
+  local held = self.incomingBox
+  self.incomingBox = nil
+  if not (held and held.box) then return false end
+  return self:unwindTo(held.game, held.box, true)
+end
+
 -- ------- requests
+
+-- The box the asker stands behind after a battle request.  B (and the only
+-- row) opens a yes/no confirm rather than cancelling outright: backing out of
+-- an ask that is already on somebody else's screen is worth a second look,
+-- and a no drops straight back onto this waiting line because the confirm
+-- sits on top of it.
+function M:showWaiting()
+  local outgoing = self.outgoing
+  if not (outgoing and outgoing.kind == "battle") then return end
+  local name = outgoing.name or "them"
+  local game = self.ui.ctx and self.ui.ctx.game
+  local box = self.ui:choose(game, ("Waiting for\n%s..."):format(name), {
+    {
+      label = "CANCEL",
+      onSelect = function()
+        if not self.outgoing then return end
+        self.ui:confirm(game, "Cancel the\nrequest?", function(yes)
+          if not yes then return end
+          self:cancelRequest()
+        end, { defaultNo = true })
+      end,
+    },
+  })
+  self.waitBox = { box = box, game = game }
+end
 
 function M:request(peer, kind)
   if self:isBusy() then
     self.ui:say("You're already busy\nwith someone.")
     return false
   end
+  local game = self.ui.ctx and self.ui.ctx.game
+  if self:inFight(game) then
+    self.ui:say("Finish your battle\nfirst.")
+    return false
+  end
   self.outgoing = { to = peer.id, kind = kind, name = peer.name }
   self.transport:send(Wire.REQUEST, { to = peer.id, kind = kind })
-  self.ui:say(("Asked %s to\n%s."):format(peer.name,
-    kind == "trade" and "trade" or "battle"))
+  -- A battle ask holds the screen until it is answered or cancelled: the
+  -- old one-line "Asked X to battle." dismissed itself on A and left the
+  -- player locked as busy with nothing on screen saying why.  Trade keeps
+  -- the short sentence -- there is no waiting box for it yet.
+  if kind == "battle" then
+    self:showWaiting()
+  else
+    self.ui:say(("Asked %s to\ntrade."):format(peer.name))
+  end
+  return true
+end
+
+-- Take our unanswered ask back.  Safe when there is none: every exit that
+-- might race a human press goes through here.
+function M:cancelRequest()
+  local outgoing = self.outgoing
+  if not outgoing then return false end
+  self.outgoing = nil
+  self:closeWaitBox()
+  self.transport:send(Wire.REQUEST_CANCEL, {})
   return true
 end
 
@@ -109,30 +240,72 @@ function M:onRequest(game, msg)
   local kind = Wire.KINDS[msg.kind] and msg.kind or nil
   if not (from and name and kind) then return end
 
-  -- Busy is answered immediately rather than queued: a prompt that appears
-  -- minutes later, over whatever the player is doing by then, is worse than
-  -- a refusal the asker can act on now.
-  if self:isBusy() then
+  -- Busy, already prompted, or mid-fight: answered immediately rather than
+  -- queued.  A yes/no over a wild encounter, a link battle, or a co-op
+  -- screen is worse than a refusal the asker can act on now -- and is how
+  -- invites used to appear in the middle of fights.
+  if self:isBusy() or self.incoming or self:inFight(game) then
     self.transport:send(Wire.RESPOND, { to = from, kind = kind, accept = false })
     return
   end
 
   self.incoming = { from = from, name = name, kind = kind }
-  self.ui:confirm(game,
+  local box = self.ui:confirm(game,
     ("%s wants to\n%s!"):format(name, kind == "trade" and "trade" or "battle"),
     function(yes)
       local pending = self.incoming
       self.incoming = nil
+      self.incomingBox = nil
       if not pending then return end
       self.transport:send(Wire.RESPOND,
         { to = pending.from, kind = pending.kind, accept = yes and true or false })
     end)
+  self.incomingBox = { box = box, game = game }
 end
 
 function M:onDecline(msg)
-  local name = Wire.name(msg.name) or "They"
+  local outgoing = self.outgoing
+  local name = Wire.name(msg.name) or (outgoing and outgoing.name) or "They"
+  local kind = outgoing and outgoing.kind
   self.outgoing = nil
-  self.ui:say(("%s said no."):format(name))
+  self:closeWaitBox()
+  if kind == "battle" then
+    self.ui:say(("%s refused\nto battle."):format(name))
+  else
+    self.ui:say(("%s said no."):format(name))
+  end
+end
+
+-- The asker walked away before we answered.  Their name is stamped by the
+-- hub, so a forged cancel cannot put somebody else's nick on this sentence.
+function M:onCancel(msg)
+  local from = Wire.id(msg.from)
+  local name = Wire.name(msg.name) or "They"
+  local pending = self.incoming
+  if not pending then return end
+  if from and pending.from ~= from then return end
+  self.incoming = nil
+  self:closeIncomingBox()
+  self.ui:say(("%s cancelled\nthe invite."):format(name))
+end
+
+-- A player left the game.  Same duty Party:onPeerGone has for invites: an
+-- unanswered ask pointed at somebody who is gone can never be answered, and
+-- without this the asker stays busy forever with nothing on screen saying
+-- why.  The hub clears its pendingTo in silence; this is the half that
+-- tells the human.
+function M:onPeerGone(id)
+  if not id then return end
+  if self.outgoing and self.outgoing.to == id then
+    local name = self.outgoing.name or "They"
+    self.outgoing = nil
+    self:closeWaitBox()
+    self.ui:say(("%s went\noffline."):format(name))
+  end
+  if self.incoming and self.incoming.from == id then
+    self.incoming = nil
+    self:closeIncomingBox()
+  end
 end
 
 -- ------- session lifecycle
@@ -145,6 +318,12 @@ function M:onSession(game, msg)
   if not (peerId and kind and role) then return end
 
   self.outgoing = nil
+  self.incoming = nil
+  -- The waiting / invite boxes outlive the ask they were about the moment
+  -- the session starts; left up they bury under the trade or battle screen
+  -- and resurface when it pops.
+  self:closeWaitBox()
+  self:closeIncomingBox()
   local modules = link()
   if not modules then return end
 
@@ -219,6 +398,7 @@ end
 function M:onSessionEnd(reason)
   local session = self.active
   self.outgoing = nil
+  self:closeWaitBox()
   if not session then
     self.active = nil
     return
@@ -251,6 +431,50 @@ end
 
 -- ------- the handshake, then the handoff
 
+-- Whether a hello claims the lockstep surface was touched: an affects_link
+-- mod, or a write into a link-surface registry.  Carried on the hello so we
+-- do not have to re-derive it from the peer's mod list alone (a mod can set
+-- affects_link false and still patch pokemon).
+function M.linkSurfaceTouched(hello)
+  return hello ~= nil and hello.linkModified == true
+end
+
+-- Cable-club battleAllowed, plus one MMO exception: fingerprints that differ
+-- only because the imported games differ (Red vs Blue, two ROM dumps) while
+-- neither side has touched the link surface.  Vanilla Gen 1 let those fight;
+-- refusing them here blamed "mods" for a cartridge mismatch.  A side that
+-- has actually changed battle rules still has to match.
+function M.canBattle(verdict, myHello, theirHello, Handshake)
+  if not (Handshake and Handshake.battleAllowed) then return false end
+  if Handshake.battleAllowed(verdict) then return true end
+  if verdict == "subset"
+      and not M.linkSurfaceTouched(myHello)
+      and not M.linkSurfaceTouched(theirHello) then
+    return true
+  end
+  return false
+end
+
+-- Why a battle was refused, naming the mods that differ when we can.
+-- Handshake.describe already diffs the hello mod lists; we keep that and
+-- add a clearer line when the lists match but one side still claims a
+-- modified link surface (registry writes with affects_link left false).
+function M.battleBlockMessage(myHello, theirHello, verdict, Handshake)
+  local fallback = "Link battle needs\nthe same mods on\nboth games."
+  if not (Handshake and Handshake.describe) then return fallback end
+  local lines = Handshake.describe(myHello, theirHello, verdict, "battle")
+  if Handshake.modDiff then
+    local diff = Handshake.modDiff(myHello, theirHello)
+    local named = #(diff.onlyMine or {}) + #(diff.onlyTheirs or {})
+      + #(diff.differing or {})
+    if named == 0 and (M.linkSurfaceTouched(myHello) or M.linkSurfaceTouched(theirHello)) then
+      return "A mod changed\nbattle rules on\none game."
+    end
+  end
+  if lines and #lines > 0 then return table.concat(lines, "\n") end
+  return fallback
+end
+
 function M:beginTrade(game, session, modules)
   if not modules.Handshake.tradeAllowed(session.verdict) then
     return self:endSession("You can't trade\nwith that game.")
@@ -265,8 +489,19 @@ function M:beginTrade(game, session, modules)
 end
 
 function M:beginBattle(game, session, modules)
-  if not modules.Handshake.battleAllowed(session.verdict) then
-    return self:endSession("Link battle needs\nthe same mods on\nboth games.")
+  if not M.canBattle(session.verdict, session.myHello, session.theirHello,
+                     modules.Handshake) then
+    return self:endSession(M.battleBlockMessage(
+      session.myHello, session.theirHello, session.verdict, modules.Handshake))
+  end
+  -- LinkBattle itself also gates on Handshake.battleAllowed(verdict).  A
+  -- subset we chose to allow (neither side link-modified) still has to
+  -- present as battle-legal at the constructor; the real verdict stays on
+  -- the session for strict unpacking.
+  if modules.Handshake.battleAllowed(session.verdict) then
+    session.battleVerdict = session.verdict
+  else
+    session.battleVerdict = "full"
   end
   session.stage = "battleWait"
   session.myParty = modules.Protocol.packParty(game.save.party)
@@ -299,7 +534,7 @@ function M:handleBattleWait(game, session, msg, modules)
     and modules.Battle.newHost or modules.Battle.newGuest
   local state, err = constructor(game, session.net, {
     theirName = session.peerName,
-    verdict = session.verdict,
+    verdict = session.battleVerdict or session.verdict,
     strict = modules.Handshake.strict(session.verdict),
     myParty = session.myParty,
     theirParty = session.theirParty,

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -795,8 +795,11 @@ end
 -- keeps the box it already had.
 function M:confirm(game, text, onChoose, opts)
   game = game or self.ctx.game
-  if not game then return end
-  mod.ui.push(game, SCREEN.CONFIRM, {
+  if not game then return nil end
+  -- Returned so a caller can take the box back down -- Sessions holds the
+  -- battle-invite prompt the same way Coop holds its ask box, and cancels
+  -- or a peer going offline have to dismiss it rather than leave it buried.
+  return mod.ui.push(game, SCREEN.CONFIRM, {
     text = text,
     onChoose = onChoose,
     defaultNo = opts and opts.defaultNo,
@@ -827,8 +830,11 @@ end
 
 function M:choose(game, text, items)
   game = game or self.ctx.game
-  if not (game and items and #items > 0) then return end
-  mod.ui.push(game, SCREEN.CHOOSE, { text = text, items = items })
+  if not (game and items and #items > 0) then return nil end
+  -- Returned for the same reason confirm is: a waiting box has to be
+  -- dismissible from outside when the answer arrives (or the ask is
+  -- cancelled) rather than only when the player presses a row.
+  return mod.ui.push(game, SCREEN.CHOOSE, { text = text, items = items })
 end
 
 function M:pushState(game, state)

--- a/src/Wire.lua
+++ b/src/Wire.lua
@@ -26,10 +26,15 @@ local M = {}
 M.HELLO         = "mmo.hello"
 M.MOVE          = "mmo.move"
 M.CHAT          = "mmo.chat"
-M.REQUEST       = "mmo.request"
-M.RESPOND       = "mmo.respond"
-M.RELAY         = "mmo.relay"
-M.SESSION_LEAVE = "mmo.session_leave"
+M.REQUEST        = "mmo.request"
+M.RESPOND        = "mmo.respond"
+-- The asker takes back an unanswered trade/battle request.  One name for
+-- both directions, the way PARTY_INVITE is: outbound it is empty (the hub
+-- already knows who we asked), inbound it carries { from, name } so the
+-- player holding the yes/no box can say who walked away.
+M.REQUEST_CANCEL = "mmo.request_cancel"
+M.RELAY          = "mmo.relay"
+M.SESSION_LEAVE  = "mmo.session_leave"
 M.PING          = "mmo.ping"
 -- Parties.  PARTY_INVITE travels both ways, the way REQUEST does: the field
 -- set says which direction it is going (`to` outbound, `from` inbound), and

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -475,6 +475,41 @@ return function(game)
     end, 120, "the guest's chat line")
     check(heardGuest, "the guest's chat reached the host")
 
+    -- ------- invite refuse (focused e2e; see run-invite-refuse-e2e.sh)
+    --
+    -- A battle ask that arrives while this side is mid-trainer fight must
+    -- be answered no immediately -- no confirm over the fight. The guest
+    -- half asserts the refusal text; we assert nothing was held incoming.
+    if os.getenv("MMO_INVITE_REFUSE_E2E") == "1" then
+      local class = H.coopTrainer(game.data)
+      check(class ~= nil, "found a trainer class to stage")
+      local staged = class and H.stageTrainer(game, class)
+      check(staged ~= nil, "staged a trainer battle on the host")
+      local fighting = H.waitSeconds(game, function()
+        return exports.isFighting and exports.isFighting()
+      end, 15, "host to report isFighting")
+      check(fighting, "host isFighting after staging a trainer")
+      H.signal("host_in_fight")
+
+      H.await(game, "guest_asked_battle_in_fight")
+      -- Room for the request to land if auto-refuse ever fails to clear it.
+      U.wait(45)
+      check(not (exports.hasIncomingRequest and exports.hasIncomingRequest()),
+            "no incoming invite held while fighting")
+      local top = H.top(game)
+      local text = (H.textOf(top) or ""):lower()
+      check(not (text:find("wants", 1, true) and text:find("battle", 1, true)),
+            "no battle confirm over the fight")
+      check(exports.isFighting and exports.isFighting(),
+            "host still in the fight after the ask")
+      U.shot(game, SHOT_DIR .. "/host-invite-refused-while-fighting.png")
+
+      H.await(game, "guest_saw_battle_refusal")
+      H.closeToOverworld(game)
+      log("DONE")
+      return
+    end
+
     -- ------- 1. the guest leaves the map, and comes back
     --
     -- A remote player on another map must not be drawn on this one; the

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -402,6 +402,44 @@ return function(game)
   check(wornOk,
         "joining leaves the player genuinely drawn as their chosen character")
 
+  -- ------- invite refuse (focused e2e; see run-invite-refuse-e2e.sh)
+  --
+  -- Host stages a trainer battle first; we ask via PLAYERS > BATTLE. Do
+  -- not drivePrompts across the waiting box -- its only row is CANCEL and
+  -- would take the ask back before the host's auto-refuse can answer.
+  if os.getenv("MMO_INVITE_REFUSE_E2E") == "1" then
+    H.await(game, "host_in_fight")
+    local asked = false
+    if H.openMmo(game) and H.selectLabel(game, "PLAYERS") then
+      if H.selectLabel(game, "HOSTY") then
+        asked = H.selectLabel(game, "BATTLE") and true or false
+        check(asked, "asked HOSTY to battle while they fight")
+      else
+        check(false, "found HOSTY on the PLAYERS list")
+      end
+    else
+      check(false, "opened PLAYERS to ask for a battle")
+    end
+    if asked then
+      H.signal("guest_asked_battle_in_fight")
+      local refused = H.waitSeconds(game, function()
+        local text = (H.textOf(H.top(game)) or ""):lower()
+        return text:find("refused", 1, true) ~= nil
+      end, 60, "HOSTY refused to battle")
+      check(refused, "saw the battle refusal after asking mid-fight")
+      check(not (exports.isSessionBusy and exports.isSessionBusy()),
+            "the outgoing ask is cleared after the refusal")
+      U.shot(game, SHOT_DIR .. "/join-invite-refused.png")
+      H.signal("guest_saw_battle_refusal")
+    else
+      H.signal("guest_asked_battle_in_fight")
+      H.signal("guest_saw_battle_refusal")
+    end
+    H.closeToOverworld(game)
+    log("DONE")
+    return
+  end
+
   -- ------- 1. leave the map and come back
 
   local home = mod_current(game)

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -619,6 +619,15 @@ local PHASE = {
   guest_battle_requested = 300,  -- 120 trade drive + 60 free
   -- guest waits on the host running a link battle to a decision
   host_battle_done       = 540,  -- 90 start + 240 run + transition
+
+  -- ------- invite-refuse e2e (tests/drivers/run-invite-refuse-e2e.sh)
+  --
+  -- Host stages a real trainer battle, guest asks to battle via PLAYERS.
+  -- The ask must be auto-refused; neither side should sit on a yes/no over
+  -- the fight. Short barriers: both are already connected and on the map.
+  host_in_fight                 = 120,
+  guest_asked_battle_in_fight   = 180,
+  guest_saw_battle_refusal      = 120,
   -- guest waits on the host re-opening the MMO menu
   host_address_checked   = 150,  -- menus only
   -- host waits on the guest leaving and proving the world still works

--- a/tests/drivers/run-invite-refuse-e2e.sh
+++ b/tests/drivers/run-invite-refuse-e2e.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Focused end-to-end: a battle invite that arrives while the host is mid-
+# trainer fight must be auto-refused -- no yes/no over the fight, and the
+# guest must see the refusal.
+#
+# Reuses mmo_host.lua / mmo_join.lua. Both early-exit after host/guest chat
+# once MMO_INVITE_REFUSE_E2E=1 (see the "invite refuse" blocks there).
+#
+#   bash mods/rby_mmo/tests/drivers/run-invite-refuse-e2e.sh
+#
+# Same prerequisites as run-mmo-e2e.sh (ROM imported, love on PATH, mod
+# symlinked into mods/). Shorter wall-clock budget: this run never reaches
+# trade / link battle / co-op.
+
+set -uo pipefail
+export MMO_INVITE_REFUSE_E2E=1
+export MMO_TIMEOUT="${MMO_TIMEOUT:-600}"
+exec "$(dirname "$0")/run-mmo-e2e.sh"

--- a/tests/drivers/run-red-yellow-battle-compat.sh
+++ b/tests/drivers/run-red-yellow-battle-compat.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Build Red + Yellow link-surface extracts and assert MMO battle compat.
+#
+# Reads ROM_PATH / ROM_VERSION / SECONDARY_ROM_PATH / SECONDARY_ROM_VERSION
+# from mods/rby_mmo/.env (or the environment). Skips cleanly when either
+# ROM is missing -- CI has no cartridges.
+#
+# Run from the engine checkout root:
+#   bash mods/rby_mmo/tests/drivers/run-red-yellow-battle-compat.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOD_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Prefer the engine root we were invoked from; fall back to walking up from
+# the mod when this script is called by absolute path.
+if [ -f "./tools/build_data.py" ]; then
+  REPO="$(pwd)"
+elif [ -f "$MOD_DIR/../../tools/build_data.py" ]; then
+  REPO="$(cd "$MOD_DIR/../.." && pwd)"
+else
+  echo "run from the gen1recomp checkout root (tools/build_data.py not found)" >&2
+  exit 2
+fi
+
+# shellcheck source=../../tools/env.sh
+. "$MOD_DIR/tools/env.sh"
+load_env "$MOD_DIR/.env"
+if type check_rom_config >/dev/null 2>&1; then
+  check_rom_config || true
+fi
+
+RED_ROM="${ROM_PATH:-}"
+RED_VER="${ROM_VERSION:-red}"
+YEL_ROM="${SECONDARY_ROM_PATH:-}"
+YEL_VER="${SECONDARY_ROM_VERSION:-yellow}"
+
+if [ -z "$RED_ROM" ] || [ ! -f "$RED_ROM" ]; then
+  echo "skip: ROM_PATH missing or not a file -- no Red cartridge to extract"
+  exit 0
+fi
+if [ -z "$YEL_ROM" ] || [ ! -f "$YEL_ROM" ]; then
+  echo "skip: SECONDARY_ROM_PATH missing or not a file -- no Yellow cartridge"
+  exit 0
+fi
+
+PY="${PYTHON:-python3}"
+CACHE_ROOT="${TMPDIR:-/tmp}/rby-mmo-link-surface"
+mkdir -p "$CACHE_ROOT"
+
+# Cache key: version + ROM sha so a replaced file rebuilds.
+slice_dir() {
+  local ver="$1" rom="$2"
+  local sha
+  sha="$(shasum -a 1 "$rom" | cut -d' ' -f1)"
+  echo "$CACHE_ROOT/${ver}-${sha:0:12}"
+}
+
+build_slice() {
+  local ver="$1" rom="$2" out="$3"
+  if [ -f "$out/pokemon.lua" ] && [ -f "$out/moves.lua" ] \
+      && [ -f "$out/type_chart.lua" ] && [ -f "$out/constants.lua" ]; then
+    echo "  reusing $out"
+    return 0
+  fi
+  echo "  extracting $ver link surface from $(basename "$rom")"
+  mkdir -p "$out"
+  "$PY" "$REPO/tools/build_data.py" \
+    --rom "$rom" --version "$ver" --out "$out" \
+    --only pokemon --only moves --only type_chart --only constants
+}
+
+RED_OUT="$(slice_dir "$RED_VER" "$RED_ROM")"
+YEL_OUT="$(slice_dir "$YEL_VER" "$YEL_ROM")"
+
+echo "== red/yellow battle compat =="
+echo "  repo: $REPO"
+echo "  mod:  $MOD_DIR"
+build_slice "$RED_VER" "$RED_ROM" "$RED_OUT"
+build_slice "$YEL_VER" "$YEL_ROM" "$YEL_OUT"
+
+cd "$REPO"
+luajit "$MOD_DIR/tests/red_yellow_battle_compat.lua" \
+  "$RED_OUT" "$YEL_OUT" "$MOD_DIR"

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -4958,9 +4958,19 @@ local function tradeSide(hub, name, species)
   }
   side.ui = {
     say = function(_, text) side.said[#side.said + 1] = text end,
-    confirm = function(_, _, text, cb) side.confirmText = text; side.confirmBox = cb end,
+    confirm = function(_, _, text, cb)
+      side.confirmText = text
+      side.confirmBox = cb
+      return { kind = "confirm" }
+    end,
+    choose = function(_, _, text, items)
+      side.chooseText = text
+      side.chosen = items
+      return { kind = "choose" }
+    end,
     pickPartyMon = function(_, _, _, cb) side.pickBox = cb end,
     pushState = function() end,
+    ctx = {},
   }
   side.sessions = Sessions.new(side.transport, side.ui)
   side.game = {
@@ -4982,6 +4992,7 @@ local sessionDispatch = {
   [Wire.SESSION_END] = function(s, m) s.sessions:onSessionEnd(m.reason) end,
   [Wire.REQUEST] = function(s, m) s.sessions:onRequest(s.game, m) end,
   [Wire.DECLINE] = function(s, m) s.sessions:onDecline(m) end,
+  [Wire.REQUEST_CANCEL] = function(s, m) s.sessions:onCancel(m) end,
 }
 
 local function pump(side, dt)
@@ -5231,6 +5242,243 @@ check(claimed ~= nil, "the battle this mod handed over is claimed")
 eq(claimed.id, liveId, "under the session it was fought in")
 eq(ann8.sessions:claimBattle(fought), nil,
    "and only once, so a result cannot be reported twice")
+
+-- ------- battle invite: waiting, refuse, cancel
+--
+-- The ask used to leave a one-line "Asked X to battle." that dismissed on A
+-- while keeping the player busy with nothing on screen.  Waiting holds the
+-- screen, B opens a cancel confirm, a refuse names who said no, and a cancel
+-- tells the other side the invite is gone.
+
+local function said(side, needle)
+  for _, line in ipairs(side.said) do
+    if line:find(needle, 1, true) then return true end
+  end
+  return false
+end
+
+local function pressCancel(side)
+  local items = side.chosen
+  check(items ~= nil and items[1] and items[1].onSelect,
+        "the waiting box has a CANCEL row")
+  -- Chosen stays: a No on the confirm drops back onto the same waiting box
+  -- (it is still underneath), so the next B has to find the same row.
+  items[1].onSelect()
+end
+
+local battleHub = Hub.new({ maxPlayers = 4 })
+local asker = tradeSide(battleHub, "ASH", "FIXMON_B")
+local target = tradeSide(battleHub, "GARY", "FIXMON_C")
+
+asker.sessions:request({ id = target.client.id, name = "GARY" }, "battle")
+eq(asker.sessions.outgoing ~= nil, true, "a battle ask is held as outgoing")
+check(asker.chooseText and asker.chooseText:find("GARY", 1, true),
+      "and the asker sees Waiting for GARY...")
+eq(asker.sessions:isBusy(), true, "so they cannot ask anybody else")
+
+pump(target)
+check(target.confirmBox ~= nil, "GARY is asked to battle")
+check(target.confirmText and target.confirmText:find("battle", 1, true),
+      "naming a battle, not a trade")
+
+-- Refuse: waiting comes down, and the sentence names the refusal.
+answerConfirm(target, false)
+pump(asker)
+eq(asker.sessions.outgoing, nil, "a refuse clears the ask")
+eq(asker.sessions:isBusy(), false, "and frees the asker")
+check(said(asker, "refused"), "with 'GARY refused to battle'")
+check(said(asker, "GARY"), "naming who refused")
+
+-- Cancel from the asker's side: GARY's prompt comes down with a sentence.
+asker.said = {}
+target.said = {}
+asker.sessions:request({ id = target.client.id, name = "GARY" }, "battle")
+pump(target)
+check(target.confirmBox ~= nil, "GARY is asked again")
+eq(battleHub.clients[asker.client.id].pendingTo, target.client.id,
+   "the hub holds the outstanding ask")
+
+pressCancel(asker)
+check(asker.confirmBox ~= nil, "B/CANCEL opens a yes/no confirm")
+-- No keeps waiting: confirm callback returns without cancelling.
+asker.confirmBox(false)
+eq(asker.sessions.outgoing ~= nil, true, "answering No leaves the ask outstanding")
+eq(battleHub.clients[asker.client.id].pendingTo, target.client.id,
+   "and the hub still holds it")
+
+pressCancel(asker)
+asker.confirmBox(true)
+pump(target)
+eq(asker.sessions.outgoing, nil, "Yes cancels the ask")
+eq(asker.sessions:isBusy(), false, "and frees the asker")
+eq(battleHub.clients[asker.client.id].pendingTo, nil,
+   "the hub drops pendingTo")
+eq(target.sessions.incoming, nil, "GARY's incoming is cleared")
+check(said(target, "cancelled"), "and GARY is told the invite was cancelled")
+check(said(target, "ASH"), "naming who cancelled")
+
+-- A yes after cancel must not open a session.
+target.confirmBox = nil
+asker.sessions:request({ id = target.client.id, name = "GARY" }, "battle")
+pump(target)
+asker.sessions:cancelRequest()
+pump(target)
+-- stale confirm from before cancel, if the harness still held the cb
+if target.confirmBox then answerConfirm(target, true) end
+pump(asker); pump(target)
+eq(asker.sessions.active, nil, "accepting a cancelled ask starts no session")
+eq(target.sessions.active, nil, "on either side")
+
+-- Peer gone while waiting: same lock Party fixed for invites.
+asker.said = {}
+asker.sessions:request({ id = target.client.id, name = "GARY" }, "battle")
+eq(asker.sessions.outgoing ~= nil, true, "waiting again")
+asker.sessions:onPeerGone(target.client.id)
+eq(asker.sessions.outgoing, nil, "a peer going offline clears the ask")
+check(said(asker, "offline"), "and says so on screen")
+
+-- ------- invites during a live fight are refused, not shown
+--
+-- isBusy only covered trade/PVP sessions. A wild encounter, a trainer
+-- battle, a link battle on the stack, or a co-op screen used to leave the
+-- confirm free to open on top of the fight.
+
+eq(Sessions.isFightState({ kind = "wild" }), true, "a wild battle is a fight")
+eq(Sessions.isFightState({ kind = "trainer" }), true, "a trainer battle is")
+eq(Sessions.isFightState({ kind = "link" }), true, "a link battle is")
+eq(Sessions.isFightState({ sim = {} }), true, "a co-op screen (has sim) is")
+eq(Sessions.isFightState({ kind = "menu" }), false, "a menu is not")
+eq(Sessions.isFightState(nil), false, "and neither is nothing")
+
+local fighting = tradeSide(battleHub, "MISTY", "FIXMON_B")
+local challenger = tradeSide(battleHub, "SURGE", "FIXMON_C")
+fighting.game.stack = {
+  states = { { kind = "overworld" }, { kind = "wild" } },
+  top = function(self) return self.states[#self.states] end,
+}
+eq(Sessions.stackHasFight(fighting.game), true,
+   "a wild battle anywhere on the stack counts")
+eq(fighting.sessions:inFight(fighting.game), true, "so inFight sees it")
+
+challenger.sessions:request({ id = fighting.client.id, name = "MISTY" }, "battle")
+pump(fighting)
+eq(fighting.confirmBox, nil, "no invite prompt opens over the wild battle")
+eq(fighting.sessions.incoming, nil, "and nothing is held as incoming")
+pump(challenger)
+eq(challenger.sessions.outgoing, nil, "the asker is told no")
+check(said(challenger, "refused") or said(challenger, "MISTY"),
+      "with a refusal naming MISTY")
+
+-- Buried under a menu: still a fight.
+fighting.game.stack.states = {
+  { kind = "trainer" }, { kind = "menu" },
+}
+challenger.said = {}
+challenger.sessions:request({ id = fighting.client.id, name = "MISTY" }, "battle")
+pump(fighting); pump(challenger)
+eq(fighting.confirmBox, nil, "a menu over a trainer battle still auto-refuses")
+
+-- Co-op running, no screen yet (handoff): fighting callback.
+fighting.game.stack = { states = {}, top = function() return nil end }
+fighting.sessions.fighting = function() return true end
+challenger.said = {}
+challenger.sessions:request({ id = fighting.client.id, name = "MISTY" }, "battle")
+pump(fighting); pump(challenger)
+eq(fighting.confirmBox, nil, "a co-op handoff without a screen still refuses")
+
+-- ------- battle compat: name the mods, allow vanilla-link mismatches
+--
+-- The engine refuses any fingerprint mismatch.  Over the hub we only refuse
+-- when a side has touched the lockstep surface (linkModified), and the
+-- refusal has to name the mods that differ so players know what to turn off.
+
+local function fakeModDiff(a, b)
+  local function index(mods)
+    local byId = {}
+    for _, mod in ipairs(mods or {}) do byId[tostring(mod.id)] = mod end
+    return byId
+  end
+  local mine, theirs = index(a and a.mods), index(b and b.mods)
+  local onlyMine, onlyTheirs, differing = {}, {}, {}
+  for id, mod in pairs(mine) do
+    local peer = theirs[id]
+    if not peer then onlyMine[#onlyMine + 1] = mod
+    elseif tostring(peer.version) ~= tostring(mod.version) then
+      differing[#differing + 1] = { id = id, mine = mod.version,
+                                    theirs = peer.version }
+    end
+  end
+  for id, mod in pairs(theirs) do
+    if not mine[id] then onlyTheirs[#onlyTheirs + 1] = mod end
+  end
+  return { onlyMine = onlyMine, onlyTheirs = onlyTheirs, differing = differing }
+end
+
+local fakeHandshake = {
+  battleAllowed = function(verdict)
+    return verdict == "full" or verdict == "vanilla_peer" or verdict == nil
+  end,
+  modDiff = fakeModDiff,
+  describe = function(a, b, verdict, mode)
+    local peer = (b and b.name) or "THEY"
+    local diff = fakeModDiff(a, b)
+    local lines = { "Your games differ." }
+    if #diff.onlyTheirs > 0 then
+      lines[#lines + 1] = peer .. " has:"
+      for _, mod in ipairs(diff.onlyTheirs) do
+        lines[#lines + 1] = (" %s %s"):format(tostring(mod.id):upper(),
+                                              tostring(mod.version or "?"))
+      end
+    end
+    if #diff.onlyMine > 0 then
+      lines[#lines + 1] = "You have:"
+      for _, mod in ipairs(diff.onlyMine) do
+        lines[#lines + 1] = (" %s %s"):format(tostring(mod.id):upper(),
+                                              tostring(mod.version or "?"))
+      end
+    end
+    for _, row in ipairs(diff.differing) do
+      lines[#lines + 1] = ("%s %s vs %s"):format(tostring(row.id):upper(),
+                                                 tostring(row.mine),
+                                                 tostring(row.theirs))
+    end
+    if mode == "battle" then
+      lines[#lines + 1] = "Link battle needs"
+      lines[#lines + 1] = "the same mods."
+    end
+    return lines
+  end,
+}
+
+local vanillaA = { name = "ASH", fingerprint = "aaa", linkModified = false,
+                   mods = { { id = "rby_mmo", version = "0.10.0", affectsLink = false } } }
+local vanillaB = { name = "GARY", fingerprint = "bbb", linkModified = false,
+                   mods = { { id = "rby_mmo", version = "0.10.0", affectsLink = false } } }
+eq(Sessions.canBattle("full", vanillaA, vanillaB, fakeHandshake), true,
+   "identical fingerprints still battle")
+eq(Sessions.canBattle("subset", vanillaA, vanillaB, fakeHandshake), true,
+   "Red-vs-Blue style mismatch is allowed when neither side touched link rules")
+eq(Sessions.canBattle("refused", vanillaA, vanillaB, fakeHandshake), false,
+   "an engine mismatch is still refused")
+
+local modded = { name = "GARY", fingerprint = "ccc", linkModified = true,
+                 mods = {
+                   { id = "rby_mmo", version = "0.10.0", affectsLink = false },
+                   { id = "stat_tweaks", version = "1.2.0", affectsLink = true },
+                 } }
+eq(Sessions.canBattle("subset", vanillaA, modded, fakeHandshake), false,
+   "a link-affecting mod on one side still blocks the fight")
+
+local block = Sessions.battleBlockMessage(vanillaA, modded, "subset", fakeHandshake)
+check(block:find("STAT_TWEAKS", 1, true) or block:find("stat_tweaks", 1, true),
+      "the refusal names the mod only they have")
+check(block:find("GARY", 1, true), "and whose game has it")
+
+local stealth = { name = "GARY", fingerprint = "ddd", linkModified = true,
+                  mods = { { id = "rby_mmo", version = "0.10.0", affectsLink = false } } }
+local stealthMsg = Sessions.battleBlockMessage(vanillaA, stealth, "subset", fakeHandshake)
+check(stealthMsg:find("battle rules", 1, true),
+      "same mod list but linkModified still explains the block")
 
 end)()
 

--- a/tests/red_yellow_battle_compat.lua
+++ b/tests/red_yellow_battle_compat.lua
@@ -1,0 +1,167 @@
+-- Red vs Yellow link-battle compatibility, against real ROM extracts.
+--
+-- Driven by tests/drivers/run-red-yellow-battle-compat.sh, which builds the
+-- link-surface slice of each ROM into a temp dir and passes the paths here.
+-- Needs the engine checkout on package.path (run from its root).
+--
+-- What it pins:
+--   * Sessions.canBattle allows the pairing when neither hello is
+--     link-modified -- the MMO exception for cartridge mismatches.
+--   * A link-modified hello on one side still refuses, and names the mod.
+--
+-- It also prints whether the fingerprints actually match.  Fingerprint.lua
+-- deliberately drops catchRate so R/B/Y can agree; if they diverge here for
+-- another field, that is worth knowing even when canBattle still says yes.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local redDir = arg[1] or os.getenv("RED_DATA_DIR")
+local yelDir = arg[2] or os.getenv("YELLOW_DATA_DIR")
+local modRoot = arg[3] or os.getenv("RBY_MMO_ROOT") or "mods/rby_mmo"
+
+if not (redDir and yelDir) then
+  io.stderr:write("usage: luajit tests/red_yellow_battle_compat.lua "
+    .. "<red-data-dir> <yellow-data-dir> [mod-root]\n")
+  os.exit(2)
+end
+
+local failures = 0
+local function check(cond, msg)
+  if cond then
+    print("ok   " .. msg)
+  else
+    failures = failures + 1
+    print("FAIL " .. msg)
+  end
+end
+local function eq(got, want, msg)
+  check(got == want, ("%s (got %s, want %s)"):format(
+    msg, tostring(got), tostring(want)))
+end
+
+local Fingerprint = require("src.link.Fingerprint")
+local Handshake = require("src.link.Handshake")
+local Version = require("src.core.Version")
+
+-- Minimal slice Fingerprint.surface reads from a ROM extract.  Statuses /
+-- move_effects / link_fields are engine-side and identical across versions
+-- when neither hello is link-modified, so leaving them absent keeps the
+-- comparison about the cartridge.
+local function loadSlice(dir)
+  local function one(name)
+    local path = dir .. "/" .. name .. ".lua"
+    local chunk, err = loadfile(path)
+    if not chunk then
+      error(("missing %s (%s)"):format(path, tostring(err)))
+    end
+    return assert(chunk())
+  end
+  return {
+    pokemon = one("pokemon"),
+    moves = one("moves"),
+    type_chart = one("type_chart"),
+    constants = one("constants"),
+  }
+end
+
+local function loadSessions()
+  local path = modRoot .. "/src/Sessions.lua"
+  local body, err = loadfile(path)
+  if not body then
+    -- Lua 5.1 loadfile returns nil, err; loadstring path for older shapes
+    error(("cannot load %s (%s)"):format(path, tostring(err)))
+  end
+  local Wire = { id = function() end, name = function() end,
+                 KINDS = { battle = true, trade = true } }
+  local function need(name)
+    if name == "Wire" then return Wire end
+    if name == "SessionNet" then return { new = function() return {} end } end
+    return {}
+  end
+  local mod = { log = { error = function() end, warn = function() end } }
+  return body(need, mod)
+end
+
+local Sessions = loadSessions()
+
+local mmoMods = {
+  { id = "rby_mmo", version = "0.10.0", affectsLink = false },
+}
+
+local function hello(name, data)
+  return {
+    type = "hello",
+    protocol = Handshake.PROTOCOL or Version.linkProtocol or 2,
+    name = name,
+    engineVersion = Version.engine,
+    apiVersion = Version.modApi,
+    fingerprint = Fingerprint.compute(data, mmoMods),
+    linkModified = false,
+    mods = mmoMods,
+  }
+end
+
+print("-- loading Red extract from " .. redDir)
+local redData = loadSlice(redDir)
+print("-- loading Yellow extract from " .. yelDir)
+local yelData = loadSlice(yelDir)
+
+local redHello = hello("RED", redData)
+local yelHello = hello("YELLOW", yelData)
+
+print(("red fingerprint:    %s"):format(redHello.fingerprint))
+print(("yellow fingerprint: %s"):format(yelHello.fingerprint))
+
+local sameFp = redHello.fingerprint == yelHello.fingerprint
+if sameFp then
+  print("note: fingerprints match -- cable-club surface agrees across versions")
+else
+  print("note: fingerprints differ -- canBattle must still allow via the "
+    .. "unmodified-link exception")
+end
+
+local verdict, reason = Handshake.checkCompat(redHello, yelHello)
+-- checkCompat returns one or two values depending on path
+if type(verdict) == "string" and reason == nil and verdict ~= "full"
+    and verdict ~= "subset" and verdict ~= "refused" and verdict ~= "vanilla_peer" then
+  -- older shape shouldn't happen; keep going
+end
+print(("checkCompat verdict: %s (%s)"):format(
+  tostring(verdict), tostring(reason)))
+
+if sameFp then
+  eq(verdict, "full", "matching fingerprints are a full verdict")
+else
+  eq(verdict, "subset", "differing fingerprints are a subset verdict")
+end
+
+check(Sessions.canBattle(verdict, redHello, yelHello, Handshake),
+      "Red vs Yellow is allowed when neither side touched link rules")
+check(Sessions.canBattle(verdict, yelHello, redHello, Handshake),
+      "and the same the other way around")
+
+-- One side with a link-affecting mod still blocks, and the refusal names it.
+local modded = {
+  type = "hello",
+  protocol = redHello.protocol,
+  name = "YELLOW",
+  engineVersion = redHello.engineVersion,
+  apiVersion = redHello.apiVersion,
+  fingerprint = "deadbeefdeadbeef",
+  linkModified = true,
+  mods = {
+    { id = "rby_mmo", version = "0.10.0", affectsLink = false },
+    { id = "stat_tweaks", version = "1.0.0", affectsLink = true },
+  },
+}
+check(not Sessions.canBattle("subset", redHello, modded, Handshake),
+      "a link-modified Yellow still cannot battle Red")
+local msg = Sessions.battleBlockMessage(redHello, modded, "subset", Handshake)
+check(type(msg) == "string" and msg:find("STAT_TWEAKS", 1, true) ~= nil,
+      "the refusal names STAT_TWEAKS")
+
+if failures > 0 then
+  print(("%d failure(s)"):format(failures))
+  os.exit(1)
+end
+print("all checks passed  (red_yellow_battle_compat)")


### PR DESCRIPTION
## Summary
- PVP battle asks hold `Waiting for <name>...` with cancel (`mmo.request_cancel`); refuse/cancel copy is explicit. **PROTOCOL 8 → 9** on client and hub so cancel clears relay `pendingTo`.
- Invites (1v1 and PARTY BATTLE) that arrive during a wild/trainer/link/co-op fight are auto-refused instead of opening a yes/no over the battle.
- Handshake: allow fingerprint `subset` when both hellos have `linkModified == false` (Red/Blue/Yellow / dumps); still refuse and name differing mods when either side touched lockstep rules.

## Test plan
- [x] `luajit mods/rby_mmo/tests/rby_mmo_test.lua` (2676/2676)
- [x] `bash mods/rby_mmo/tests/drivers/run-invite-refuse-e2e.sh`
- [ ] Optional: `run-red-yellow-battle-compat.sh` with `SECONDARY_ROM_PATH` set