### PR TITLE
fix: Gen1 catch and CoopBattle intro ball animations for party wild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ here must match `manifest.version`.
 
 ### Added
 
+- **PROTOCOL 18 — Party vs Wild vocabulary.** `Config.PROTOCOL` / `relay.js`
+  bump **17 → 18** so a protocol-17 hub cannot silently drop a `coop_wild`
+  open or strip an unknown `catcher` on `mmo.battle_outcome`. Mode token and
+  optional outcome field landed; overworld divert / seating / catch grant
+  follow in later waves.
+- **`coop_wild` battle mode** on the wire (`Wire.BATTLE_MODES` /
+  sanitize twin) and in `Config.MEDIATED_COOP`: two humans vs one wild NPC
+  seat (catch/run legal).
+- **Optional `catcher` on `mmo.battle_outcome`.** Present-and-bad refuses the
+  whole outcome (same posture as winners/losers); absent stays fine for
+  solo wild / KO paths.
 - **Friends hold keys use `Wire.nameKey` / relay `nameKey`, not `Rank.keyOf`.** PROTOCOL 16 made `Rank.keyOf` playerId-only; friendships stay trainer-name pairs, so the merge wires friend routing through the name fold.
 - **Friends (from main) under PROTOCOL 17.** Parallel main shipped friends as PROTOCOL 10 while this line claimed 10–16 for mediated battles + playerId; the merge keeps both feature sets and bumps `Config.PROTOCOL` / `relay.js` to **17** so a protocol-16 hub cannot silently ignore `mmo.friend_*`. Lists stay client-side (`src/Friends.lua`); the hub only holds offline asks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,15 @@ here must match `manifest.version`.
 
 ### Added
 
-- **PROTOCOL 18 — Party vs Wild vocabulary.** `Config.PROTOCOL` / `relay.js`
-  bump **17 → 18** so a protocol-17 hub cannot silently drop a `coop_wild`
-  open or strip an unknown `catcher` on `mmo.battle_outcome`. Mode token and
-  optional outcome field landed; overworld divert / seating / catch grant
-  follow in later waves.
-- **`coop_wild` battle mode** on the wire (`Wire.BATTLE_MODES` /
-  sanitize twin) and in `Config.MEDIATED_COOP`: two humans vs one wild NPC
-  seat (catch/run legal).
-- **Optional `catcher` on `mmo.battle_outcome`.** Present-and-bad refuses the
-  whole outcome (same posture as winners/losers); absent stays fine for
-  solo wild / KO paths.
+- **PROTOCOL 18 — Party vs Wild (`coop_wild`).** `Config.PROTOCOL` / `relay.js`
+  bump **17 → 18**. New mediated mode: two partied humans vs one wild NPC
+  seat. When partners share a map, a grass encounter auto-opens the fight
+  with no invite UI (partner auto-joins); otherwise solo wild stays on the
+  local engine. Balls are legal; throws resolve in active-mon speed order
+  before moves; first success ends the fight and `catcher` on
+  `mmo.battle_outcome` names who keeps the mon. Either player may RUN
+  without partner consent. Hubs refuse opens that are not exactly two
+  humans; settle fans out `catcher` with `caught`.
 - **Friends hold keys use `Wire.nameKey` / relay `nameKey`, not `Rank.keyOf`.** PROTOCOL 16 made `Rank.keyOf` playerId-only; friendships stay trainer-name pairs, so the merge wires friend routing through the name fold.
 - **Friends (from main) under PROTOCOL 17.** Parallel main shipped friends as PROTOCOL 10 while this line claimed 10–16 for mediated battles + playerId; the merge keeps both feature sets and bumps `Config.PROTOCOL` / `relay.js` to **17** so a protocol-16 hub cannot silently ignore `mmo.friend_*`. Lists stay client-side (`src/Friends.lua`); the hub only holds offline asks.
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,6 +10,7 @@ Working notes for features that were (or are being) implemented in this repo.
 | Plan | Notes |
 | --- | --- |
 | [`party-wild-encounter.md`](party-wild-encounter.md) | Party vs Wild (`coop_wild`) — in progress |
+| [`coop-battle-intro-anims.md`](coop-battle-intro-anims.md) | CoopBattle intro balls + sequential Go!/POOF — implemented |
 | [`guild-focus-battle-ui.md`](guild-focus-battle-ui.md) | CoopBattle focus stage + side strips |
 | [`hub-twin-parity.md`](hub-twin-parity.md) | Hub.lua ↔ relay.js drift process + carve-outs |
 | [`battle-sim-move-effects.md`](battle-sim-move-effects.md) | Complete; locked BattleSim decisions |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -9,6 +9,7 @@ Working notes for features that were (or are being) implemented in this repo.
 
 | Plan | Notes |
 | --- | --- |
+| [`party-wild-encounter.md`](party-wild-encounter.md) | Party vs Wild (`coop_wild`) — in progress |
 | [`guild-focus-battle-ui.md`](guild-focus-battle-ui.md) | CoopBattle focus stage + side strips |
 | [`hub-twin-parity.md`](hub-twin-parity.md) | Hub.lua ↔ relay.js drift process + carve-outs |
 | [`battle-sim-move-effects.md`](battle-sim-move-effects.md) | Complete; locked BattleSim decisions |

--- a/docs/plans/coop-battle-intro-anims.md
+++ b/docs/plans/coop-battle-intro-anims.md
@@ -1,0 +1,94 @@
+# Plan — CoopBattle intro anims (balls + sequential Go! / POOF)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-11 |
+| Source | `/implement` after catch-path e2e; missing intro vs solo wild |
+| Config | AGENTS_CONFIG.yml (quality/v3, host=cursor) |
+| Branch | `fix/party-wild-encounter` |
+| Base SHA | 243ee6de38b63bddeb745c10a9a12c85a4202962 (dirty tree: ball-chain + catch e2e already present) |
+
+## 1. Objective & success criteria
+
+Bring CoopBattle openings closer to Gen1 wild/trainer feel **without** silhouette slide or trainer-back walk-off:
+
+1. **Intro ball chrome** for **both** humans’ parties while the opening line is up, then clear.
+2. **Sequential ally send-out:** local `"Go! X!"` → `POOF_ANIM` + `Ball_Poof` → grow-in + entrance cry; then partner `"Name sent out Y!"` → same POOF/grow/cry.
+3. **`Ball_Poof` SFX** on every `POOF_ANIM` (intro **and** catch chain).
+4. Applies to **all CoopBattle modes** (`coop_wild`, `coop_npc`, party-vs-party, etc.) — not MediatedBattle 1v1.
+
+**Done when:** headless tests assert ordered intro lines + POOF for `coop_wild` and one non-wild mode; `startAnim` plays `Ball_Poof`; party-wild e2e still reaches command menu (longer intro dwell OK); no PROTOCOL bump.
+
+## 2. Context & constraints
+
+- Solo engine sequence (BattleState): slide → appear + **local** balls → clear → gap → back off → Go! → POOF/`Ball_Poof` → grow-in + cry. Wild foe is already on field (no enemy ball send-out).
+- Coop today: music + one line (`Wild X appeared!` / `2 on 2 battle!`) → choose. Mons already full-size from `CoopSim:sendOut` at construct.
+- Catch toss/shake already uncommitted on this branch — intro work must not break `_emitBallChain` / `medBall` / `foePicHidden`.
+- Guild-focus layout stays; intro must not invent a second stage system.
+- Owner decisions (Phase 2): **all modes**; **both allies sequential**; **skip introSlide/back**; **both parties’ ball chrome**.
+
+## 3. Approach & key decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Scope | All `CoopBattle` modes | Owner |
+| Slide / trainer-back | **Skip** | Owner C; avoids fighting 2-ally layout |
+| Ball chrome | Both humans’ parties | Owner B — two rows (or one row each side) under appear text |
+| Go! | Local then partner `"sent out"` | Owner B; matches Mediated mid-send split |
+| Grow-in | Hide ally pics until their send-out step (`sendingOut` / per-slot flag), then scale 0→full over ~12f | Otherwise full-size mons flash under the appear line |
+| Foe intro | No trainer/enemy ball send-out in this pass | Wild foe already visible; trainer foe chrome deferred |
+| MediatedBattle | Out of scope | Owner: CoopBattle only |
+| SFX | Load `Sound` in `loadEngine`; `Ball_Poof` on `POOF_ANIM` in `startAnim` | Shared with catch |
+| Queue | Local cinematic in `enter()` via existing messages/anim/`act`-like rows **before** `after=choose`; do not wait on hub `send` | Intro is presentation, seats already exist |
+| Timing | Approximate engine: short gap (~40f) between appear dismiss and first Go!; POOF uses AnimPlayer | Exact 72f slide unused |
+
+**Opening copy (unchanged):**
+- `coop_wild` → `Wild %s\nappeared!`
+- else → `2 on 2 battle!`
+
+## 4. Work breakdown — implementation
+
+### T1 — Sound + Ball_Poof on POOF
+- **Owns:** `src/CoopBattle.lua` (`loadEngine`, `startAnim` only for SFX hook)
+- **Does:** grab `Sound`; on `POOF_ANIM`, `pcall(Sound.play, data, "Ball_Poof")` (nil-safe headless).
+- **Accept:** catch and intro POOFs both attempt SFX; no throw without Sound.
+
+### T2 — Intro state + ball chrome draw
+- **Owns:** `src/CoopBattle.lua` (flags, `draw` / HUD path for balls)
+- **Does:** `introBalls` (or equivalent) true for opening line; draw **two** player ball rows (local + partner party HP/alive counts via HudTiles / engine ball-row helper if exposable, else minimal replicate); clear when appear text advances.
+- **Accept:** chrome visible only during opening message; cleared before Go!.
+
+### T3 — Sequential Go! / POOF / grow-in queue
+- **Owns:** `src/CoopBattle.lua` (`enter`, message/`act` queue, draw gates for `sendingOut` / `growIn`)
+- **Does:** After appear + clear balls: wait → local Go! → queue `POOF_ANIM` → grow-in + cry for **mine**; then partner line → POOF → grow-in + cry for partner seat; hide those ally sprites until their step; then `after=choose`.
+- **Accept:** order stable; partner line uses roster name; single-human edge (if any) skips partner step; `coop_wild` foe never gets a send-out POOF from intro.
+
+**Wave note:** T1–T3 all touch `CoopBattle.lua` → **one sequential wave** (single builder agent), not three parallel agents.
+
+## 5. Work breakdown — tests
+
+### TT1 — Unit / headless
+- **Owns:** `tests/rby_mmo_test.lua` and/or `tests/coop_mediated.lua`
+- **Does:** Construct CoopBattle `coop_wild` + one non-wild mode; stub Sound; drain update until `choose`; assert message order (`Wild…`/`2 on 2` → `Go!` → partner `sent out`); assert a `POOF_ANIM` was started; stub records `Ball_Poof`.
+- **E2e:** existing `run-party-wild-e2e.sh` — no new driver required; may need slightly longer patience to command menu. Assert e2e still green (optional log that intro reached Go! if easy).
+
+E2e applies: party-wild already exercises CoopBattle open; re-run after impl.
+
+## 6. Execution waves
+
+1. **Wave A:** T1+T2+T3 in one agent (single-file ownership).
+2. **Wave B:** TT1 tests + re-run unit suite + party-wild e2e.
+
+## 7. Blast radius & risks
+
+- Longer intro delays first choice — e2e/command-menu waits must tolerate dwell.
+- Both-party ball chrome on guild-focus layout may need compact placement; prefer classic bottom-box adjacent positions.
+- Grow-in hide must not blank partner forever if intro interrupted (forfeit / disconnect) — clear flags on `exit` / `over`.
+- Do not emit new wire events; intro is client-local (both clients run the same local cinematic from their seat view — each client’s “local” is themselves, so each hears their own Go! first). **Clarify:** each client runs intro from **viewer** perspective: my Go! then partner sent-out. That keeps asymmetry correct without hub sync.
+
+## 8. Open questions / assumptions
+
+- **Assumed:** “Both parties” chrome = two Gen1-style ball icon rows (local + partner), not foe trainer balls.
+- **Assumed:** Non-wild modes keep `"2 on 2 battle!"` as the appear line (no trainer theatrical frame this pass).
+- **Assumed:** Grow-in scale can approximate engine 0 / 3/7 / 5/7 over ~12 frames without pixel-perfect feet pin.
+- **Deferred:** `introSlide`, trainer-back, MediatedBattle wild parity, foe trainer send-out grow-in.

--- a/docs/plans/party-wild-encounter.md
+++ b/docs/plans/party-wild-encounter.md
@@ -1,0 +1,200 @@
+# Plan — Party vs Wild (`coop_wild`)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-10 |
+| Source | `/implement` conversation — Party vs Wild (auto-join, ordered balls) |
+| Config | AGENTS_CONFIG.yml (quality / v3, host=cursor) |
+| Branch | `fix/party-wild-encounter` |
+| Base SHA | `f9934515733c5eea936a517277b613b1205f071a` (tree had plan docs only before Wave 1) |
+
+## 1. Objective & success criteria
+
+Add a fifth mediated battle mode, **`coop_wild`**: two partied humans vs **one** wild mon.
+
+Success when all of the following hold:
+
+1. **Divert only when partied + partner online on the same map.** Otherwise the grass encounter stays on the **local engine** (solo wild contract unchanged).
+2. **No invite / WAIT / ALONE.** The player who steps the encounter tile is host, uploads the wild sheet, and the partner is **auto-pulled** into the mediated fight immediately.
+3. **Catch is legal** (unlike `coop_npc` / `coop_pvp`). Both players may choose a ball; a ball choice is the whole turn (no attack the same turn). Balls resolve **before** moves; among ball choices, order is **active-mon speed** (same tie policy as fight speed). First successful catch ends the turn/fight; later balls are not resolved.
+4. **Whoever’s ball succeeds keeps the mon.** Outcome attributes a catcher; that client grants into their party. Only one catch can succeed (one wild).
+5. **RUN:** either player can flee and end the battle (solo-wild semantics — no mutual consent).
+6. **PROTOCOL bump** so older hubs refuse the new mode instead of silent-dropping.
+7. **Tests:** Lua BattleSim + hub + Node twins/parity, plus an **e2e** driver path covering auto-join Party vs Wild.
+
+## 2. Context & constraints
+
+### Ground truth (Phase 1)
+
+- Wire modes today: `1v1`, `coop_npc`, `coop_pvp`, `wild` — `Wire.BATTLE_MODES` (`src/Wire.lua` ~1679), mirrored in sanitize / BattleSim `Turn.MODES`.
+- Solo `wild` is **protocol-only** (`Sessions:beginWildMediated`, Hub comments ~1252–1285): catch works in sim/tests; **no overworld divert**; **no production caller**.
+- Party trainer divert is `screen.pushed` → `kind == "trainer"` → `Coop:onTrainerBattle` (`src/Client.lua` ~2008–2019, `src/Coop.lua` ~508+). Wild is never diverted; partner only gets `mmo.party_event` narration for solo grass.
+- Coop battles are always mediated (`Config.MEDIATED_COOP = { coop_pvp, coop_npc }`). Balls fail outside wild modes via `Effects.isWildMode` (substring `"wild"`) — a mode named `coop_wild` already satisfies that check.
+- Turn phases: `runs → switches → items → fights` (`Turn.lua` ~1324–1327). Item phase walks **fighter array order**, not speed. Fight phase sorts by speed. Ball XOR fight is already one choice/seat.
+- Catch grant lives only on `MediatedBattle:grantCatch` (local `wildCatchMon`); `CoopBattle` `MED_REASONS` omits `catch`. Outcome winners = whole catching side, not thrower.
+- Historical plans marked solo wild out of scope for the intermediator product path; **Party vs Wild was never planned** — greenfield.
+
+### Locked owner decisions (Phase 2)
+
+| # | Decision |
+| --- | --- |
+| Field | 2 humans vs **1** wild |
+| Catch attempts | Both may throw; **one** successful catch |
+| Ownership | **(a)** whoever’s ball succeeded |
+| Same-turn balls | Speed order; **first success ends**; later ball never resolved |
+| Partner off-map / offline | **Solo engine wild** |
+| Host | Encounter stepper; uploads wild sheet; partner **auto-pulled, no prompt** |
+| RUN | Either can flee and end it |
+| Mode name | **`coop_wild`** |
+| Solo overworld | Stays on local engine; divert only partied + same map |
+| Acceptance | Unit/hub/parity **and e2e** |
+
+### Assumptions (not re-asked)
+
+- **PROTOCOL → 18** (new mode in closed `BATTLE_MODES`; older hubs must refuse).
+- Ball order key = **active mon speed** (+ existing fight tie-break), not move priority (BattleSim fights ignore move priority today).
+- Each player spends **their own** bag balls (existing per-seat bag sheets).
+- Ranking: treat like a non-ranked wild / mirror how solo mediated wild / coop_npc non-rank paths behave — no new ranked ladder for catching wildlife unless an existing path already scores wild (it does not).
+- Displace the engine wild screen the same family of way trainer divert freezes/replaces the stack once the mediated fight is ready (no WAIT menu).
+
+## 3. Approach & key decisions
+
+**New mode `coop_wild`**, not stretching `wild` or `coop_npc`.
+
+| Concern | Choice | Why |
+| --- | --- | --- |
+| Seating | Side `a` = 2 memberIds; side `b` = **one** NPC seat | Matches 2v1; `wild` caps `perSide=1`; `coop_npc` uses two NPC seats |
+| Catch legality | Rely on `isWildMode` substring + explicit mode in `MODES` | Avoid special-casing trainer coop |
+| Item order | Sort **ball** item choices by active speed before resolving; non-ball items keep array order (or follow same sort if cheap) | Owner: “who would attack first” |
+| Catcher | Add optional `catcher` (player id) on `mmo.battle_outcome` when `reason=catch` | Grant must not go to the whole side |
+| Grant | Shared helper used by CoopBattle (and MediatedBattle if trivial); both clients stash a grantable wild mon / use `caught` sheet with engine rebuild | Partner did not own the engine encounter mon |
+| Start path | New `Coop:onWildEncounter` (name TBD) from `screen.pushed` kind `wild`; auto-open hub battle; no invite wire | Distinct from WAIT/JOIN trainer flow |
+| RUN | Direct `action=run` like solo wild; no `run_ask` | Owner decision |
+| Solo `wild` mode | Leave as protocol/test stub | Owner: no product divert for solo |
+
+Alternatives rejected:
+
+- Reuse `coop_npc` + allow balls — wrong seating (2 NPC) and pollutes trainer rules.
+- Stretch `wild` to 2 humans — breaks `perSide=1` assumptions and hub comments; naming would confuse solo stub.
+- WAIT/ALONE for grass — owner forbade invite UX.
+
+## 4. Work breakdown — implementation tasks
+
+### T1 — Wire vocabulary + PROTOCOL 18
+**Owns:** `src/Wire.lua`, `src/Config.lua` (PROTOCOL + comment + `MEDIATED_COOP`), `server/lib/sanitize.js`, `CHANGELOG.md` (Unreleased notes), `manifest.json` / `mod.card` protocol note if they cite PROTOCOL, `server/twin_parity.test.js` (constant lists only if asserted).
+**Does:** Add `coop_wild` to `BATTLE_MODES`; optional outcome field `catcher` (clean via `Wire.id`); bump PROTOCOL 17→18 both sides’ comment blocks; add `coop_wild` to `Config.MEDIATED_COOP`.
+**Deps:** none.
+**Accept:** sanitize accepts/rejects correctly; twin constant parity green for mode set.
+
+### T2 — Hub seating twins
+**Owns:** `src/Hub.lua` (`openMediatedBattle` + any open helpers), `server/lib/relay.js` (same), tiny touch to `tests/fixtures/hub_protocol_parity.json` **only if** regenerating is required by this task’s open path (else leave for test wave).
+**Does:** For `coop_wild`: one NPC id; sides `{ a = memberIds (2), b = npcIds (1) }`; host uploads side `"b"` wild party (same upload path as wild/coop_npc host). Refuse open if ≠2 humans when mode is coop_wild (or document host+partner membership from party).
+**Deps:** T1 (mode token exists).
+**Accept:** hub/relay open record shape matches; existing wild/coop_npc paths unchanged.
+
+### T3 — BattleSim item/ball order + roster
+**Owns:** `src/BattleSim/Turn.lua`, `server/lib/battle/Turn.js` (and `MODES` / `perSide` only).
+**Does:**
+- Register `coop_wild` in `MODES`.
+- `perSide`: side `a` allows 2, side `b` allows 1 (or mode-specific caps — do not force 2v2).
+- `_resolveItems`: collect ball choices, sort by active-mon speed (+ fight-equivalent tie-break), resolve in that order; abort when `self.result` set (already); on catch, set `finish.catcher = fighter.playerId` (or equivalent) before/with `_finish`.
+- Non-wild modes unchanged; solo `wild` still 1v1 seating.
+**Deps:** T1 for outcome catcher if sanitizer must allow the field through hub fan-out (hub may pass result opaque — confirm; if outcome is built in sim and sanitized on send, T1 must land first).
+**Accept:** two humans both `item`+ball → faster mon’s ball resolves first; success stops second; bag spend only for resolved throws that entered resolve (failed shake still spends — existing rule).
+
+### T4 — Overworld divert + auto-pull (no invite)
+**Owns:** `src/Client.lua` (event wiring), `src/Coop.lua` (wild start / auto membership / busy gates).
+**Does:**
+- On `screen.pushed` with `state.kind == "wild"`: if transport ready, local player has a party partner **online and same map**, divert into mediated `coop_wild` (host = local stepper). Else no-op (engine wild proceeds).
+- Open hub battle with `memberIds = { self, partner }`, `mode = coop_wild`, host = stepper.
+- Partner client: on `mmo.coop_battle` / battle open for `coop_wild`, enter `CoopBattle` **without** confirm UI; displace any conflicting overworld state safely.
+- Do **not** use `mmo.coop_wait` / join invite path.
+- Offline / other-map partner → leave engine wild alone (already gated).
+**Deps:** T2 (hub can open), T5 for screen class behavior ideally same wave barrier after T5 starts — prefer T5 before or with careful stubs; **wave order: T5 then T4** if CoopBattle must already understand the mode.
+**Accept:** headless/unit hooks prove divert predicate; no invite messages on the wire for this path.
+
+### T5 — CoopBattle wild UX / catch grant / run
+**Owns:** `src/CoopBattle.lua`, small shared grant helper if extracted (`src/MediatedBattle.lua` only if sharing `grantCatch` without widening ownership — prefer extract to a tiny module **or** duplicate minimal grant in CoopBattle to keep file ownership clean; choose extract `src/CatchGrant.lua` only if both need edits — default: implement grant on CoopBattle + optional thin call from MediatedBattle in a follow-up only if needed).
+**Does:**
+- Treat `coop_wild` as mediated (already via Config once T1 lands).
+- Host uploads wild party sheets to side `b` (from frozen engine encounter mon / snapshot).
+- Both clients stash grant material (`wildCatchMon` or rebuild-from-sheet).
+- On outcome `reason=catch`: only `catcher` id grants; others see Gotcha narration without adding a mon.
+- RUN: no `run_ask`; commit `action=run` like wild.
+- `MED_REASONS` / result copy for catch; balls offered in item menu (already) now succeed in sim.
+**Deps:** T1–T3.
+**Accept:** catcher-only grant; partner flee ends fight for both.
+
+### T6 — Docs index
+**Owns:** `docs/plans/README.md` (add this plan under Living).
+**Deps:** none (can land anytime).
+**Accept:** linked from README Living table.
+
+## 5. Work breakdown — test tasks
+
+### TT1 — BattleSim / turn parity
+**Owns:** `tests/battle_sim_turn.lua`, `tests/drivers/battle_turn_parity.lua` fixtures as needed, `server/battle_turn.test.js`.
+**Covers:** T3 — dual ball speed order; first catch wins; ball before move; balls legal in `coop_wild`; still illegal in `coop_npc`.
+**E2E?** no.
+
+### TT2 — Hub open + choice path
+**Owns:** `tests/hub_battle.lua`, `server/hub_battle.test.js`, regenerate `tests/fixtures/hub_protocol_parity.json` if open/catcher paths are in the parity driver (`tests/drivers/hub_protocol_parity.lua` + Node twin).
+**Covers:** T2 — `coop_wild` seating (2 humans, 1 npc); catcher on outcome; PROTOCOL 18 handshake refusal sketch if present in suite.
+**E2E?** no.
+
+### TT3 — Coop divert / CoopBattle unit
+**Owns:** `tests/coop_mediated.lua` and/or `tests/rby_mmo_test.lua` sections for wild divert predicate + catch grant + run-without-consent.
+**Covers:** T4–T5.
+**E2E?** no.
+
+### TT4 — E2E Party vs Wild
+**Owns:** `tests/drivers/run-mmo-e2e.sh` **or** new `tests/drivers/run-party-wild-e2e.sh` + `tests/drivers/mmo_util.lua` barriers/tappers; prefer **dedicated script** mirroring `run-invite-refuse-e2e.sh` pattern so LAN coop trainer e2e stays stable.
+**Covers:** two LOVE clients, party formed, same map, force/trigger wild encounter on host, assert hub log `coop_wild` started, both in battle, optional ball/catch or run end.
+**Run recipe (from Phase 1):**
+- Engine: `~/Projects/alamops/gen1recomp`, mod symlinked `mods/rby_mmo`.
+- ROM imported via `scripts/setup.sh --rom "…"`.
+- `bash mods/rby_mmo/tests/drivers/run-party-wild-e2e.sh` (name TBD) with `love` on PATH.
+- Hub may be in-game Hub.lua (LAN) or Node — match whichever sibling e2e is closest; document in script header.
+**E2E?** **yes — required for v1.**
+
+## 6. Execution waves
+
+| Wave | Tasks | Barrier |
+| --- | --- | --- |
+| 1 | **T1** ‖ **T6** | Vocabulary + docs index |
+| 2 | **T2** ‖ **T3** | Hub seating + sim (disjoint files) |
+| 3 | **T5** | CoopBattle understands mode/catch/run |
+| 4 | **T4** | Divert wires into T5 screen |
+| 5 | **TT1** ‖ **TT2** ‖ **TT3** | Unit/hub tests |
+| 6 | **TT4** | E2E last (needs full stack) |
+
+Checkpoint commit after each wave (`wave N: …`).
+
+## 7. Blast radius & risks
+
+| Risk | Mitigation |
+| --- | --- |
+| PROTOCOL 18 breaks mixed-version parties | Intentional refuse with version sentence; document in CHANGELOG |
+| Partner auto-pulled while in a menu / movement | Reuse busy/in-battle gates; if partner is mid-trainer, do not divert host (predicate: partner free + same map) — **assumption:** if partner busy, host falls back to **solo engine wild** |
+| Engine wild already dealing damage under frozen stack | Divert immediately on push (same as trainer prompt-on-top timing); replace/pop engine battle when mediated ready |
+| Grant without engine mon on partner | Stash sheets at battle start; test sheet→party path |
+| `isWildMode` false positive on future names | Accept for `coop_wild`; don’t name trainer modes `*wild*` |
+| Twin drift Hub.lua ↔ relay.js | Same task owns both; parity tests |
+| E2E flaky grass RNG | Driver forces encounter via existing tap/debug hooks if any; else map with high rate + retry budget — spike in TT4 if no force seam |
+
+Rollback: revert PROTOCOL bump + mode; solo engine path remains default.
+
+## 8. Open questions / assumptions
+
+Resolved in Phase 2 — see §2 table.
+
+Remaining soft assumptions (owner deferred by silence / “correct”):
+
+1. If partner is **same map but busy** (menu, other battle), treat as “not available” → **solo engine wild** for the stepper.
+2. Non-ball items in `coop_wild` keep Gen1 wild rules (doll flees, etc.) via existing `isWildMode` branches.
+3. No ranked rating movement on `coop_wild` catch/run/ko.
+4. E2e may be LAN in-game hub first; dedicated Node hub optional if timeboxed.
+
+---
+
+**Approval gate:** please confirm this plan (or note edits). No production code until you approve.

--- a/mod.card
+++ b/mod.card
@@ -265,7 +265,7 @@ return {
         .. "HOOD in their catalog, so somebody wearing one shows up as RED "
         .. "on their screen -- the same fallback a character their ROM does "
         .. "not carry already gets.",
-      "The protocol is exact-match: this release speaks PROTOCOL 16. An older "
+      "The protocol is exact-match: this release speaks PROTOCOL 18. An older "
         .. "mod or hub is refused at the door with a sentence that names both "
         .. "versions rather than connecting and going quiet. The mod and its "
         .. "hub have to be updated together; there is no degraded mode that "

--- a/server/hub_battle.test.js
+++ b/server/hub_battle.test.js
@@ -363,6 +363,114 @@ function testTradeRelayStillWorks() {
     'trade mmo.relay still forwards unread');
 }
 
+function testCoopWildSeating() {
+  const clock = makeClock();
+  const relay = makeRelay(clock);
+  const a = dial(relay, 'CWILDA');
+  const b = dial(relay, 'CWILDB');
+
+  const record = relay.openMediatedBattle('cw-1', {
+    mode: 'coop_wild',
+    hostId: a.id,
+    memberIds: [a.id, b.id],
+  });
+  ok(record && record.npcIds.length === 1,
+    'coop_wild opens with one synthetic wild seat');
+  ok(record.sides.a.length === 2 && record.sides.b.length === 1,
+    'side a is two humans and side b is the wild seat');
+  ok(record.sides.b[0] === record.npcIds[0],
+    'side b names the wild seat');
+  ok(relay.battleSeat(record, relay.get(a.id), { side: 'b' }) === record.npcIds[0],
+    "the host's side-b upload fills the wild seat");
+
+  const solo = relay.openMediatedBattle('cw-2', {
+    mode: 'coop_wild',
+    hostId: a.id,
+    memberIds: [a.id],
+  });
+  ok(solo === null, 'coop_wild refuses without exactly two humans');
+
+  const c = dial(relay, 'CWILDC');
+  const crowd = relay.openMediatedBattle('cw-3', {
+    mode: 'coop_wild',
+    hostId: a.id,
+    memberIds: [a.id, b.id, c.id],
+  });
+  ok(crowd === null, 'coop_wild refuses with three humans');
+}
+
+function testCoopWildCatchCatcher() {
+  const clock = makeClock();
+  const relay = makeRelay(clock);
+  const a = dial(relay, 'CATCHA');
+  const b = dial(relay, 'CATCHB');
+  relay.openCoopBattle('cw-catch', [a.id, b.id],
+    { mode: 'coop_wild', hostId: a.id });
+  const record = relay.battles.get('cw-catch');
+  a.peer.outbox = [];
+  b.peer.outbox = [];
+
+  relay.handle(a.id, { type: 'mmo.battle_ruleset', chart: [[100]] });
+  relay.handle(a.id, {
+    type: 'mmo.battle_party',
+    battle: 'cw-catch',
+    side: 'a',
+    mons: [mon(90)],
+    bag: [{ id: 'MASTER_BALL', count: 1 }],
+  });
+  relay.handle(b.id, {
+    type: 'mmo.battle_party',
+    battle: 'cw-catch',
+    side: 'a',
+    mons: [mon(90)],
+  });
+  relay.handle(a.id, {
+    type: 'mmo.battle_party',
+    battle: 'cw-catch',
+    side: 'b',
+    mons: [{
+      species: 'PIDGEY',
+      level: 50,
+      hp: 100,
+      maxHp: 100,
+      catchRate: 255,
+      stats: { atk: 40, def: 40, spd: 40, spc: 40 },
+      moves: [{
+        id: 'm1', pp: 15, power: 0, accuracy: 255, type: 0, effect: 0, chance: 0,
+      }],
+    }],
+  });
+  ok(record && record.sim, 'coop_wild sim starts with two humans and a wild party');
+  take(a, 'mmo.battle_ready');
+  take(b, 'mmo.battle_ready');
+  a.peer.outbox = [];
+  b.peer.outbox = [];
+
+  let outcome = null;
+  for (let turn = 0; turn < 20; turn += 1) {
+    takeAll(a, 'mmo.battle_event');
+    takeAll(b, 'mmo.battle_event');
+    if (!relay.battles.has('cw-catch')) break;
+    relay.handle(a.id, {
+      type: 'mmo.battle_choice', battle: 'cw-catch',
+      action: 'item', item: 'MASTER_BALL',
+    });
+    relay.handle(b.id, {
+      type: 'mmo.battle_choice', battle: 'cw-catch',
+      action: 'fight', move: 0,
+    });
+    outcome = take(a, 'mmo.battle_outcome') || take(b, 'mmo.battle_outcome');
+    if (outcome) break;
+  }
+  ok(outcome && outcome.reason === 'catch',
+    'catch success reasons the outcome as catch');
+  ok(outcome.catcher === a.id, 'catcher names the thrower');
+  ok(take(a, 'mmo.battle_outcome') || take(b, 'mmo.battle_outcome'),
+    'both players hear the outcome');
+  ok(!relay.battles.has('cw-catch'),
+    'the record is cleared like any other settlement');
+}
+
 function testBagProofs() {
   const clock = makeClock();
   const relay = makeRelay(clock);
@@ -453,6 +561,8 @@ testRelayHardCutDuringBattle();
 testDisconnectForfeitAfterGrace();
 testDrawCarriesNoLists();
 testCoopNpcMediated();
+testCoopWildSeating();
+testCoopWildCatchCatcher();
 testTradeRelayStillWorks();
 testBagProofs();
 

--- a/server/lib/battle/Turn.js
+++ b/server/lib/battle/Turn.js
@@ -87,8 +87,20 @@ const RESOLVE_TIMEOUT = 30; // Config.BATTLE_RESOLVE_TIMEOUT
 // Below this the side-a member of a tied group moves first.
 const TIE_BREAK_ROLL = 128;
 
-const MODES = { '1v1': true, coop_npc: true, coop_pvp: true, wild: true };
+const MODES = {
+  '1v1': true, coop_npc: true, coop_pvp: true, wild: true, coop_wild: true,
+};
 const SIDES = ['a', 'b'];
+
+// Roster cap per side. coop_wild is 2v1 (humans on a, wild on b); other modes
+// keep a single per-side ceiling (1 for 1v1/wild, FIGHTERS_PER_SIDE otherwise).
+function maxFighters(mode, side) {
+  if (mode === 'coop_wild') {
+    return side === 'a' ? FIGHTERS_PER_SIDE : 1;
+  }
+  if (mode === '1v1' || mode === 'wild') return 1;
+  return FIGHTERS_PER_SIDE;
+}
 
 // Auto-pick priorities (twin of Turn.lua AUTO_* tables).
 const AUTO_STATUS_PRI = {
@@ -1353,276 +1365,46 @@ class Battle {
   }
 
   _resolveItems() {
+    // Non-ball items keep Gen1 array order (heals, dolls, vitamins, …). Balls
+    // resolve in a second pass ordered by active-mon speed (fight tie policy),
+    // so the faster thrower spends first and a successful catch aborts the rest.
     for (const fighter of this.fighters) {
       if (this.result) return;
       const choice = fighter.choice;
       if (choice && choice.action === 'item') {
         const effect = Effects.itemEffect(choice.item);
-        // Vitamins apply before the `item` event so `amount=1` can mean
-        // "Stat Exp writeback is owed"; a failed vitamin still spends the bag
-        // stack (Gen1) but must not bump save.statExp on the client.
-        let vitaminApplied = false;
-        let vitaminMon = null;
-        let vitaminResult = null;
-        if (effect && effect.vitamin) {
-          const partyIdx = choice.slot != null ? choice.slot : fighter.active;
-          const mon = monAt(fighter, partyIdx);
-          if (mon && mon.hp > 0) {
-            const result = Effects.applyVitamin(mon, choice.item);
-            if (result) {
-              vitaminApplied = true;
-              vitaminMon = mon;
-              vitaminResult = result;
-            }
-          }
-        }
-        const itemEv = {
-          slot: fighter.slot, side: fighter.side, text: choice.item,
-        };
-        if (vitaminApplied) itemEv.amount = 1;
-        this._emit('item', itemEv);
-        this._say(`${fighter.name} used an item`);
-        // Spend after the announce, win or fail (Gen1 bag stack). noConsume
-        // (Poké Flute) and seats with no bag sheet are left alone.
-        if (!(effect && effect.noConsume)) {
-          this._spendBag(fighter, choice.item);
-        }
-        if (!effect) {
-          this._say('But it failed');
-        } else if (effect.ball) {
-          if (!Effects.isWildMode(this.mode)) {
-            this._say('But it failed');
-          } else {
-            const foe = this._firstLivingFoe(fighter);
-            const target = foe && activeMon(foe);
-            if (!target) {
-              this._say('But it failed');
-            } else {
-              const result = Effects.catchAttempt(choice.item, target, this.rng);
-              if (result.shakes > 0 && !result.caught) this._say('The ball shook');
-              if (result.caught) {
-                this._say('Gotcha');
-                const finish = this._finish(
-                  'win',
-                  this._sidePlayers(fighter.side),
-                  this._sidePlayers(fighter.side === 'a' ? 'b' : 'a'),
-                  'catch',
-                );
-                const sheet = Effects.caughtSheet(target);
-                if (finish && sheet) finish.caught = sheet;
-              } else {
-                this._say('It broke free');
-              }
-            }
-          }
-        } else if (effect.pokeDoll) {
-          if (Effects.isWildMode(this.mode)) {
-            this._say('The wild pokemon ran away');
-            this._finish(
-              'win',
-              this._sidePlayers(fighter.side),
-              this._sidePlayers(fighter.side === 'a' ? 'b' : 'a'),
-              'run',
-            );
-          } else {
-            this._say('But it failed');
-          }
-        } else if (effect.vitamin) {
-          if (!vitaminApplied) {
-            this._say('But it failed');
-          } else {
-            const mon = vitaminMon;
-            const result = vitaminResult;
-            const label = ({
-              hp: 'HEALTH POINTS', atk: 'ATTACK', def: 'DEFENSE',
-              spd: 'SPEED', spc: 'SPECIAL',
-            })[result.stat] || 'STAT';
-            if (result.stat === 'hp' && result.delta > 0) {
-              this._emit('drain', {
-                slot: fighter.slot, side: fighter.side,
-                amount: result.delta, hp: mon.hp,
-              });
-            } else if (result.delta > 0) {
-              this._emit('stat', {
-                slot: fighter.slot, side: fighter.side,
-                amount: mon.stats[result.stat],
-                text: `${mon.species}'s ${label} rose`,
-              });
-            }
-            this._say(`${mon.species}'s ${label} rose`);
-          }
-        } else if (effect.pokeFlute) {
-          let woke = false;
-          for (const seat of this.fighters) {
-            for (const mon of seat.mons || []) {
-              if (mon && mon.status === 'sleep') {
-                mon.status = null;
-                mon.statusTurns = 0;
-                woke = true;
-                this._emit('status', {
-                  slot: seat.slot, side: seat.side,
-                  text: `${mon.species} woke up`,
-                });
-              }
-            }
-          }
-          if (woke) this._say('All sleeping POKeMON woke up');
-          else this._say("Now, that's a catchy tune");
-        } else {
-          const partyIdx = choice.slot != null ? choice.slot : fighter.active;
-          const mon = monAt(fighter, partyIdx);
-          if (!mon) {
-            this._say('But it failed');
-          } else if (effect.activeOnly && partyIdx !== fighter.active) {
-            this._say('But it failed');
-          } else if (effect.faintedOnly && mon.hp > 0) {
-            this._say('But it failed');
-          } else if (!effect.faintedOnly && mon.hp <= 0
-                     && (effect.heal || effect.healFull || effect.clearStatuses
-                         || effect.clearAllStatus || effect.ppRestore
-                         || effect.ppRestoreAll)) {
-            this._say('But it failed');
-          } else {
-            let applied = false;
-            if (effect.xAccuracy) {
-              mon.xAccuracy = true;
-              this._say(`${mon.species}'s hits will never miss`);
-              applied = true;
-            }
-            if (effect.focusEnergy) {
-              mon.focusEnergy = true;
-              this._say(`${mon.species} is getting pumped`);
-              applied = true;
-            }
-            if (effect.mist) {
-              mon.mist = true;
-              this._say(`${mon.species} is protected against stat changes`);
-              applied = true;
-            }
-            if (effect.stage) {
-              const stat = effect.stage.stat;
-              const before = Effects.clampStage(mon.stages[stat]);
-              if (before >= Effects.STAGE_MAX) {
-                this._say('Nothing happened');
-              } else {
-                const after = Effects.clampStage(before + int(effect.stage.delta, 1));
-                mon.stages[stat] = after;
-                const label = ({
-                  atk: 'ATTACK', def: 'DEFENSE', spd: 'SPEED',
-                  spc: 'SPECIAL', acc: 'ACCURACY', eva: 'EVASION',
-                })[stat] || 'STAT';
-                this._say(`${mon.species}'s ${label} rose`);
-                this._emit('stat', {
-                  slot: fighter.slot, side: fighter.side,
-                  amount: after, text: `${mon.species}'s ${label} rose`,
-                });
-              }
-              applied = true;
-            }
-            if (effect.revive) {
-              const amount = effect.revive;
-              const hp = amount === 1 ? mon.maxHp
-                : Math.max(1, Math.floor(mon.maxHp * amount));
-              mon.hp = hp;
-              mon.status = null;
-              mon.statusTurns = 0;
-              this._emit('drain', {
-                slot: fighter.slot, side: fighter.side,
-                amount: hp, hp: mon.hp,
-              });
-              this._say(`${mon.species} was revived`);
-              applied = true;
-            }
-            if (effect.ppRestore) {
-              const move = mon.moves[choice.move - 1];
-              if (!move) {
-                this._say('But it failed');
-              } else {
-                const maxPp = Math.max(int(move.maxPp, move.pp), move.pp);
-                const before = move.pp;
-                if (effect.ppRestore === true) move.pp = maxPp;
-                else move.pp = Math.min(maxPp, move.pp + int(effect.ppRestore, 0));
-                if (move.pp > before) {
-                  this._say(`${mon.species}'s PP was restored`);
-                  applied = true;
-                } else {
-                  this._say('But it failed');
-                }
-              }
-            }
-            if (effect.ppRestoreAll) {
-              let any = false;
-              for (const move of mon.moves || []) {
-                if (!move) continue;
-                const maxPp = Math.max(int(move.maxPp, move.pp), move.pp);
-                const before = move.pp;
-                if (effect.ppRestoreAll === true) move.pp = maxPp;
-                else move.pp = Math.min(maxPp, move.pp + int(effect.ppRestoreAll, 0));
-                if (move.pp > before) any = true;
-              }
-              if (any) {
-                this._say(`${mon.species}'s PP was restored`);
-                applied = true;
-              } else {
-                this._say('But it failed');
-              }
-            }
-            let healed = false;
-            if (effect.healFull) {
-              const before = mon.hp;
-              mon.hp = mon.maxHp;
-              if (mon.hp > before) {
-                this._emit('drain', {
-                  slot: fighter.slot, side: fighter.side,
-                  amount: mon.hp - before, hp: mon.hp,
-                });
-                healed = true;
-              }
-            } else if (effect.heal && effect.heal > 0 && mon.hp < mon.maxHp) {
-              this._heal(fighter, mon, effect.heal);
-              healed = true;
-            }
-            let cleared = false;
-            if (effect.clearAllStatus && mon.status) {
-              mon.status = null;
-              mon.statusTurns = 0;
-              cleared = true;
-            } else if (effect.clearStatuses && mon.status
-                       && effect.clearStatuses[mon.status]) {
-              mon.status = null;
-              mon.statusTurns = 0;
-              cleared = true;
-            }
-            if (cleared) {
-              this._emit('status', {
-                slot: fighter.slot, side: fighter.side,
-                text: `${mon.species} recovered`,
-              });
-            }
-            if (!applied && !healed && !cleared) {
-              this._say('But it failed');
-            }
-          }
+        if (!(effect && effect.ball)) {
+          this._resolveOneItem(fighter);
         }
       }
+    }
+
+    const balls = [];
+    for (const fighter of this.fighters) {
+      const choice = fighter.choice;
+      if (choice && choice.action === 'item') {
+        const effect = Effects.itemEffect(choice.item);
+        if (effect && effect.ball) {
+          const mon = activeMon(fighter);
+          balls.push({
+            fighter,
+            speed: mon ? this._speedOf(fighter, mon) : 0,
+            order: balls.length + 1,
+          });
+        }
+      }
+    }
+    this._sortActorsBySpeed(balls);
+    for (const actor of balls) {
+      if (this.result) return;
+      this._resolveOneItem(actor.fighter);
     }
   }
 
-  _resolveFights() {
-    const actors = [];
-    for (const fighter of this.fighters) {
-      const choice = fighter.choice;
-      const mon = activeMon(fighter);
-      if (choice && choice.action === 'fight' && mon) {
-        actors.push({
-          fighter,
-          mon, // pinned: see the skip in the loop
-          speed: this._speedOf(fighter, mon),
-          order: actors.length + 1,
-        });
-      }
-    }
-    if (actors.length === 0) return;
+  // Sort actors by active-mon speed (desc), then field order; tied groups flip
+  // on one RNG byte >= TIE_BREAK_ROLL. Shared by fights and ball throws.
+  _sortActorsBySpeed(actors) {
+    if (actors.length <= 1) return;
 
     actors.sort((x, y) => {
       if (x.speed !== y.speed) return y.speed - x.speed;
@@ -1645,6 +1427,279 @@ class Battle {
       }
       i = j + 1;
     }
+  }
+
+  _resolveOneItem(fighter) {
+    const choice = fighter.choice;
+    if (!(choice && choice.action === 'item')) return;
+
+    const effect = Effects.itemEffect(choice.item);
+    // Vitamins apply before the `item` event so `amount=1` can mean
+    // "Stat Exp writeback is owed"; a failed vitamin still spends the bag
+    // stack (Gen1) but must not bump save.statExp on the client.
+    let vitaminApplied = false;
+    let vitaminMon = null;
+    let vitaminResult = null;
+    if (effect && effect.vitamin) {
+      const partyIdx = choice.slot != null ? choice.slot : fighter.active;
+      const mon = monAt(fighter, partyIdx);
+      if (mon && mon.hp > 0) {
+        const result = Effects.applyVitamin(mon, choice.item);
+        if (result) {
+          vitaminApplied = true;
+          vitaminMon = mon;
+          vitaminResult = result;
+        }
+      }
+    }
+    const itemEv = {
+      slot: fighter.slot, side: fighter.side, text: choice.item,
+    };
+    if (vitaminApplied) itemEv.amount = 1;
+    this._emit('item', itemEv);
+    this._say(`${fighter.name} used an item`);
+    // Spend after the announce, win or fail (Gen1 bag stack). noConsume
+    // (Poké Flute) and seats with no bag sheet are left alone.
+    if (!(effect && effect.noConsume)) {
+      this._spendBag(fighter, choice.item);
+    }
+    if (!effect) {
+      this._say('But it failed');
+    } else if (effect.ball) {
+      if (!Effects.isWildMode(this.mode)) {
+        this._say('But it failed');
+      } else {
+        const foe = this._firstLivingFoe(fighter);
+        const target = foe && activeMon(foe);
+        if (!target) {
+          this._say('But it failed');
+        } else {
+          const result = Effects.catchAttempt(choice.item, target, this.rng);
+          if (result.shakes > 0 && !result.caught) this._say('The ball shook');
+          if (result.caught) {
+            this._say('Gotcha');
+            const finish = this._finish(
+              'win',
+              this._sidePlayers(fighter.side),
+              this._sidePlayers(fighter.side === 'a' ? 'b' : 'a'),
+              'catch',
+            );
+            const sheet = Effects.caughtSheet(target);
+            if (finish && sheet) finish.caught = sheet;
+            if (finish) finish.catcher = fighter.playerId;
+          } else {
+            this._say('It broke free');
+          }
+        }
+      }
+    } else if (effect.pokeDoll) {
+      if (Effects.isWildMode(this.mode)) {
+        this._say('The wild pokemon ran away');
+        this._finish(
+          'win',
+          this._sidePlayers(fighter.side),
+          this._sidePlayers(fighter.side === 'a' ? 'b' : 'a'),
+          'run',
+        );
+      } else {
+        this._say('But it failed');
+      }
+    } else if (effect.vitamin) {
+      if (!vitaminApplied) {
+        this._say('But it failed');
+      } else {
+        const mon = vitaminMon;
+        const result = vitaminResult;
+        const label = ({
+          hp: 'HEALTH POINTS', atk: 'ATTACK', def: 'DEFENSE',
+          spd: 'SPEED', spc: 'SPECIAL',
+        })[result.stat] || 'STAT';
+        if (result.stat === 'hp' && result.delta > 0) {
+          this._emit('drain', {
+            slot: fighter.slot, side: fighter.side,
+            amount: result.delta, hp: mon.hp,
+          });
+        } else if (result.delta > 0) {
+          this._emit('stat', {
+            slot: fighter.slot, side: fighter.side,
+            amount: mon.stats[result.stat],
+            text: `${mon.species}'s ${label} rose`,
+          });
+        }
+        this._say(`${mon.species}'s ${label} rose`);
+      }
+    } else if (effect.pokeFlute) {
+      let woke = false;
+      for (const seat of this.fighters) {
+        for (const mon of seat.mons || []) {
+          if (mon && mon.status === 'sleep') {
+            mon.status = null;
+            mon.statusTurns = 0;
+            woke = true;
+            this._emit('status', {
+              slot: seat.slot, side: seat.side,
+              text: `${mon.species} woke up`,
+            });
+          }
+        }
+      }
+      if (woke) this._say('All sleeping POKeMON woke up');
+      else this._say("Now, that's a catchy tune");
+    } else {
+      const partyIdx = choice.slot != null ? choice.slot : fighter.active;
+      const mon = monAt(fighter, partyIdx);
+      if (!mon) {
+        this._say('But it failed');
+      } else if (effect.activeOnly && partyIdx !== fighter.active) {
+        this._say('But it failed');
+      } else if (effect.faintedOnly && mon.hp > 0) {
+        this._say('But it failed');
+      } else if (!effect.faintedOnly && mon.hp <= 0
+                 && (effect.heal || effect.healFull || effect.clearStatuses
+                     || effect.clearAllStatus || effect.ppRestore
+                     || effect.ppRestoreAll)) {
+        this._say('But it failed');
+      } else {
+        let applied = false;
+        if (effect.xAccuracy) {
+          mon.xAccuracy = true;
+          this._say(`${mon.species}'s hits will never miss`);
+          applied = true;
+        }
+        if (effect.focusEnergy) {
+          mon.focusEnergy = true;
+          this._say(`${mon.species} is getting pumped`);
+          applied = true;
+        }
+        if (effect.mist) {
+          mon.mist = true;
+          this._say(`${mon.species} is protected against stat changes`);
+          applied = true;
+        }
+        if (effect.stage) {
+          const stat = effect.stage.stat;
+          const before = Effects.clampStage(mon.stages[stat]);
+          if (before >= Effects.STAGE_MAX) {
+            this._say('Nothing happened');
+          } else {
+            const after = Effects.clampStage(before + int(effect.stage.delta, 1));
+            mon.stages[stat] = after;
+            const label = ({
+              atk: 'ATTACK', def: 'DEFENSE', spd: 'SPEED',
+              spc: 'SPECIAL', acc: 'ACCURACY', eva: 'EVASION',
+            })[stat] || 'STAT';
+            this._say(`${mon.species}'s ${label} rose`);
+            this._emit('stat', {
+              slot: fighter.slot, side: fighter.side,
+              amount: after, text: `${mon.species}'s ${label} rose`,
+            });
+          }
+          applied = true;
+        }
+        if (effect.revive) {
+          const amount = effect.revive;
+          const hp = amount === 1 ? mon.maxHp
+            : Math.max(1, Math.floor(mon.maxHp * amount));
+          mon.hp = hp;
+          mon.status = null;
+          mon.statusTurns = 0;
+          this._emit('drain', {
+            slot: fighter.slot, side: fighter.side,
+            amount: hp, hp: mon.hp,
+          });
+          this._say(`${mon.species} was revived`);
+          applied = true;
+        }
+        if (effect.ppRestore) {
+          const move = mon.moves[choice.move - 1];
+          if (!move) {
+            this._say('But it failed');
+          } else {
+            const maxPp = Math.max(int(move.maxPp, move.pp), move.pp);
+            const before = move.pp;
+            if (effect.ppRestore === true) move.pp = maxPp;
+            else move.pp = Math.min(maxPp, move.pp + int(effect.ppRestore, 0));
+            if (move.pp > before) {
+              this._say(`${mon.species}'s PP was restored`);
+              applied = true;
+            } else {
+              this._say('But it failed');
+            }
+          }
+        }
+        if (effect.ppRestoreAll) {
+          let any = false;
+          for (const move of mon.moves || []) {
+            if (!move) continue;
+            const maxPp = Math.max(int(move.maxPp, move.pp), move.pp);
+            const before = move.pp;
+            if (effect.ppRestoreAll === true) move.pp = maxPp;
+            else move.pp = Math.min(maxPp, move.pp + int(effect.ppRestoreAll, 0));
+            if (move.pp > before) any = true;
+          }
+          if (any) {
+            this._say(`${mon.species}'s PP was restored`);
+            applied = true;
+          } else {
+            this._say('But it failed');
+          }
+        }
+        let healed = false;
+        if (effect.healFull) {
+          const before = mon.hp;
+          mon.hp = mon.maxHp;
+          if (mon.hp > before) {
+            this._emit('drain', {
+              slot: fighter.slot, side: fighter.side,
+              amount: mon.hp - before, hp: mon.hp,
+            });
+            healed = true;
+          }
+        } else if (effect.heal && effect.heal > 0 && mon.hp < mon.maxHp) {
+          this._heal(fighter, mon, effect.heal);
+          healed = true;
+        }
+        let cleared = false;
+        if (effect.clearAllStatus && mon.status) {
+          mon.status = null;
+          mon.statusTurns = 0;
+          cleared = true;
+        } else if (effect.clearStatuses && mon.status
+                   && effect.clearStatuses[mon.status]) {
+          mon.status = null;
+          mon.statusTurns = 0;
+          cleared = true;
+        }
+        if (cleared) {
+          this._emit('status', {
+            slot: fighter.slot, side: fighter.side,
+            text: `${mon.species} recovered`,
+          });
+        }
+        if (!applied && !healed && !cleared) {
+          this._say('But it failed');
+        }
+      }
+    }
+  }
+
+  _resolveFights() {
+    const actors = [];
+    for (const fighter of this.fighters) {
+      const choice = fighter.choice;
+      const mon = activeMon(fighter);
+      if (choice && choice.action === 'fight' && mon) {
+        actors.push({
+          fighter,
+          mon, // pinned: see the skip in the loop
+          speed: this._speedOf(fighter, mon),
+          order: actors.length + 1,
+        });
+      }
+    }
+    if (actors.length === 0) return;
+
+    this._sortActorsBySpeed(actors);
 
     for (const actor of actors) {
       if (this.result) break;
@@ -2554,13 +2609,13 @@ function attempt(opts) {
   if (!isTable(opts)) return refuse('battle needs an options table');
 
   const self = new Battle(opts);
-  const perSide = (self.mode === '1v1' || self.mode === 'wild') ? 1 : FIGHTERS_PER_SIDE;
 
   const sides = isTable(opts.sides) ? opts.sides : {};
   for (const side of SIDES) {
     const roster = Array.isArray(sides[side]) ? sides[side] : [];
     if (roster.length === 0) return refuse(`side ${side} has nobody on it`);
-    if (roster.length > perSide) {
+    const sideMax = maxFighters(self.mode, side);
+    if (roster.length > sideMax) {
       return refuse(`side ${side} has more fighters than ${self.mode} allows`);
     }
     for (let index = 1; index <= roster.length; index += 1) {

--- a/server/lib/battle/Turn.js
+++ b/server/lib/battle/Turn.js
@@ -1475,6 +1475,8 @@ class Battle {
           this._say('But it failed');
         } else {
           const result = Effects.catchAttempt(choice.item, target, this.rng);
+          // Gen1 TossBallAnimation chain before the catch text (engine ballChain).
+          this._emitBallChain(fighter, choice.item, result.caught, result.shakes);
           if (result.shakes > 0 && !result.caught) this._say('The ball shook');
           if (result.caught) {
             this._say('Gotcha');
@@ -1680,6 +1682,30 @@ class Battle {
           this._say('But it failed');
         }
       }
+    }
+  }
+
+  // Gen1 TossBallAnimation event stream (mirror BattleState:ballChain / tossAnimFor).
+  // Clients pair AnimPlayer opts.ball from the preceding `item` event's text.
+  _emitBallChain(fighter, ballId, caught, shakes) {
+    const slot = fighter.slot;
+    const side = fighter.side;
+    const toss = ballId === 'POKE_BALL' ? 'TOSS_ANIM'
+      : ballId === 'GREAT_BALL' ? 'GREATTOSS_ANIM'
+      : 'ULTRATOSS_ANIM';
+    const anim = (text, amount) => {
+      const fields = { slot, side, text };
+      if (amount !== undefined) fields.amount = amount;
+      this._emit('anim', fields);
+    };
+    anim(toss);
+    anim('POOF_ANIM');
+    if (!caught && !(shakes > 0)) return;
+    anim('HIDEPIC_ANIM');
+    anim('SHAKE_ANIM', shakes || 0);
+    if (!caught) {
+      anim('POOF_ANIM');
+      anim('SHOWPIC_ANIM');
     }
   }
 

--- a/server/lib/battle/events.js
+++ b/server/lib/battle/events.js
@@ -98,7 +98,8 @@ const FIELDS = {
 //     `text` carries the sentence either way.
 const SHAPES = {
   msg: { text: true },
-  anim: { slot: true, side: true, text: "the move's id" },
+  anim: { slot: true, side: true, text: 'move or ball-anim id',
+    amount: 'shake count on SHAKE_ANIM (0-3)' },
   damage: {
     slot: true, side: true, amount: true, hp: 'hp left',
     status: 'set when a residual dealt it',

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -2415,10 +2415,12 @@ class Relay {
    * Open the hub's record of a fight. The sim is still null: a ruleset and
    * every required party have to arrive before tryStartSim takes it over.
    *
-   * `npcIds` is set for coop_npc (two synthetic seats) and wild (one seat).
-   * Coop_npc: two players meet two monsters. Wild: one player meets one wild
-   * mon on a hub NPC seat (protocol-only — no overworld divert). The host
-   * uploads the NPC team as side "b".
+   * `npcIds` is set for coop_npc (two synthetic seats) and for wild /
+   * coop_wild (one seat). Coop_npc: two players meet two monsters. Wild: one
+   * player meets one wild mon on a hub NPC seat (protocol-only — no overworld
+   * divert). Coop_wild: two humans on side a, one wild seat on side b
+   * (overworld divert is client-side). The host uploads the NPC / wild team
+   * as side "b".
    *
    * They are ids a client could in principle type, and that is safe rather than
    * sloppy: client ids are minted as decimal counters, these carry a letter and
@@ -2438,7 +2440,7 @@ class Relay {
 
     let mode = p.mode;
     if (mode !== '1v1' && mode !== 'coop_npc' && mode !== 'coop_pvp'
-        && mode !== 'wild') {
+        && mode !== 'wild' && mode !== 'coop_wild') {
       mode = memberIds.length <= 2 ? '1v1' : 'coop_pvp';
     }
 
@@ -2449,9 +2451,10 @@ class Relay {
       for (let i = 0; i < COOP_SIDE; i += 1) {
         npcIds.push(`n${id}${String.fromCharCode(97 + i)}`);
       }
-    } else if (mode === 'wild') {
-      // One human, one synthetic wild seat. Protocol-only: nothing here
-      // diverts an overworld encounter onto this path.
+    } else if (mode === 'wild' || mode === 'coop_wild') {
+      // One synthetic wild seat. Wild: one human. Coop_wild: two humans (party
+      // size is client-gated; hub opens with whatever members arrived).
+      // Protocol-only here — overworld divert for coop_wild is client-side.
       npcIds = [`n${id}a`];
     }
 
@@ -2459,7 +2462,7 @@ class Relay {
     if (!sides || typeof sides !== 'object') {
       if (mode === '1v1') {
         sides = { a: [memberIds[0]], b: [memberIds[1] || memberIds[0]] };
-      } else if (mode === 'coop_npc' || mode === 'wild') {
+      } else if (mode === 'coop_npc' || mode === 'wild' || mode === 'coop_wild') {
         sides = { a: memberIds.slice(), b: npcIds.slice() };
       } else {
         const mid = Math.ceil(memberIds.length / 2);
@@ -2509,7 +2512,7 @@ class Relay {
         && client.id === record.hostId && record.npcIds) {
       return record.npcIds[0];
     }
-    if (record.mode === 'wild' && party.side === 'b'
+    if ((record.mode === 'wild' || record.mode === 'coop_wild') && party.side === 'b'
         && client.id === record.hostId && record.npcIds) {
       return record.npcIds[0];
     }

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -2447,6 +2447,8 @@ class Relay {
         && mode !== 'wild' && mode !== 'coop_wild') {
       mode = memberIds.length <= 2 ? '1v1' : 'coop_pvp';
     }
+    // coop_wild is a 2v1 contract (exactly two humans vs one wild seat).
+    if (mode === 'coop_wild' && memberIds.length !== 2) return null;
 
     const hostId = p.hostId || memberIds[0];
     let npcIds = null;
@@ -2456,8 +2458,7 @@ class Relay {
         npcIds.push(`n${id}${String.fromCharCode(97 + i)}`);
       }
     } else if (mode === 'wild' || mode === 'coop_wild') {
-      // One synthetic wild seat. Wild: one human. Coop_wild: two humans (party
-      // size is client-gated; hub opens with whatever members arrived).
+      // One synthetic wild seat. Wild: one human. Coop_wild: two humans.
       // Protocol-only here — overworld divert for coop_wild is client-side.
       npcIds = [`n${id}a`];
     }
@@ -2903,6 +2904,7 @@ class Relay {
     }
     if (outcome.reason) payload.reason = outcome.reason;
     if (outcome.caught) payload.caught = outcome.caught;
+    if (outcome.catcher) payload.catcher = outcome.catcher;
     this.broadcastBattle(record, 'mmo.battle_outcome', payload);
 
     // Rank from the intermediator alone -- no dual mmo.result vote.

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -38,7 +38,7 @@ const {
   cleanText, cleanId, cleanSpriteId, cleanMapId, cleanInt, cleanHex,
   cleanProfile, cleanOutcome, cleanPoints, cleanPlayerId, payloadOk, FACINGS,
   KINDS, SCOPES, NAME_MAX, MESSAGE_MAX, MOTD_MAX, LOCAL_RADIUS,
-  cleanBattleKey, cleanCoopReason, cleanLabel, cleanPartyEvent, PARTY_MAX,
+  cleanBattleKey, cleanCoopReason, cleanCoopOfferMode, cleanLabel, cleanPartyEvent, PARTY_MAX,
   cleanBattleRuleset, cleanBattleParty, cleanBattleChoice, cleanBattleReconnect,
   BATTLE_MOVE_MAX,
 } = require('./sanitize');
@@ -753,12 +753,15 @@ handlers['mmo.coop_wait'] = (relay, client, msg) => {
 
   const label = cleanLabel(msg.label);
   const map = cleanMapId(msg.map);
+  // Optional mode: only coop_wild is stored (Party vs Wild auto-join). Absent
+  // keeps the trainer WAIT/JOIN invite path.
+  const mode = cleanCoopOfferMode(msg.mode);
   // startedAt so the sweep can expire it on the same clock the partner's
   // client already uses. Mirrors src/Hub.lua.
-  client.coopOffer = { battle, label, map, startedAt: relay.now() };
-  relay.send(partner, 'mmo.coop_offer', {
-    from: client.id, name: client.name, battle, label, map,
-  });
+  client.coopOffer = { battle, label, map, mode, startedAt: relay.now() };
+  const offer = { from: client.id, name: client.name, battle, label, map };
+  if (mode) offer.mode = mode;
+  relay.send(partner, 'mmo.coop_offer', offer);
 };
 
 handlers['mmo.coop_cancel'] = (relay, client, msg) => {
@@ -817,17 +820,17 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
   // The pair get a fan-out group of their own, on the same footing as a
   // four-player one: from here on the battle traffic does not care which of the
   // two ways it was agreed.
-  // `coop_npc`, and it is the flow that decides it rather than a count: this
-  // pair agreed by one of them standing in front of a trainer, so the other
-  // side of the field is that trainer -- an opponent with a party and no
-  // connection. The four-way path below is the only one that makes a
-  // `coop_pvp`, because it is the only one where both sides are players.
+  // The mode is taken from the offer when the waiter named one: coop_wild for
+  // Party vs Wild (auto-join grass), otherwise coop_npc for the trainer path.
+  // The four-way path below is the only one that makes a coop_pvp, because it
+  // is the only one where both sides are players.
   // "c", for startSession's reason: sessions and co-op battles share the
   // `battles` map and are numbered by two counters that know nothing of each
   // other.
   const battleId = `c${relay.nextCoopAsk++}`;
+  const mode = offer.mode === 'coop_wild' ? 'coop_wild' : 'coop_npc';
   relay.openCoopBattle(battleId, [host.id, client.id],
-    { mode: 'coop_npc', hostId: host.id });
+    { mode, hostId: host.id });
 
   // `plan` is the hub's mediated battle id (`c*`). Without it the waiting
   // host's CoopBattle has no battleId, uploadMediated is a no-op, and the
@@ -837,10 +840,11 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
     { id: client.id, name: client.name, plan: battleId });
   // `host` names the client that simulates: the player who was already standing
   // at the fight, since they are the one guaranteed to have walked into the
-  // trainer -- the joiner usually has too, but a join taken from the ACTIONS
-  // menu never went near them.
+  // encounter -- the joiner usually has too, but a join taken from the ACTIONS
+  // menu never went near them. `mode` rides so the joiner's CoopBattle opens
+  // as coop_wild without re-deriving from an offer that is already cleared.
   relay.send(client, 'mmo.coop_battle',
-    { id: battleId, side: 'a', allies: members, battle, host: host.id });
+    { id: battleId, side: 'a', allies: members, battle, host: host.id, mode });
 };
 
 // Battle traffic, fanned out to everyone else in the same battle. The payload

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -102,10 +102,16 @@ const DEFAULT_SPRITE = 'SPRITE_RED';
 // this is the one feature whose answer may legitimately arrive later (the hub
 // holds an ask for a player who is offline), so "nothing has happened yet" is
 // an ordinary state and a player would have no way at all to tell it from a
-// hub that cannot do this. The rule every bump follows is unchanged: bump
-// whenever a client can send something a hub silently ignores. Kept in step
-// with Config.PROTOCOL on the mod side.
-const PROTOCOL = 17;
+// hub that cannot do this. 18 is Party vs Wild: mode token `coop_wild` (two
+// humans vs one wild NPC seat) and an optional `catcher` player id on
+// mmo.battle_outcome so a successful ball names who keeps the mon. A
+// protocol-17 hub's closed BATTLE_MODES set drops `coop_wild` opens, and its
+// outcome cleaner strips an unknown `catcher` -- either way the partner never
+// joins the grass fight, or both clients grant (or neither) because ownership
+// was never named. The rule every bump follows is unchanged: bump whenever a
+// client can send something a hub silently ignores. Kept in step with
+// Config.PROTOCOL on the mod side.
+const PROTOCOL = 18;
 
 // How long a four-way PARTY BATTLE ask waits for its three answers. Mirrors
 // Config.COOP_ASK_TIMEOUT: every one of the four is looking at a box right

--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -1089,8 +1089,8 @@ function cleanBattleEvent(raw) {
 
   const event = { battle, seq, t: raw.t };
   if (raw.text !== undefined && raw.text !== null) {
-    // Item events carry an id in `text`, not prose -- cleanText strips `_`.
-    const text = raw.t === 'item'
+    // Item / anim `text` is an id (POKE_BALL, TOSS_ANIM, move id) — cleanText strips `_`.
+    const text = (raw.t === 'item' || raw.t === 'anim')
       ? cleanId(raw.text)
       : cleanText(raw.text, MESSAGE_MAX);
     if (text) event.text = text;

--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -544,12 +544,14 @@ const BATTLE_REASONS = new Set([
   'timeout', 'disconnect', 'run', 'ko', 'agree', 'forfeit', 'catch',
 ]);
 
-// The three shapes a mediated fight comes in: two players with one monster
-// each, a pair against a trainer somebody walked into, or two pairs against
-// each other. Named on the wire rather than inferred from how many ids arrived,
-// because the two co-op modes have the same four field slots and differ only in
-// whether one side has an owner.
-const BATTLE_MODES = new Set(['1v1', 'coop_npc', 'coop_pvp', 'wild']);
+// The shapes a mediated fight comes in: two players with one monster each, a
+// pair against a trainer somebody walked into, two pairs against each other,
+// one player against a wild NPC seat, or two humans against one wild NPC seat
+// (coop_wild). Named on the wire rather than inferred from how many ids
+// arrived, because the co-op modes share field-slot shapes and differ in who
+// owns a side -- and "guess the mode from the roster" is right until an NPC
+// battle happens to have a spectatorless second slot.
+const BATTLE_MODES = new Set(['1v1', 'coop_npc', 'coop_pvp', 'wild', 'coop_wild']);
 
 /*
  * A roster: who is on a side, who won, who lost.
@@ -1165,6 +1167,15 @@ function cleanBattleOutcome(raw) {
     const caught = cleanBattleMon(raw.caught);
     if (!caught) return null;
     result.caught = caught;
+  }
+  // Optional catcher: who keeps the mon on a coop_wild catch. Absent is fine
+  // (solo wild / KO outcomes need no thrower); present-and-bad refuses the
+  // whole outcome -- same posture as winners/losers, since this is the name
+  // a grant moves for.
+  if (raw.catcher !== undefined && raw.catcher !== null) {
+    const catcher = cleanId(raw.catcher);
+    if (!catcher) return null;
+    result.catcher = catcher;
   }
   return result;
 }

--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -212,6 +212,13 @@ function cleanBattleKey(value) {
   return /^[\w.\-:|]+$/.test(value) ? value : null;
 }
 
+// Optional wait/offer mode. Only coop_wild is meaningful; anything else
+// (including absent) is null so the trainer invite path stays the default.
+// Mirrors Wire.coopOfferMode.
+function cleanCoopOfferMode(value) {
+  return value === 'coop_wild' ? 'coop_wild' : null;
+}
+
 // Which side of a co-op battle somebody is on, and why an offer or an ask
 // ended. Both are closed sets rather than free text: each value picks a
 // different sentence on the client, and an unknown one has to degrade to the
@@ -1195,6 +1202,7 @@ module.exports = {
   cleanId,
   cleanMember,
   cleanBattleKey,
+  cleanCoopOfferMode,
   cleanLabel,
   cleanSide,
   cleanCoopReason,

--- a/src/BattleSim/Turn.lua
+++ b/src/BattleSim/Turn.lua
@@ -110,8 +110,20 @@ M.RESOLVE_TIMEOUT     = 30    -- Config.BATTLE_RESOLVE_TIMEOUT
 -- Below this the side-a member of a tied group moves first.
 M.TIE_BREAK_ROLL = 128
 
-M.MODES = { ["1v1"] = true, coop_npc = true, coop_pvp = true, wild = true }
+M.MODES = {
+  ["1v1"] = true, coop_npc = true, coop_pvp = true, wild = true, coop_wild = true,
+}
 M.SIDES = { "a", "b" }
+
+-- Roster cap per side. coop_wild is 2v1 (humans on a, wild on b); other modes
+-- keep a single per-side ceiling (1 for 1v1/wild, FIGHTERS_PER_SIDE otherwise).
+local function maxFighters(mode, side)
+  if mode == "coop_wild" then
+    return (side == "a") and M.FIGHTERS_PER_SIDE or 1
+  end
+  if mode == "1v1" or mode == "wild" then return 1 end
+  return M.FIGHTERS_PER_SIDE
+end
 
 -- Wire spells a condition as a three-letter token and Status.lua spells it as
 -- a word.  Both are accepted on the way in and the token is what goes back out
@@ -435,7 +447,6 @@ function M.create(opts)
   if type(opts) ~= "table" then return nil, "battle needs an options table" end
 
   local mode = M.MODES[opts.mode] and opts.mode or "1v1"
-  local perSide = (mode == "1v1" or mode == "wild") and 1 or M.FIGHTERS_PER_SIDE
 
   local self = setmetatable({
     id             = str(opts.id) or "battle",
@@ -480,7 +491,8 @@ function M.create(opts)
   for _, side in ipairs(M.SIDES) do
     local roster = type(sides[side]) == "table" and sides[side] or {}
     if #roster == 0 then return nil, "side " .. side .. " has nobody on it" end
-    if #roster > perSide then
+    local sideMax = maxFighters(mode, side)
+    if #roster > sideMax then
       return nil, "side " .. side .. " has more fighters than " .. mode .. " allows"
     end
     for index = 1, #roster do
@@ -1408,270 +1420,46 @@ function Battle:_clearTrapsFrom(slot)
 end
 
 function Battle:_resolveItems()
+  -- Non-ball items keep Gen1 array order (heals, dolls, vitamins, …). Balls
+  -- resolve in a second pass ordered by active-mon speed (fight tie policy),
+  -- so the faster thrower spends first and a successful catch aborts the rest.
   for _, fighter in ipairs(self.fighters) do
     if self.result then return end
     local choice = fighter.choice
     if choice and choice.action == "item" then
       local effect = Effects.itemEffect(choice.item)
-      -- Vitamins apply before the `item` event so `amount=1` can mean "Stat Exp
-      -- writeback is owed"; a failed vitamin still spends the bag stack (Gen1)
-      -- but must not bump save.statExp on the client.
-      local vitaminApplied, vitaminMon, vitaminResult = false, nil, nil
-      if effect and effect.vitamin then
-        local partyIdx = choice.slot or fighter.active
-        local mon = fighter.mons[partyIdx]
-        if mon and mon.hp > 0 then
-          local result = Effects.applyVitamin(mon, choice.item)
-          if result then
-            vitaminApplied, vitaminMon, vitaminResult = true, mon, result
-          end
-        end
-      end
-      local itemEv = { slot = fighter.slot, side = fighter.side, text = choice.item }
-      if vitaminApplied then itemEv.amount = 1 end
-      self:_emit("item", itemEv)
-      self:_say(fighter.name .. " used an item")
-      -- Spend after the announce, win or fail (Gen1 bag stack). noConsume
-      -- (Poké Flute) and seats with no bag sheet are left alone.
-      if not (effect and effect.noConsume) then
-        self:_spendBag(fighter, choice.item)
-      end
-      if not effect then
-        self:_say("But it failed")
-      elseif effect.ball then
-        if not Effects.isWildMode(self.mode) then
-          self:_say("But it failed")
-        else
-          local foe = self:_firstLivingFoe(fighter)
-          local target = foe and activeMon(foe)
-          if not target then
-            self:_say("But it failed")
-          else
-            local caught, shakes = Effects.catchAttempt(choice.item, target, self.rng)
-            if shakes and shakes > 0 and not caught then
-              self:_say("The ball shook")
-            end
-            if caught then
-              self:_say("Gotcha")
-              local finish = self:_finish("win", self:_sidePlayers(fighter.side),
-                self:_sidePlayers(fighter.side == "a" and "b" or "a"), "catch")
-              local sheet = Effects.caughtSheet(target)
-              if finish and sheet then finish.caught = sheet end
-            else
-              self:_say("It broke free")
-            end
-          end
-        end
-      elseif effect.pokeDoll then
-        if Effects.isWildMode(self.mode) then
-          self:_say("The wild pokemon ran away")
-          self:_finish("win", self:_sidePlayers(fighter.side),
-            self:_sidePlayers(fighter.side == "a" and "b" or "a"), "run")
-        else
-          self:_say("But it failed")
-        end
-      elseif effect.vitamin then
-        if not vitaminApplied then
-          self:_say("But it failed")
-        else
-          local mon, result = vitaminMon, vitaminResult
-          local label = ({
-            hp = "HEALTH POINTS", atk = "ATTACK", def = "DEFENSE",
-            spd = "SPEED", spc = "SPECIAL",
-          })[result.stat] or "STAT"
-          if result.stat == "hp" and result.delta > 0 then
-            self:_emit("drain", {
-              slot = fighter.slot, side = fighter.side,
-              amount = result.delta, hp = mon.hp,
-            })
-          elseif result.delta > 0 then
-            self:_emit("stat", {
-              slot = fighter.slot, side = fighter.side,
-              amount = mon.stats[result.stat],
-              text = mon.species .. "'s " .. label .. " rose",
-            })
-          end
-          self:_say(mon.species .. "'s " .. label .. " rose")
-        end
-      elseif effect.pokeFlute then
-        local woke = false
-        for _, seat in ipairs(self.fighters) do
-          for i = 1, #(seat.mons or {}) do
-            local mon = seat.mons[i]
-            if mon and mon.status == "sleep" then
-              mon.status, mon.statusTurns = nil, 0
-              woke = true
-              self:_emit("status", {
-                slot = seat.slot, side = seat.side,
-                text = mon.species .. " woke up",
-              })
-            end
-          end
-        end
-        if woke then
-          self:_say("All sleeping POKeMON woke up")
-        else
-          self:_say("Now, that's a catchy tune")
-        end
-      else
-        local partyIdx = choice.slot or fighter.active
-        local mon = fighter.mons[partyIdx]
-        if not mon then
-          self:_say("But it failed")
-        elseif effect.activeOnly and partyIdx ~= fighter.active then
-          self:_say("But it failed")
-        elseif effect.faintedOnly and mon.hp > 0 then
-          self:_say("But it failed")
-        elseif not effect.faintedOnly and mon.hp <= 0
-           and (effect.heal or effect.healFull or effect.clearStatuses
-                or effect.clearAllStatus or effect.ppRestore
-                or effect.ppRestoreAll) then
-          self:_say("But it failed")
-        else
-          local applied = false
-          if effect.xAccuracy then
-            mon.xAccuracy = true
-            self:_say(mon.species .. "'s hits will never miss")
-            applied = true
-          end
-          if effect.focusEnergy then
-            mon.focusEnergy = true
-            self:_say(mon.species .. " is getting pumped")
-            applied = true
-          end
-          if effect.mist then
-            mon.mist = true
-            self:_say(mon.species .. " is protected against stat changes")
-            applied = true
-          end
-          if effect.stage then
-            local stat = effect.stage.stat
-            local before = Effects.clampStage(mon.stages[stat])
-            if before >= Effects.STAGE_MAX then
-              self:_say("Nothing happened")
-            else
-              local after = Effects.clampStage(before + int(effect.stage.delta, 1))
-              mon.stages[stat] = after
-              local label = ({
-                atk = "ATTACK", def = "DEFENSE", spd = "SPEED",
-                spc = "SPECIAL", acc = "ACCURACY", eva = "EVASION",
-              })[stat] or "STAT"
-              self:_say(mon.species .. "'s " .. label .. " rose")
-              self:_emit("stat", {
-                slot = fighter.slot, side = fighter.side,
-                amount = after, text = mon.species .. "'s " .. label .. " rose",
-              })
-            end
-            applied = true
-          end
-          if effect.revive then
-            local amount = effect.revive
-            local hp = amount == 1 and mon.maxHp or max(1, floor(mon.maxHp * amount))
-            mon.hp = hp
-            mon.status, mon.statusTurns = nil, 0
-            self:_emit("drain", {
-              slot = fighter.slot, side = fighter.side,
-              amount = hp, hp = mon.hp,
-            })
-            self:_say(mon.species .. " was revived")
-            applied = true
-          end
-          if effect.ppRestore then
-            local move = mon.moves[choice.move]
-            if not move then
-              self:_say("But it failed")
-            else
-              local maxPp = max(int(move.maxPp, move.pp), move.pp, 1)
-              local before = move.pp
-              if effect.ppRestore == true then
-                move.pp = maxPp
-              else
-                move.pp = min(maxPp, move.pp + int(effect.ppRestore, 0))
-              end
-              if move.pp > before then
-                self:_say(mon.species .. "'s PP was restored")
-                applied = true
-              else
-                self:_say("But it failed")
-              end
-            end
-          end
-          if effect.ppRestoreAll then
-            local any = false
-            for i = 1, #(mon.moves or {}) do
-              local move = mon.moves[i]
-              if move then
-                local maxPp = max(int(move.maxPp, move.pp), move.pp, 1)
-                local before = move.pp
-                if effect.ppRestoreAll == true then
-                  move.pp = maxPp
-                else
-                  move.pp = min(maxPp, move.pp + int(effect.ppRestoreAll, 0))
-                end
-                if move.pp > before then any = true end
-              end
-            end
-            if any then
-              self:_say(mon.species .. "'s PP was restored")
-              applied = true
-            else
-              self:_say("But it failed")
-            end
-          end
-          local healed = false
-          if effect.healFull then
-            local before = mon.hp
-            mon.hp = mon.maxHp
-            if mon.hp > before then
-              self:_emit("drain", {
-                slot = fighter.slot, side = fighter.side,
-                amount = mon.hp - before, hp = mon.hp,
-              })
-              healed = true
-            end
-          elseif effect.heal and effect.heal > 0 and mon.hp < mon.maxHp then
-            self:_heal(fighter, mon, effect.heal)
-            healed = true
-          end
-          local cleared = false
-          if effect.clearAllStatus and mon.status then
-            mon.status, mon.statusTurns = nil, 0
-            cleared = true
-          elseif effect.clearStatuses and mon.status
-             and effect.clearStatuses[mon.status] then
-            mon.status, mon.statusTurns = nil, 0
-            cleared = true
-          end
-          if cleared then
-            self:_emit("status", {
-              slot = fighter.slot, side = fighter.side,
-              text = mon.species .. " recovered",
-            })
-          end
-          if not applied and not healed and not cleared then
-            self:_say("But it failed")
-          end
-        end
+      if not (effect and effect.ball) then
+        self:_resolveOneItem(fighter)
       end
     end
+  end
+
+  local balls = {}
+  for _, fighter in ipairs(self.fighters) do
+    local choice = fighter.choice
+    if choice and choice.action == "item" then
+      local effect = Effects.itemEffect(choice.item)
+      if effect and effect.ball then
+        local mon = activeMon(fighter)
+        balls[#balls + 1] = {
+          fighter = fighter,
+          speed = mon and self:_speedOf(fighter, mon) or 0,
+          order = #balls + 1,
+        }
+      end
+    end
+  end
+  self:_sortActorsBySpeed(balls)
+  for _, actor in ipairs(balls) do
+    if self.result then return end
+    self:_resolveOneItem(actor.fighter)
   end
 end
 
-function Battle:_resolveFights()
-  local actors = {}
-  for _, fighter in ipairs(self.fighters) do
-    local choice = fighter.choice
-    local mon = activeMon(fighter)
-    if choice and choice.action == "fight" and mon then
-      actors[#actors + 1] = {
-        fighter = fighter,
-        mon = mon,                      -- pinned: see the skip in the loop
-        speed = self:_speedOf(fighter, mon),
-        order = #actors + 1,
-      }
-    end
-  end
-  if #actors == 0 then return end
+-- Sort actors by active-mon speed (desc), then field order; tied groups flip on
+-- one RNG byte >= TIE_BREAK_ROLL. Shared by fights and ball throws.
+function Battle:_sortActorsBySpeed(actors)
+  if #actors <= 1 then return end
 
   table.sort(actors, function(x, y)
     if x.speed ~= y.speed then return x.speed > y.speed end
@@ -1693,6 +1481,273 @@ function Battle:_resolveFights()
     end
     i = j + 1
   end
+end
+
+function Battle:_resolveOneItem(fighter)
+  local choice = fighter.choice
+  if not (choice and choice.action == "item") then return end
+
+  local effect = Effects.itemEffect(choice.item)
+  -- Vitamins apply before the `item` event so `amount=1` can mean "Stat Exp
+  -- writeback is owed"; a failed vitamin still spends the bag stack (Gen1)
+  -- but must not bump save.statExp on the client.
+  local vitaminApplied, vitaminMon, vitaminResult = false, nil, nil
+  if effect and effect.vitamin then
+    local partyIdx = choice.slot or fighter.active
+    local mon = fighter.mons[partyIdx]
+    if mon and mon.hp > 0 then
+      local result = Effects.applyVitamin(mon, choice.item)
+      if result then
+        vitaminApplied, vitaminMon, vitaminResult = true, mon, result
+      end
+    end
+  end
+  local itemEv = { slot = fighter.slot, side = fighter.side, text = choice.item }
+  if vitaminApplied then itemEv.amount = 1 end
+  self:_emit("item", itemEv)
+  self:_say(fighter.name .. " used an item")
+  -- Spend after the announce, win or fail (Gen1 bag stack). noConsume
+  -- (Poké Flute) and seats with no bag sheet are left alone.
+  if not (effect and effect.noConsume) then
+    self:_spendBag(fighter, choice.item)
+  end
+  if not effect then
+    self:_say("But it failed")
+  elseif effect.ball then
+    if not Effects.isWildMode(self.mode) then
+      self:_say("But it failed")
+    else
+      local foe = self:_firstLivingFoe(fighter)
+      local target = foe and activeMon(foe)
+      if not target then
+        self:_say("But it failed")
+      else
+        local caught, shakes = Effects.catchAttempt(choice.item, target, self.rng)
+        if shakes and shakes > 0 and not caught then
+          self:_say("The ball shook")
+        end
+        if caught then
+          self:_say("Gotcha")
+          local finish = self:_finish("win", self:_sidePlayers(fighter.side),
+            self:_sidePlayers(fighter.side == "a" and "b" or "a"), "catch")
+          local sheet = Effects.caughtSheet(target)
+          if finish and sheet then finish.caught = sheet end
+          if finish then finish.catcher = fighter.playerId end
+        else
+          self:_say("It broke free")
+        end
+      end
+    end
+  elseif effect.pokeDoll then
+    if Effects.isWildMode(self.mode) then
+      self:_say("The wild pokemon ran away")
+      self:_finish("win", self:_sidePlayers(fighter.side),
+        self:_sidePlayers(fighter.side == "a" and "b" or "a"), "run")
+    else
+      self:_say("But it failed")
+    end
+  elseif effect.vitamin then
+    if not vitaminApplied then
+      self:_say("But it failed")
+    else
+      local mon, result = vitaminMon, vitaminResult
+      local label = ({
+        hp = "HEALTH POINTS", atk = "ATTACK", def = "DEFENSE",
+        spd = "SPEED", spc = "SPECIAL",
+      })[result.stat] or "STAT"
+      if result.stat == "hp" and result.delta > 0 then
+        self:_emit("drain", {
+          slot = fighter.slot, side = fighter.side,
+          amount = result.delta, hp = mon.hp,
+        })
+      elseif result.delta > 0 then
+        self:_emit("stat", {
+          slot = fighter.slot, side = fighter.side,
+          amount = mon.stats[result.stat],
+          text = mon.species .. "'s " .. label .. " rose",
+        })
+      end
+      self:_say(mon.species .. "'s " .. label .. " rose")
+    end
+  elseif effect.pokeFlute then
+    local woke = false
+    for _, seat in ipairs(self.fighters) do
+      for i = 1, #(seat.mons or {}) do
+        local mon = seat.mons[i]
+        if mon and mon.status == "sleep" then
+          mon.status, mon.statusTurns = nil, 0
+          woke = true
+          self:_emit("status", {
+            slot = seat.slot, side = seat.side,
+            text = mon.species .. " woke up",
+          })
+        end
+      end
+    end
+    if woke then
+      self:_say("All sleeping POKeMON woke up")
+    else
+      self:_say("Now, that's a catchy tune")
+    end
+  else
+    local partyIdx = choice.slot or fighter.active
+    local mon = fighter.mons[partyIdx]
+    if not mon then
+      self:_say("But it failed")
+    elseif effect.activeOnly and partyIdx ~= fighter.active then
+      self:_say("But it failed")
+    elseif effect.faintedOnly and mon.hp > 0 then
+      self:_say("But it failed")
+    elseif not effect.faintedOnly and mon.hp <= 0
+       and (effect.heal or effect.healFull or effect.clearStatuses
+            or effect.clearAllStatus or effect.ppRestore
+            or effect.ppRestoreAll) then
+      self:_say("But it failed")
+    else
+      local applied = false
+      if effect.xAccuracy then
+        mon.xAccuracy = true
+        self:_say(mon.species .. "'s hits will never miss")
+        applied = true
+      end
+      if effect.focusEnergy then
+        mon.focusEnergy = true
+        self:_say(mon.species .. " is getting pumped")
+        applied = true
+      end
+      if effect.mist then
+        mon.mist = true
+        self:_say(mon.species .. " is protected against stat changes")
+        applied = true
+      end
+      if effect.stage then
+        local stat = effect.stage.stat
+        local before = Effects.clampStage(mon.stages[stat])
+        if before >= Effects.STAGE_MAX then
+          self:_say("Nothing happened")
+        else
+          local after = Effects.clampStage(before + int(effect.stage.delta, 1))
+          mon.stages[stat] = after
+          local label = ({
+            atk = "ATTACK", def = "DEFENSE", spd = "SPEED",
+            spc = "SPECIAL", acc = "ACCURACY", eva = "EVASION",
+          })[stat] or "STAT"
+          self:_say(mon.species .. "'s " .. label .. " rose")
+          self:_emit("stat", {
+            slot = fighter.slot, side = fighter.side,
+            amount = after, text = mon.species .. "'s " .. label .. " rose",
+          })
+        end
+        applied = true
+      end
+      if effect.revive then
+        local amount = effect.revive
+        local hp = amount == 1 and mon.maxHp or max(1, floor(mon.maxHp * amount))
+        mon.hp = hp
+        mon.status, mon.statusTurns = nil, 0
+        self:_emit("drain", {
+          slot = fighter.slot, side = fighter.side,
+          amount = hp, hp = mon.hp,
+        })
+        self:_say(mon.species .. " was revived")
+        applied = true
+      end
+      if effect.ppRestore then
+        local move = mon.moves[choice.move]
+        if not move then
+          self:_say("But it failed")
+        else
+          local maxPp = max(int(move.maxPp, move.pp), move.pp, 1)
+          local before = move.pp
+          if effect.ppRestore == true then
+            move.pp = maxPp
+          else
+            move.pp = min(maxPp, move.pp + int(effect.ppRestore, 0))
+          end
+          if move.pp > before then
+            self:_say(mon.species .. "'s PP was restored")
+            applied = true
+          else
+            self:_say("But it failed")
+          end
+        end
+      end
+      if effect.ppRestoreAll then
+        local any = false
+        for i = 1, #(mon.moves or {}) do
+          local move = mon.moves[i]
+          if move then
+            local maxPp = max(int(move.maxPp, move.pp), move.pp, 1)
+            local before = move.pp
+            if effect.ppRestoreAll == true then
+              move.pp = maxPp
+            else
+              move.pp = min(maxPp, move.pp + int(effect.ppRestoreAll, 0))
+            end
+            if move.pp > before then any = true end
+          end
+        end
+        if any then
+          self:_say(mon.species .. "'s PP was restored")
+          applied = true
+        else
+          self:_say("But it failed")
+        end
+      end
+      local healed = false
+      if effect.healFull then
+        local before = mon.hp
+        mon.hp = mon.maxHp
+        if mon.hp > before then
+          self:_emit("drain", {
+            slot = fighter.slot, side = fighter.side,
+            amount = mon.hp - before, hp = mon.hp,
+          })
+          healed = true
+        end
+      elseif effect.heal and effect.heal > 0 and mon.hp < mon.maxHp then
+        self:_heal(fighter, mon, effect.heal)
+        healed = true
+      end
+      local cleared = false
+      if effect.clearAllStatus and mon.status then
+        mon.status, mon.statusTurns = nil, 0
+        cleared = true
+      elseif effect.clearStatuses and mon.status
+         and effect.clearStatuses[mon.status] then
+        mon.status, mon.statusTurns = nil, 0
+        cleared = true
+      end
+      if cleared then
+        self:_emit("status", {
+          slot = fighter.slot, side = fighter.side,
+          text = mon.species .. " recovered",
+        })
+      end
+      if not applied and not healed and not cleared then
+        self:_say("But it failed")
+      end
+    end
+  end
+end
+
+function Battle:_resolveFights()
+  local actors = {}
+  for _, fighter in ipairs(self.fighters) do
+    local choice = fighter.choice
+    local mon = activeMon(fighter)
+    if choice and choice.action == "fight" and mon then
+      actors[#actors + 1] = {
+        fighter = fighter,
+        mon = mon,                      -- pinned: see the skip in the loop
+        speed = self:_speedOf(fighter, mon),
+        order = #actors + 1,
+      }
+    end
+  end
+  if #actors == 0 then return end
+
+  self:_sortActorsBySpeed(actors)
 
   for _, actor in ipairs(actors) do
     if self.result then break end

--- a/src/BattleSim/Turn.lua
+++ b/src/BattleSim/Turn.lua
@@ -1523,6 +1523,8 @@ function Battle:_resolveOneItem(fighter)
         self:_say("But it failed")
       else
         local caught, shakes = Effects.catchAttempt(choice.item, target, self.rng)
+        -- Gen1 TossBallAnimation chain before the catch text (engine ballChain).
+        self:_emitBallChain(fighter, choice.item, caught, shakes)
         if shakes and shakes > 0 and not caught then
           self:_say("The ball shook")
         end
@@ -1728,6 +1730,29 @@ function Battle:_resolveOneItem(fighter)
         self:_say("But it failed")
       end
     end
+  end
+end
+
+-- Gen1 TossBallAnimation event stream (mirror BattleState:ballChain / tossAnimFor).
+-- Clients pair AnimPlayer opts.ball from the preceding `item` event's text.
+function Battle:_emitBallChain(fighter, ballId, caught, shakes)
+  local slot, side = fighter.slot, fighter.side
+  local toss = ballId == "POKE_BALL" and "TOSS_ANIM"
+    or ballId == "GREAT_BALL" and "GREATTOSS_ANIM"
+    or "ULTRATOSS_ANIM"
+  local function anim(text, amount)
+    local fields = { slot = slot, side = side, text = text }
+    if amount ~= nil then fields.amount = amount end
+    self:_emit("anim", fields)
+  end
+  anim(toss)
+  anim("POOF_ANIM")
+  if not caught and (not shakes or shakes == 0) then return end
+  anim("HIDEPIC_ANIM")
+  anim("SHAKE_ANIM", shakes or 0)
+  if not caught then
+    anim("POOF_ANIM")
+    anim("SHOWPIC_ANIM")
   end
 end
 

--- a/src/BattleSim/events.lua
+++ b/src/BattleSim/events.lua
@@ -106,7 +106,8 @@ M.FIELDS = {
 -- field it has and is compared rather than sized, so a long fight is fine.
 M.SHAPES = {
   msg       = { text = true },
-  anim      = { slot = true, side = true, text = "the move's id" },
+  anim      = { slot = true, side = true, text = "move or ball-anim id",
+                amount = "shake count on SHAKE_ANIM (0-3)" },
   damage    = { slot = true, side = true, amount = true, hp = "hp left",
                 status = "set when a residual dealt it" },
   drain     = { slot = true, side = true, amount = true, hp = true },

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -2003,19 +2003,33 @@ function M.install()
   -- is why BATTLE ALONE costs nothing but closing a menu, and why a player who
   -- is not in a party never notices any of this happened.
   --
-  -- src/Coop.lua's onTrainerBattle is where the two answers diverge, and its
-  -- header explains what the co-op one does with the battle it took.
+  -- src/Coop.lua's onTrainerBattle / onWildEncounter is where the answers
+  -- diverge, and their headers explain what the co-op path does with the
+  -- battle it took. Wild divert has no WAIT/ALONE prompt -- only same-map
+  -- auto-join into coop_wild, else the engine wild is left alone.
   mod.events:on("screen.pushed", function(payload)
     local state = payload and payload.state
-    if not (state and state.kind == "trainer") then return end
+    if not state then return end
     if not transport:isReady() then return end
     local current = World.current()
-    local ok, err = pcall(function()
-      coop:onTrainerBattle(ctx.game, state, current and current.mapId)
-    end)
-    if not ok then
-      mod.log:warn("the co-op prompt failed (%s); this trainer is fought the "
-        .. "ordinary way -- the battle itself is unaffected", tostring(err))
+    local mapId = current and current.mapId
+    if state.kind == "trainer" then
+      local ok, err = pcall(function()
+        coop:onTrainerBattle(ctx.game, state, mapId)
+      end)
+      if not ok then
+        mod.log:warn("the co-op prompt failed (%s); this trainer is fought the "
+          .. "ordinary way -- the battle itself is unaffected", tostring(err))
+      end
+    elseif state.kind == "wild" then
+      local ok, err = pcall(function()
+        coop:onWildEncounter(ctx.game, state, mapId)
+      end)
+      if not ok then
+        mod.log:warn("the party wild divert failed (%s); this encounter is "
+          .. "fought the ordinary way -- the battle itself is unaffected",
+          tostring(err))
+      end
     end
   end)
 

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -102,8 +102,16 @@ M.MOD_ID = "rby_mmo"
 -- whose answer may legitimately arrive *later* -- the hub holds an ask for a
 -- player who is offline -- so "nothing yet" is an ordinary state, and a player
 -- would have no way at all to tell it apart from a hub that cannot do this.
+--
+-- 18 is Party vs Wild: mode token `coop_wild` (two humans vs one wild NPC seat)
+-- and an optional `catcher` player id on `mmo.battle_outcome` so a successful
+-- ball names who keeps the mon. A protocol-17 hub's closed BATTLE_MODES set
+-- drops `coop_wild` opens, and its outcome cleaner strips an unknown `catcher`
+-- field -- either way the partner never joins the grass fight, or both clients
+-- grant (or neither does) because ownership was never named. Refusal that
+-- names both versions is the only sentence either player can act on.
 -- This number lives here and in server/lib/relay.js -- bump them together.
-M.PROTOCOL = 17
+M.PROTOCOL = 18
 
 -- The port an in-game host binds, and the one a bare address is completed
 -- with.
@@ -415,11 +423,11 @@ M.COOP_STALL_TIMEOUT = 75
 -- together: a client on this line talking to a hub without them is the 2-on-1
 -- that never resolves, which is what PROTOCOL is for.
 --
--- **Not a host toggle.** coop_pvp / coop_npc are always hub-refereed. The
--- host-sim CoopSim path for those modes was removed so BattleSim and engine
+-- **Not a host toggle.** coop_pvp / coop_npc / coop_wild are always hub-refereed.
+-- The host-sim CoopSim path for those modes was removed so BattleSim and engine
 -- ItemEffects cannot diverge mid-match. `CoopBattle.mediates` hard-codes the
--- same two modes; this table stays as the documented surface for e2e / docs.
-M.MEDIATED_COOP = { coop_pvp = true, coop_npc = true }
+-- mediated modes; this table stays as the documented surface for e2e / docs.
+M.MEDIATED_COOP = { coop_pvp = true, coop_npc = true, coop_wild = true }
 
 -- How long a battle waits for a player who has dropped mid-fight.
 --

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -1,7 +1,8 @@
--- Co-op battles: the two of you against one trainer, and the two of you
--- against the two of them.
+-- Co-op battles: the two of you against one trainer, the two of you against
+-- the two of them, and (when partied on the same map) the two of you against
+-- one wild encounter.
 --
--- Two flows live here, and they are less alike than they look.
+-- Three flows live here, and they are less alike than they look.
 --
 --   * **Against an NPC.**  One partner walks into a trainer, is asked whether
 --     to wait or to go in alone. Waiting is allowed even when the partner is
@@ -9,6 +10,10 @@
 --     automatically when they arrive. They can leave wait mode and take the
 --     trainer alone at any time. Accept → both fight it together. Decline →
 --     the waiter is told, encouraged, and released into a solo 1v1.
+--   * **Against a wild.**  Same-map partner online and free → divert into
+--     mediated `coop_wild` with no WAIT/ALONE box; the partner auto-joins.
+--     Otherwise the engine wild proceeds alone. Soft-lock: a wait with no
+--     join within COOP_ASK_TIMEOUT withdraws and releases into solo wild.
 --   * **Against another party.**  PARTY BATTLE on the ACTIONS menu, and all
 --     four have to agree before anything starts.
 --
@@ -544,6 +549,88 @@ function M:onTrainerBattle(game, state, mapId)
   return true
 end
 
+-- The wild mon the engine just built, for a grant and for the battle key.
+--
+-- Wild BattleState keeps the mon on `enemy.mon` (newWild never fills
+-- enemyParty). Trainer battles put it in enemyParty[1]. Both shapes are
+-- accepted so a headless fixture that only stubs enemyParty still works.
+function M.wildMonOf(state)
+  if type(state) ~= "table" then return nil end
+  local mon = state.enemyParty and state.enemyParty[1]
+  if mon then return mon end
+  local enemy = state.enemy
+  return enemy and enemy.mon or nil
+end
+
+-- Called when the engine has just pushed a wild encounter.
+--
+-- Divert only when partied, the partner is roster-online on *this* map, and
+-- neither side is busy. Busy here is: we are already mid-co-op / mid-ask /
+-- holding their invite, another fight is already on the stack (excluding this
+-- just-pushed wild), or their presence says session-busy. Otherwise return
+-- false and leave the engine wild completely alone.
+--
+-- No WAIT/ALONE UI: beginWildCoop posts COOP_WAIT with mode=coop_wild and the
+-- partner auto-joins (see considerOffer). The engine wild stays frozen under
+-- the stack until onJoined → startBattle unwinds it.
+function M:onWildEncounter(game, state, mapId)
+  if not (state and state.kind == "wild") then return false end
+  if not (self.transport:isReady() and self.party:has()) then return false end
+  if self.running or self.waiting or self.ask or self.offer then return false end
+  if self.joinAsk then return false end
+  if not self:partnerOnMap(mapId) then return false end
+  local partner = self.party:partner()
+  local row = partner and self.roster:get(partner.id)
+  if row and row.busy then return false end
+  if self:inFightExcept(game, state) then return false end
+
+  local mon = M.wildMonOf(state)
+  if not mon then return false end
+  local species = mon.species
+  local label = Wire.label(tostring(species or ""):gsub("_", " "))
+  local key = M.battleKey(mapId, species, mon.level)
+
+  self.encounter = {
+    battle = key,
+    label = label,
+    map = mapId,
+    engine = state,
+    game = game,
+    kind = "wild",
+    wildCatchMon = mon,
+  }
+  return self:beginWildCoop()
+end
+
+-- Start a Party vs Wild wait: same wire as trainer WAIT, no box, short clock.
+--
+-- The encounter is held (not released) so a timed-out wait can still hand the
+-- engine wild back via release(), and a successful join can hand it to
+-- startBattle the same way the trainer path does.
+function M:beginWildCoop()
+  local encounter = self.encounter
+  if not (encounter and encounter.kind == "wild") then return false end
+  if not self.transport:isReady() then return false end
+  self.waiting = {
+    battle = encounter.battle,
+    label = encounter.label,
+    map = encounter.map,
+    engine = encounter.engine,
+    game = encounter.game,
+    kind = "wild",
+    mode = "coop_wild",
+    wildCatchMon = encounter.wildCatchMon,
+    clock = 0,
+  }
+  self.transport:send(Wire.COOP_WAIT, {
+    battle = encounter.battle,
+    label = encounter.label,
+    map = encounter.map,
+    mode = "coop_wild",
+  })
+  return true
+end
+
 -- Is this state still on the stack at all?
 --
 -- Three answers, not two: true, false, and *nil* for "this stack cannot say".
@@ -754,13 +841,32 @@ end
 -- Same-map only: an invite for a fight three screens away is stored (chat
 -- note + JOIN row) but not shoved in the player's face. Mid-fight and mid-
 -- wait are also quiet -- a box over a wild encounter is worse than a note.
+--
+-- `coop_wild` never asks: partner auto-joins when free on the same map, which
+-- is the whole Party vs Wild product rule. Busy / off-map leaves the offer
+-- standing so the host's short wait can time out into solo wild.
 function M:considerOffer(game, myMap)
   local offer = self.offer
   if not offer then return false end
   if self.joinAsk or self.ask or self.waiting or self.running then return false end
   if self:inFight(game) then return false end
   if not (offer.map and myMap and offer.map == myMap) then return false end
+  if offer.mode == "coop_wild" then
+    return self:autoJoinWild(offer)
+  end
   return self:askToJoin(game, offer)
+end
+
+-- Answer a Party vs Wild offer without a confirm box.
+function M:autoJoinWild(offer)
+  if not (offer and offer.mode == "coop_wild") then return false end
+  if not self.transport:isReady() then return false end
+  local from, battle = offer.from, offer.battle
+  -- Cleared before the send so a second considerOffer tick cannot double-join.
+  -- A late alone from the hub still lands as COOP_OFFER_END with no box up.
+  self.offer = nil
+  self.transport:send(Wire.COOP_JOIN, { to = from, battle = battle })
+  return true
 end
 
 -- The yes/no that ends somebody else's wait.
@@ -813,6 +919,10 @@ function M:joinFromMenu(game)
   -- No encounter is set: nobody triggered a trainer to get here, so releasing
   -- is a no-op and "no" is simply no, leaving the player standing where they
   -- were rather than dropping them into a fight they never walked into.
+  -- coop_wild never shows the confirm -- same auto-join as considerOffer.
+  if offer.mode == "coop_wild" then
+    return self:autoJoinWild(offer)
+  end
   return self:askToJoin(game, offer)
 end
 
@@ -955,10 +1065,35 @@ function M.stackHasFight(game)
   return M.isFightState(top)
 end
 
+-- Like stackHasFight, but ignore one state -- the wild (or trainer) that was
+-- just pushed and is the reason we are deciding whether to divert. Without
+-- the exclusion, every divert predicate would see "already in a fight" and
+-- refuse itself.
+function M.stackHasFightExcept(game, except)
+  local stack = game and game.stack
+  if not stack then return false end
+  local states = stack.states
+  if type(states) == "table" then
+    for i = #states, 1, -1 do
+      local s = states[i]
+      if s ~= except and M.isFightState(s) then return true end
+    end
+    return false
+  end
+  local top = stack.top and stack:top()
+  return top ~= except and M.isFightState(top)
+end
+
 function M:inFight(game)
   if self.running or self.state then return true end
   if self.fighting and self.fighting(game) then return true end
   return M.stackHasFight(game)
+end
+
+function M:inFightExcept(game, except)
+  if self.running or self.state then return true end
+  if self.fighting and self.fighting(game) then return true end
+  return M.stackHasFightExcept(game, except)
 end
 
 -- The ask, as it reaches the other three.  All four have to agree, so this is
@@ -996,8 +1131,15 @@ function M:onDecline(msg)
 
   -- NPC invite declined while we wait: the fight still has to happen (rule 2),
   -- so after the two sentences we release into the solo battle under the prompt.
+  -- Party vs Wild has no invite UI and no "take them alone" pep talk -- just
+  -- hand the engine wild back.
   if self.waiting then
+    local wild = self.waiting.kind == "wild"
     self.waiting = nil
+    if wild then
+      self:release()
+      return
+    end
     local who = name or self.party:partnerName() or "Your friend"
     self.ui:say(("%s decided\nnot to join."):format(who), function()
       self.ui:say("You can take\nthem alone!", function()
@@ -1034,9 +1176,12 @@ function M:onOffer(game, msg, myMap)
   offer.clock = 0
   self.offer = offer
   self.aloneAnnounced = false
-  self:note(("%s is waiting at %s."):format(offer.name, fightName(offer.label)))
+  if offer.mode ~= "coop_wild" then
+    self:note(("%s is waiting at %s."):format(offer.name, fightName(offer.label)))
+  end
   -- Invite like a 2-on-2 ask: same map, and free to answer. Off-map stays a
-  -- note + JOIN row until considerOffer runs on map.entered.
+  -- note + JOIN row until considerOffer runs on map.entered. coop_wild
+  -- auto-joins from considerOffer when free on-map.
   self:considerOffer(game, myMap)
 end
 
@@ -1070,17 +1215,20 @@ function M:onJoined(game, msg)
   -- collide with `id` (the joiner). Without this, uploadMediated has nothing
   -- to name and the fight stays on host CoopSim under PROTOCOL 10.
   local planId = Wire.id(msg and msg.plan)
+  local wild = waiting.kind == "wild" or waiting.mode == "coop_wild"
   self.waiting = nil
   self:note(("%s joined the fight."):format(name))
   self:begin(game, {
-    kind = "npc",
+    kind = wild and "wild" or "npc",
+    mode = wild and "coop_wild" or nil,
     id = planId,
     battle = waiting.battle,
     label = waiting.label,
     engine = waiting.engine,
     trainer = waiting.trainer,
+    wildCatchMon = waiting.wildCatchMon or M.wildMonOf(waiting.engine),
     allies = self.party:list(),
-    -- The player who was waiting is the one standing at the trainer, so they
+    -- The player who was waiting is the one standing at the encounter, so they
     -- are the one that simulates.
     host = true,
     hostId = self.party.selfId,
@@ -1144,8 +1292,12 @@ function M:onBattle(game, msg)
   self:closeAskBox()
   if not (side and allies) then return end
   local hostId = Wire.id(msg.host)
+  local mode = Wire.coopOfferMode(msg and msg.mode)
+  local wild = mode == "coop_wild"
+  local engine = self:joinedEngine(game, msg, foes)
   self:begin(game, {
-    kind = foes and "party" or "npc",
+    kind = foes and "party" or (wild and "wild" or "npc"),
+    mode = mode,
     id = Wire.id(msg.id),
     side = side,
     allies = allies,
@@ -1153,7 +1305,8 @@ function M:onBattle(game, msg)
     -- The battle this client is standing in front of, so the co-op one can
     -- stand in for it and hand it its result.  Nil on both paths that were
     -- never standing in front of anything -- see M:joinedEngine.
-    engine = self:joinedEngine(game, msg, foes),
+    engine = engine,
+    wildCatchMon = wild and M.wildMonOf(engine) or nil,
     -- Derived from the id the hub named rather than assumed, so exactly one of
     -- the four believes it is the host.
     host = hostId ~= nil and self.party:isSelf(hostId),
@@ -1547,6 +1700,13 @@ end
 function M:npcSide(game, plan)
   local engine = plan.engine
   local party = engine and engine.enemyParty
+  -- Wild battles (and coop_wild plans) carry one mon on wildCatchMon / enemy.mon
+  -- rather than enemyParty. Feed that into the same pack path so buildField
+  -- still produces a side-b slot the screen can draw.
+  if not (party and #party > 0) then
+    local mon = plan.wildCatchMon or M.wildMonOf(engine)
+    if mon then party = { mon } end
+  end
   if not (party and #party > 0) then return nil end
 
   local left, right = {}, {}
@@ -1702,15 +1862,28 @@ function M:startBattle(game, field)
     -- between the two paths.
     --
     -- `mode` is derived the same way `kind` on the plan is, and from the same
-    -- fact: a co-op battle with human foes is the hub's `coop_pvp` and one
-    -- without is its `coop_npc`. Derived rather than carried on the wire because
-    -- the hub decided it from this same fact when it opened the record (see
-    -- Hub:openCoopBattle's callers), so a second statement of it is a second
-    -- thing to disagree.
+    -- fact: a co-op battle with human foes is the hub's `coop_pvp`, a wild
+    -- divert is `coop_wild`, and one without foes against a trainer is
+    -- `coop_npc`. The plan may also carry mode explicitly (hub fan-out on
+    -- COOP_BATTLE) so a joiner that never held the encounter still opens the
+    -- right screen.
     transport = self.transport,
     battleId = battle.plan and battle.plan.id,
     selfId = self.party and self.party.selfId,
-    mode = M.ranksPoints(battle.plan) and "coop_pvp" or "coop_npc",
+    mode = (function()
+      local plan = battle.plan
+      if plan and (plan.kind == "wild" or plan.mode == "coop_wild") then
+        return "coop_wild"
+      end
+      if M.ranksPoints(plan) then return "coop_pvp" end
+      return "coop_npc"
+    end)(),
+    wildCatchMon = (function()
+      local plan = battle.plan
+      if not plan then return nil end
+      if plan.kind ~= "wild" and plan.mode ~= "coop_wild" then return nil end
+      return plan.wildCatchMon or M.wildMonOf(plan.engine)
+    end)(),
     -- Whether a win here is worth points, so the screen can say so once
     -- rather than leave a player wondering why their rating did not move.
     ranksPoints = M.ranksPoints(battle.plan),
@@ -1958,7 +2131,7 @@ function M:update(dt)
     if offer.clock >= Config.COOP_OFFER_TIMEOUT then self.offer = nil end
   end
 
-  -- Waiting has no clock, deliberately.
+  -- Waiting has no clock on the trainer path, deliberately.
   --
   -- The offer and the ask both expire, because both are questions somebody may
   -- never answer. Standing at a fight is not a question: the battle cannot be
@@ -1966,6 +2139,20 @@ function M:update(dt)
   -- waiting screen reopens the wait/alone choice, and BATTLE ALONE is how it
   -- ends. A clock here used to be accumulated and never read, which reads as
   -- an expiry somebody forgot to finish.
+  --
+  -- Party vs Wild is the exception: there is no box, so a partner who cannot
+  -- auto-join (busy, lag) would soft-lock the host on a frozen engine wild.
+  -- COOP_ASK_TIMEOUT is short enough that solo wild resumes before the grass
+  -- fight feels abandoned, and withdraw clears the hub offer so the partner
+  -- stops holding it.
+  local waiting = self.waiting
+  if waiting and waiting.kind == "wild" then
+    waiting.clock = (waiting.clock or 0) + dt
+    if waiting.clock >= Config.COOP_ASK_TIMEOUT then
+      self:withdraw("timeout")
+      self:release()
+    end
+  end
 
   local ask = self.ask
   if ask then

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -11,9 +11,11 @@
 --     trainer alone at any time. Accept → both fight it together. Decline →
 --     the waiter is told, encouraged, and released into a solo 1v1.
 --   * **Against a wild.**  Same-map partner online and free → divert into
---     mediated `coop_wild` with no WAIT/ALONE box; the partner auto-joins.
---     Otherwise the engine wild proceeds alone. Soft-lock: a wait with no
---     join within COOP_ASK_TIMEOUT withdraws and releases into solo wild.
+--     mediated `coop_wild`: host posts COOP_WAIT and covers the engine wild
+--     with a wait box (ALONE = withdraw + solo). Partner auto-joins; no
+--     WAIT/JOIN invite. Soft-lock: a wait with no join within COOP_ASK_TIMEOUT
+--     withdraws and releases into solo wild. Mutual waits arbitrate by
+--     lexicographically smaller playerId (their wait wins; see considerOffer).
 --   * **Against another party.**  PARTY BATTLE on the ACTIONS menu, and all
 --     four have to agree before anything starts.
 --
@@ -566,18 +568,38 @@ end
 --
 -- Divert only when partied, the partner is roster-online on *this* map, and
 -- neither side is busy. Busy here is: we are already mid-co-op / mid-ask /
--- holding their invite, another fight is already on the stack (excluding this
--- just-pushed wild), or their presence says session-busy. Otherwise return
--- false and leave the engine wild completely alone.
+-- mid-wait, another fight is already on the stack (excluding this just-pushed
+-- wild), or their presence says session-busy. Otherwise return false and leave
+-- the engine wild completely alone.
 --
--- No WAIT/ALONE UI: beginWildCoop posts COOP_WAIT with mode=coop_wild and the
--- partner auto-joins (see considerOffer). The engine wild stays frozen under
--- the stack until onJoined → startBattle unwinds it.
+-- Exception: a standing `coop_wild` offer from the partner means they already
+-- diverted -- join that fight instead of opening a second wait (and drop the
+-- just-pushed local wild so it cannot be fought under/after the join). A
+-- trainer offer still refuses divert (solo engine wild).
+--
+-- beginWildCoop posts COOP_WAIT and covers the engine wild with a wait box so
+-- the host cannot fight solo while the partner auto-joins (see considerOffer).
 function M:onWildEncounter(game, state, mapId)
   if not (state and state.kind == "wild") then return false end
   if not (self.transport:isReady() and self.party:has()) then return false end
-  if self.running or self.waiting or self.ask or self.offer then return false end
+  if self.running or self.waiting or self.ask then return false end
   if self.joinAsk then return false end
+  if self.offer then
+    if self.offer.mode ~= "coop_wild" then return false end
+    -- Partner already waiting on grass: join them; do not start a local wait.
+    if not self:partnerOnMap(mapId) then return false end
+    if self:inFightExcept(game, state) then return false end
+    local partner = self.party:partner()
+    local row = partner and self.roster:get(partner.id)
+    if row and row.busy then return false end
+    local offer = self.offer
+    -- Pop the just-pushed wild; their battle key will not match ours, so
+    -- joinedEngine would leave this fight under the co-op screen otherwise.
+    if game and game.stack and game.stack:top() == state then
+      game.stack:pop()
+    end
+    return self:autoJoinWild(offer)
+  end
   if not self:partnerOnMap(mapId) then return false end
   local partner = self.party:partner()
   local row = partner and self.roster:get(partner.id)
@@ -602,7 +624,9 @@ function M:onWildEncounter(game, state, mapId)
   return self:beginWildCoop()
 end
 
--- Start a Party vs Wild wait: same wire as trainer WAIT, no box, short clock.
+-- Start a Party vs Wild wait: same wire as trainer WAIT, with a covering box
+-- so the engine wild under it cannot update (frozen until join / ALONE /
+-- timeout). Short clock still applies -- see M:update.
 --
 -- The encounter is held (not released) so a timed-out wait can still hand the
 -- engine wild back via release(), and a successful join can hand it to
@@ -628,6 +652,7 @@ function M:beginWildCoop()
     map = encounter.map,
     mode = "coop_wild",
   })
+  self:showWildWaiting()
   return true
 end
 
@@ -793,6 +818,29 @@ function M:showWaiting()
     })
 end
 
+-- Cover the engine wild while a Party vs Wild offer stands.
+--
+-- Single row: ALONE is last (and only), so B maps to withdraw+release and the
+-- host fights the engine wild solo -- same ending as trainer ALONE, without a
+-- BACK row that would reopen a WAIT/ALONE ask this path never showed. The
+-- choose screen is stack-top, so the wild underneath cannot update until this
+-- pops (join → startBattle, ALONE/timeout → release, or arbitration unwind).
+function M:showWildWaiting()
+  local waiting = self.waiting
+  if not (waiting and waiting.mode == "coop_wild") then return end
+  local name = self.party:partnerName() or "your friend"
+  local prompt = ("Waiting for %s..."):format(name)
+  self.ui:choose(waiting.game, prompt, {
+    {
+      label = "ALONE",
+      onSelect = function()
+        self:withdraw("alone")
+        self:release()
+      end,
+    },
+  })
+end
+
 -- Take our offer off the table.  Safe to call when there is none: every exit
 -- from a fight goes through here, and making each of them check first would be
 -- four places to forget.
@@ -845,22 +893,62 @@ end
 -- `coop_wild` never asks: partner auto-joins when free on the same map, which
 -- is the whole Party vs Wild product rule. Busy / off-map leaves the offer
 -- standing so the host's short wait can time out into solo wild.
+--
+-- Mutual coop_wild waits: lexicographically smaller playerId's wait wins.
+-- If offer.from < selfId we withdraw our wait and join theirs; otherwise we
+-- keep ours and drop the inbound offer so both sides cannot time out stuck.
 function M:considerOffer(game, myMap)
   local offer = self.offer
   if not offer then return false end
-  if self.joinAsk or self.ask or self.waiting or self.running then return false end
-  if self:inFight(game) then return false end
+  if self.joinAsk or self.ask or self.running then return false end
   if not (offer.map and myMap and offer.map == myMap) then return false end
+
   if offer.mode == "coop_wild" then
+    if self.waiting then
+      if self.waiting.mode ~= "coop_wild" then return false end
+      local selfId = self.party and self.party.selfId
+      local from = offer.from
+      if not (selfId and from) then return false end
+      if from < selfId then
+        return self:autoJoinWild(offer)
+      end
+      -- Ours wins; clear inbound so waiting+offer cannot block later gates.
+      self.offer = nil
+      return false
+    end
+    -- Covered wild under a wait box counts as inFight; free joiners must not
+    -- be mid-fight. Mutual wait is handled above before this check.
+    if self:inFight(game) then return false end
     return self:autoJoinWild(offer)
   end
+
+  if self.waiting or self:inFight(game) then return false end
   return self:askToJoin(game, offer)
 end
 
 -- Answer a Party vs Wild offer without a confirm box.
+--
+-- When called while we already hold a coop_wild wait (mutual divert / menu
+-- JOIN after arbitration chose their offer), withdraw ours and discard the
+-- local engine wild first -- their battle key will not match ours.
+-- Same rule as considerOffer: only join over our wait when offer.from < selfId.
 function M:autoJoinWild(offer)
   if not (offer and offer.mode == "coop_wild") then return false end
   if not self.transport:isReady() then return false end
+  if self.running or self.ask then return false end
+  if self.waiting then
+    if self.waiting.mode ~= "coop_wild" then return false end
+    local selfId = self.party and self.party.selfId
+    local from = offer.from
+    if not (selfId and from and from < selfId) then return false end
+    -- Quiet cancel: onOfferEnd does not announce timeout the way alone/left do.
+    self:withdraw("timeout")
+    local enc = self.encounter
+    self.encounter = nil
+    if enc and enc.engine then
+      self:unwindTo(enc.game, enc.engine, true)
+    end
+  end
   local from, battle = offer.from, offer.battle
   -- Cleared before the send so a second considerOffer tick cannot double-join.
   -- A late alone from the hub still lands as COOP_OFFER_END with no box up.
@@ -2140,11 +2228,11 @@ function M:update(dt)
   -- ends. A clock here used to be accumulated and never read, which reads as
   -- an expiry somebody forgot to finish.
   --
-  -- Party vs Wild is the exception: there is no box, so a partner who cannot
-  -- auto-join (busy, lag) would soft-lock the host on a frozen engine wild.
-  -- COOP_ASK_TIMEOUT is short enough that solo wild resumes before the grass
-  -- fight feels abandoned, and withdraw clears the hub offer so the partner
-  -- stops holding it.
+  -- Party vs Wild is the exception: the partner is auto-pulled with no JOIN
+  -- confirm, so a busy/lagging partner would leave the host on a covering wait
+  -- box forever. COOP_ASK_TIMEOUT is short enough that solo wild resumes before
+  -- the grass fight feels abandoned, and withdraw clears the hub offer so the
+  -- partner stops holding it.
   local waiting = self.waiting
   if waiting and waiting.kind == "wild" then
     waiting.clock = (waiting.clock or 0) + dt

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -21,12 +21,12 @@
 -- own host-authoritative branch already takes for `action`/`event` in a link
 -- battle, one player wider.
 --
--- The upshot for this file: for **hub-refereed** coop modes (always
--- `coop_pvp` / `coop_npc`), the intermediator decides and this screen draws
--- an ordered `mmo.battle_event` stream — same as MediatedBattle. `CoopSim`
--- is still constructed to hold the field the screen is drawn from, and is
--- not asked to *decide* anything. See "the intermediator, when there is one"
--- near the bottom.
+-- The upshot for this file: for **hub-refereed** coop modes (always the three
+-- in Config.MEDIATED_COOP — `coop_pvp` / `coop_npc` / `coop_wild`), the
+-- intermediator decides and this screen draws an ordered `mmo.battle_event`
+-- stream — same as MediatedBattle. `CoopSim` is still constructed to hold the
+-- field the screen is drawn from, and is not asked to *decide* anything. See
+-- "the intermediator, when there is one" near the bottom.
 --
 -- ------- what this covers
 --
@@ -43,17 +43,20 @@
 -- a potion heals and an item that refuses mid-battle refuses in the engine's
 -- words. SWITCH costs the turn, as it does in the original.
 --
--- A thrown ball is **refused**, and that is the complete behaviour rather than
--- a missing one: every monster on the far side belongs to a trainer, and Gen 1
--- does not let you catch somebody else's. It is refused in the original's own
--- words, taken from the game's text table.
+-- A thrown ball is **refused** against a trainer (`coop_npc` / host-sim), and
+-- that is the complete behaviour rather than a missing one: every monster on
+-- the far side belongs to somebody, and Gen 1 does not let you catch somebody
+-- else's. It is refused in the original's own words, taken from the game's
+-- text table. Against **`coop_wild`** the far side is wildlife, so balls are
+-- legal — the referee resolves them (speed-ordered among ball choices).
 --
--- RUN is two questions wearing one label, and they are answered separately.
+-- RUN is three questions wearing one label, and they are answered separately.
 -- Against an **NPC trainer** it is the original's question and keeps the
 -- original's refusal, word for word. Against **two other players** it is a
 -- question Gen 1 never had to ask -- and the answer is yes, with the consent of
--- the partner who shares the loss. See "RUN, in a battle where the other side
--- is people" below for the whole of it.
+-- the partner who shares the loss. Against a **partied wild** (`coop_wild`) it
+-- is solo-wild semantics: either player flees unilaterally, no consent ask.
+-- See "RUN, in a battle where the other side is people" below for the PvP half.
 
 local need, mod = ...
 local Config = need("Config")
@@ -213,7 +216,12 @@ end
 --   battleId  the hub's id for this fight, which every mediated message names
 --   selfId    this client's own hub id, which is how an outcome naming four
 --             players is read as a result for one
---   mode      "coop_npc" | "coop_pvp", the hub's word for which shape this is
+--   mode      "coop_npc" | "coop_pvp" | "coop_wild", the hub's word for which
+--             shape this is (Config.MEDIATED_COOP)
+--   wildCatchMon  engine mon kept for Party.add / Boxes.deposit on a catch
+--                 (coop_wild; host and preferably partner both stash one)
+--   wildParty     optional prebuilt battleMon sheets for the host's side-"b"
+--                 upload; else snapshotMons of wildCatchMon
 function M.new(game, opts)
   local eng = loadEngine()
   if not eng then return nil, "2-on-2 battles need the engine's battle modules." end
@@ -259,6 +267,10 @@ function M.new(game, opts)
     battleId = opts.battleId,
     selfId = opts.selfId,
     mode = opts.mode,
+    -- coop_wild grant material: engine mon for Party.add, optional sheets for
+    -- the host's side-b upload (else snapshot of wildCatchMon at upload time).
+    wildCatchMon = opts.wildCatchMon,
+    wildParty = opts.wildParty,
     mediated = false,
     medUploaded = false,
     medFailed = false, -- upload refused; do not fall back to host-sim
@@ -1102,8 +1114,11 @@ function M:updateCommand(input)
       self.itemIndex = 1
       self.phase = "item"
     elseif command == "RUN" then
-      -- Two different questions behind one command, told apart by who is on
-      -- the other side of the field (M:partyBattle).
+      -- Three different questions behind one command.
+      --
+      -- Against a **partied wild** (`coop_wild`) it is solo-wild semantics:
+      -- either player flees unilaterally. No COOP_RUN_ASK / partner consent —
+      -- the choice goes straight to the referee (or host-sim commit).
       --
       -- Against a **trainer** it is the original's question, and the original's
       -- answer: you cannot run from a trainer battle. Filed as an action rather
@@ -1115,7 +1130,9 @@ function M:updateCommand(input)
       -- ends the battle for four people and books the pair who left a ranked
       -- loss, so the other half of that pair is asked first (M:askToRun).
       -- Nothing is committed until they answer -- see the state machine there.
-      if self:partyBattle() then
+      if self.mode == "coop_wild" then
+        self:commit({ slot = self.mine, kind = "run" })
+      elseif self:partyBattle() then
         self:askToRun()
       else
         self:commit({ slot = self.mine, kind = "run" })
@@ -1678,8 +1695,12 @@ function M:mediatedRunAsk()
   return true
 end
 
--- Ask the partner. Commits nothing.
+-- Ask the partner. Commits nothing — except `coop_wild`, which never asks:
+-- flee is unilateral (solo-wild), so this routes to a run choice instead.
 function M:askToRun()
+  if self.mode == "coop_wild" then
+    return self:commit({ slot = self.mine, kind = "run" })
+  end
   if not self:partyBattle() then return false end
   if self.mediated then return self:mediatedRunAsk() end
   local partner = self:partnerOf(self:mySlot())
@@ -4648,11 +4669,12 @@ end
 -- batch (`turn`, or `over`), which makes an arriving turn look exactly like the
 -- single `res` the client-simulated path sends.
 
--- Is this mode hub-refereed? Always for shipped coop_pvp / coop_npc — not a
--- Config toggle. Host-sim for those modes was removed (BattleSim vs engine
+-- Is this mode hub-refereed? Always for Config.MEDIATED_COOP
+-- (`coop_pvp` / `coop_npc` / `coop_wild`) — not a Config toggle beyond that
+-- table. Host-sim for those modes was removed (BattleSim vs engine
 -- ItemEffects must not diverge). CoopSim remains for field layout / tests.
 function M.mediates(mode)
-  return mode == "coop_pvp" or mode == "coop_npc"
+  return mode == "coop_pvp" or mode == "coop_npc" or mode == "coop_wild"
 end
 
 -- ------- 1. what we are bringing
@@ -4669,6 +4691,9 @@ end
 --
 -- One party and not two, because the intermediator seats one npc: see
 -- Config.MEDIATED_COOP's first reason.
+--
+-- **Not used for `coop_wild`.** Wild is one mon on side b; interleave would
+-- invent a second trainer slot. See `uploadMediated`'s coop_wild branch.
 function M:npcMons()
   if not self.sim then return nil end
   local parties = {}
@@ -4691,6 +4716,19 @@ function M:npcMons()
     index = index + 1
   end
   return Mediated.snapshotMons(self.game, flat)
+end
+
+-- Sheets for the wild seat (coop_wild side b): prebuilt `wildParty`, else a
+-- snapshot of the stashed `wildCatchMon`. Never npcMons interleave — that
+-- assumes two ownerless trainer slots.
+function M:wildMons()
+  if type(self.wildParty) == "table" and #self.wildParty > 0 then
+    return self.wildParty
+  end
+  if self.wildCatchMon then
+    return Mediated.snapshotMons(self.game, { self.wildCatchMon })
+  end
+  return nil
 end
 
 -- Offer this fight to the intermediator.
@@ -4743,6 +4781,17 @@ function M:uploadMediated()
     else
       mod.log:warn("the trainer's party could not be described for a refereed "
         .. "2-on-2 -- report which trainer it was")
+      self.medFailed = true
+    end
+  elseif self.host and self.mode == "coop_wild" then
+    -- One wild mon on side b (not npcMons — that re-interleaves two trainer
+    -- slots). Sheets from wildParty or a snapshot of wildCatchMon.
+    local wild = self:wildMons()
+    if wild and #wild > 0 then
+      Mediated.sendParty(self.transport, self.battleId, wild, "b")
+    else
+      mod.log:warn("the wild POKeMON could not be described for a refereed "
+        .. "party encounter -- report this with the map and the encounter")
       self.medFailed = true
     end
   end
@@ -4843,6 +4892,7 @@ local MED_REASONS = {
   run        = "Someone ran away!",
   forfeit    = "Someone gave up.",
   agree      = "The battle was\ncalled off.",
+  catch      = "Gotcha!",
 }
 
 -- One wire event, as rows `playEvents` understands.
@@ -5158,7 +5208,42 @@ function M:onBattleOutcome(msg)
     self.medPending[#self.medPending + 1] = { kind = "msg", text = why }
   end
   self:medFlush()
+  -- Catcher-only grant: everyone sees Gotcha; only msg.catcher adds the mon.
+  if msg.reason == "catch" then
+    local catcher = msg.catcher
+    if catcher ~= nil and (catcher == self.selfId
+        or tostring(catcher) == tostring(self.selfId)) then
+      self:grantCatch(msg)
+    end
+  end
   return true
+end
+
+-- Put the caught wild into this client's party (or PC). Mirrors
+-- MediatedBattle:grantCatch — duplicated so CoopBattle owns the coop_wild
+-- path without sharing a module with the 1v1 screen.
+function M:grantCatch(msg)
+  local mon = self.wildCatchMon
+  if not mon and msg and msg.caught then
+    -- Sheet-only path: cannot rebuild a full engine mon without ROM data.
+    self:say("Caught, but could not\nadd to the party.")
+    return
+  end
+  if not mon then return end
+  local game = self.game
+  local save = game and game.save
+  if not save then return end
+  local okParty, Party = pcall(require, "src.pokemon.Party")
+  if okParty and Party.add(save.party, mon) then
+    self:say((mon.nickname or mon.species or "It") .. " was\nadded to the party!")
+    return
+  end
+  local okBoxes, Boxes = pcall(require, "src.pokemon.Boxes")
+  if okBoxes and Boxes.deposit(save, mon) then
+    self:say((mon.nickname or mon.species or "It") .. " was\nsent to the PC!")
+    return
+  end
+  self:say("But every BOX\nis full!")
 end
 
 -- ------- one turn's intent

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -199,6 +199,126 @@ function M.trainerParty(game, oppClass, partyIndex)
   return out
 end
 
+-- Map a battleMon / caught-sheet species token to a pokedex registry id.
+-- Sheets narrate under Wire.name(display); Pokemon.new needs the registry key.
+-- Prefer speciesId when present (upload-time snapshots); else the species
+-- field as an id; else a display-name scan — same idea as MediatedBattle's
+-- speciesKeyFor, without needing a live party.
+local function speciesKeyFromSheet(game, sheet)
+  if type(sheet) ~= "table" then return nil end
+  local data = game and game.data
+  local pokedex = data and data.pokemon
+  if type(pokedex) ~= "table" then return nil end
+  local id = sheet.speciesId
+  if type(id) == "string" and id ~= "" and pokedex[id] then return id end
+  local label = sheet.species
+  if type(label) ~= "string" or label == "" then return nil end
+  if pokedex[label] then return label end
+  for key, def in pairs(pokedex) do
+    if type(def) == "table" then
+      local name = Wire.name(def.name or key)
+      if name == label then return key end
+    end
+  end
+  return nil
+end
+
+-- Rebuild a depositable engine mon from a catch-outcome battleMon sheet.
+-- Used when this client never held the encounter (joiner / partner catcher):
+-- wildCatchMon is nil, but the outcome still carries Effects.caughtSheet.
+-- Best-effort: DVs/EVs from ivs/evs when present, else combat stats from the
+-- sheet; moves and current HP always prefer the sheet. Returns nil when the
+-- species cannot be resolved or Pokemon.new fails.
+function M.monFromCaughtSheet(game, sheet)
+  if type(sheet) ~= "table" then return nil end
+  local eng = loadEngine()
+  if not (eng and eng.Pokemon and eng.Stats) then return nil end
+  local species = speciesKeyFromSheet(game, sheet)
+  if not species then return nil end
+  local level = tonumber(sheet.level) or 1
+  if level < 1 then level = 1 end
+  local ok, mon = pcall(eng.Pokemon.new, game.data, species, level)
+  if not (ok and mon) then return nil end
+
+  local wireToEngine = { atk = "attack", def = "defense", spd = "speed", spc = "special" }
+
+  if type(sheet.ivs) == "table" then
+    local dvs = {}
+    for wireKey, engineKey in pairs(wireToEngine) do
+      local n = tonumber(sheet.ivs[wireKey])
+      if not n then dvs = nil break end
+      dvs[engineKey] = math.max(0, math.min(15, math.floor(n)))
+    end
+    if dvs then
+      dvs.hp = (dvs.attack % 2) * 8 + (dvs.defense % 2) * 4
+        + (dvs.speed % 2) * 2 + (dvs.special % 2)
+      mon.dvs = dvs
+    end
+  end
+
+  if type(sheet.evs) == "table" then
+    local statExp = mon.statExp or {
+      hp = 0, attack = 0, defense = 0, speed = 0, special = 0,
+    }
+    for wireKey, engineKey in pairs(wireToEngine) do
+      local n = tonumber(sheet.evs[wireKey])
+      if n then
+        statExp[engineKey] = math.max(0, math.min(65535, math.floor(n)))
+      end
+    end
+    if sheet.evs.hp ~= nil then
+      local n = tonumber(sheet.evs.hp)
+      if n then statExp.hp = math.max(0, math.min(65535, math.floor(n))) end
+    end
+    mon.statExp = statExp
+  end
+
+  if mon.dvs then
+    local def = game.data.pokemon[species]
+    local statsOk, stats = pcall(eng.Stats.calc, def, level, mon.dvs, mon.statExp)
+    if statsOk and stats then mon.stats = stats end
+  elseif type(sheet.stats) == "table" then
+    mon.stats = mon.stats or {}
+    for wireKey, engineKey in pairs(wireToEngine) do
+      local n = tonumber(sheet.stats[wireKey])
+      if n then mon.stats[engineKey] = math.max(1, math.floor(n)) end
+    end
+    local maxHp = tonumber(sheet.maxHp)
+    if maxHp then mon.stats.hp = math.max(1, math.floor(maxHp)) end
+  elseif sheet.maxHp ~= nil then
+    mon.stats = mon.stats or {}
+    local maxHp = tonumber(sheet.maxHp)
+    if maxHp then mon.stats.hp = math.max(1, math.floor(maxHp)) end
+  end
+
+  if type(sheet.moves) == "table" and #sheet.moves > 0 then
+    local moves = {}
+    for _, slot in ipairs(sheet.moves) do
+      if type(slot) == "table" and type(slot.id) == "string" and slot.id ~= "" then
+        local mdef = game.data.moves and game.data.moves[slot.id]
+        local pp = tonumber(slot.pp)
+        if not pp then pp = mdef and mdef.pp or 0 end
+        moves[#moves + 1] = { id = slot.id, pp = math.max(0, math.floor(pp)) }
+      end
+    end
+    if #moves > 0 then mon.moves = moves end
+  end
+
+  local hp = tonumber(sheet.hp)
+  if hp then
+    local maxHp = (mon.stats and mon.stats.hp) or tonumber(sheet.maxHp) or 1
+    mon.hp = math.max(0, math.min(math.floor(hp), maxHp))
+  end
+
+  if sheet.catchRate ~= nil then
+    local rate = tonumber(sheet.catchRate)
+    if rate then mon.catchRate = math.max(0, math.min(255, math.floor(rate))) end
+  end
+  if sheet.status ~= nil then mon.status = sheet.status end
+
+  return mon
+end
+
 -- ------- construction
 --
 -- opts:
@@ -5222,12 +5342,18 @@ end
 -- Put the caught wild into this client's party (or PC). Mirrors
 -- MediatedBattle:grantCatch — duplicated so CoopBattle owns the coop_wild
 -- path without sharing a module with the 1v1 screen.
+--
+-- Host usually has wildCatchMon from the engine encounter. Partner / joiner
+-- often does not; rebuild from msg.caught (Effects.caughtSheet) so a catcher
+-- who never held the wild can still Party.add / Boxes.deposit.
 function M:grantCatch(msg)
   local mon = self.wildCatchMon
   if not mon and msg and msg.caught then
-    -- Sheet-only path: cannot rebuild a full engine mon without ROM data.
-    self:say("Caught, but could not\nadd to the party.")
-    return
+    mon = M.monFromCaughtSheet(self.game, msg.caught)
+    if not mon then
+      self:say("Caught, but could not\nadd to the party.")
+      return
+    end
   end
   if not mon then return end
   local game = self.game

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -121,6 +121,12 @@ local function loadEngine()
     engine = false
     return engine
   end
+  -- Optional SFX (Ball_Poof, entrance cries). Missing Sound must not fail the
+  -- whole load — headless / no-audio builds still fight without it.
+  do
+    local good, value = pcall(require, "src.core.Sound")
+    if good then parts.Sound = value end
+  end
   engine = parts
   return engine
 end
@@ -636,6 +642,113 @@ function M:wildIntroName()
   return "POKeMON"
 end
 
+-- Display name for an on-field battler (Go! / sent out lines).
+local function seatMonName(slot)
+  local battler = slot and slot.battler
+  if not battler then return "?" end
+  return battler.name
+    or (battler.mon and (battler.mon.nickname or battler.mon.species))
+    or "?"
+end
+
+-- Wire-safe trainer/player label for "Name sent out Y!".
+local function seatOwnerName(slot)
+  if not slot then return "Someone" end
+  local raw = slot.name
+  if type(raw) == "string" and raw ~= "" then
+    return Wire.name(raw) or raw
+  end
+  return "Someone"
+end
+
+-- Clear intro presentation flags (exit, forfeit, or battle over).
+function M:clearIntroFlags()
+  self.introBalls = nil
+  self.introHide = nil
+  self.growIn = nil
+end
+
+-- Entrance cry via optional Sound (same clips BattleState:playEntranceCry).
+function M:playEntranceCry(battler)
+  local mon = battler and battler.mon
+  if not mon then return end
+  local Sound = engine and engine.Sound
+  if not (Sound and Sound.playCry) then return end
+  pcall(Sound.playCry, self.game.data, mon.species,
+    mon.status == "SLP" and 37 or 11)
+end
+
+-- Grow-in scale for a slot this frame (nil when not growing). Stages match
+-- BattleState:growInScale: 0 / 3/7 / 5/7 over ~12 frames, then full.
+function M:growInScale(index)
+  local grow = self.growIn
+  if not grow or grow.slot ~= index then return nil end
+  local f = grow.frame or 0
+  return f < 3 and 0 or f < 7 and 3 / 7 or 5 / 7
+end
+
+-- After the opening appear line: wait, then sequential viewer-centric
+-- send-outs (my Go! → POOF/grow/cry, then partner sent out). Ball chrome is
+-- cleared when the appear page advances (see messages dismiss), not here.
+function M:queueIntroSendOut()
+  local sendWait = 40
+  do
+    local ok, Timing = pcall(require, "src.core.Timing")
+    if ok and Timing and Timing.BATTLE_START_SENDOUT then
+      sendWait = Timing.BATTLE_START_SENDOUT
+    end
+  end
+  self.messages[#self.messages + 1] = { wait = sendWait }
+
+  local mine = self.mine
+  local mySlot = self:mySlot()
+  self:say(("Go! %s!"):format(seatMonName(mySlot)))
+  self.messages[#self.messages + 1] = {
+    anim = "POOF_ANIM", from = mine, attackerIsPlayer = true,
+  }
+  self.messages[#self.messages + 1] = {
+    act = function(battle)
+      if battle.introHide then battle.introHide[mine] = nil end
+      local slot = battle.sim and battle.sim:slot(mine)
+      local battler = slot and slot.battler
+      if battler then
+        battle.growIn = { slot = mine, frame = 0 }
+        battle:playEntranceCry(battler)
+      end
+    end,
+  }
+  self.messages[#self.messages + 1] = { wait = 12 }
+
+  local partner = self:partnerOf(mySlot)
+  if not partner then
+    -- Seats we hid in enter() but will not animate must not stay blank.
+    if self.introHide then
+      for idx, _ in pairs(self.introHide) do
+        if idx ~= mine then self.introHide[idx] = nil end
+      end
+    end
+    return
+  end
+  local pIndex = partner.index
+  self:say(("%s sent out\n%s!"):format(
+    seatOwnerName(partner), seatMonName(partner)))
+  self.messages[#self.messages + 1] = {
+    anim = "POOF_ANIM", from = pIndex, attackerIsPlayer = true,
+  }
+  self.messages[#self.messages + 1] = {
+    act = function(battle)
+      if battle.introHide then battle.introHide[pIndex] = nil end
+      local slot = battle.sim and battle.sim:slot(pIndex)
+      local battler = slot and slot.battler
+      if battler then
+        battle.growIn = { slot = pIndex, frame = 0 }
+        battle:playEntranceCry(battler)
+      end
+    end,
+  }
+  self.messages[#self.messages + 1] = { wait = 12 }
+end
+
 function M:enter()
   -- The trainer theme, through the engine's own picker so a gym leader still
   -- gets a gym leader's music. `kind` is the battle's, not this screen's: a
@@ -646,6 +759,15 @@ function M:enter()
     pcall(eng.Music.playBattle, self.game.data, self:musicKind(),
       self.trainer and self.trainer.id or nil)
   end
+  -- Intro ball chrome + hide ally humans until their Go!/sent-out step.
+  -- Foes (wild / NPC) stay visible; no introSlide / trainer-back this pass.
+  self.introBalls = true
+  self.introHide = {}
+  for _, slot in ipairs((self.sim and self.sim.slots) or {}) do
+    if slot.owner ~= nil and not self:foeSide(slot.index) then
+      self.introHide[slot.index] = true
+    end
+  end
   -- Party vs Wild is a grass encounter shared with a partner, not a 2-on-2:
   -- open with the same sentence solo wild uses (BattleState introText).
   if self.mode == "coop_wild" then
@@ -653,6 +775,7 @@ function M:enter()
   else
     self:say("2 on 2 battle!")
   end
+  self:queueIntroSendOut()
   self.phase = "messages"
   self.after = "choose"
   self:announce("coop_battle_started")
@@ -707,6 +830,7 @@ end
 
 function M:exit()
   self:refundUnspent()
+  self:clearIntroFlags()
 
   -- The world gets its music back on the way out, win or lose. The victory
   -- theme loops until something stops it -- each Defeated* song ends in a
@@ -840,6 +964,11 @@ local MSG_AUTO_ADVANCE = 1.6
 
 function M:update(dt)
   self.frame = self.frame + 1
+  -- Grow-in advances on the same fixed step as the engine's AnimateSendingOutMon.
+  if self.growIn then
+    self.growIn.frame = (self.growIn.frame or 0) + 1
+    if self.growIn.frame >= 12 then self.growIn = nil end
+  end
   if self.sim and not self.result then
     self:stepFocusSlides()
   end
@@ -911,17 +1040,35 @@ function M:update(dt)
       -- in the middle of the thing it is describing.
       local head = self.messages[1]
       if type(head) == "table"
-         and (head.anim or head.drain or head.faintfx) then
-        table.remove(self.messages, 1)
-        if head.anim then
-          self.acting = head.from or self.acting
-          self:startAnim(head)
-        elseif head.drain then
-          self:startDrain(head)
+         and (head.anim or head.drain or head.faintfx
+              or head.wait or head.act) then
+        -- Hold wait/act/anim behind opening appear line(s). Drop ball chrome
+        -- when the post-appear wait starts (not on every page advance), so a
+        -- multi-page appear does not begin the gap early.
+        if (head.wait or head.act or head.anim)
+           and self.shown ~= nil and self.introBalls then
+          -- fall through to dwell
+        elseif head.wait then
+          if self.introBalls then self.introBalls = nil end
+          head._t = (head._t or 0) + 1
+          if head._t >= (tonumber(head.wait) or 0) then
+            table.remove(self.messages, 1)
+          end
+          return
         else
-          self:startFaint(head)
+          table.remove(self.messages, 1)
+          if head.act then
+            if type(head.act) == "function" then pcall(head.act, self) end
+          elseif head.anim then
+            self.acting = head.from or self.acting
+            self:startAnim(head)
+          elseif head.drain then
+            self:startDrain(head)
+          else
+            self:startFaint(head)
+          end
+          return
         end
-        return
       end
       if self.shown == nil then
         local next = table.remove(self.messages, 1)
@@ -962,10 +1109,14 @@ function M:update(dt)
       -- on screen long enough to be read (see MSG_MIN_DWELL). The clock is not
       -- ticked while an effect runs, so the floor is a quarter of a second of
       -- the line actually being *up*, not of wall time under a flash.
+      local advance = false
       if self.msgClock >= MSG_MIN_DWELL
          and (input:wasPressed("a") or input:wasPressed("b")) then
-        self.shown = nil
+        advance = true
       elseif self.msgClock > MSG_AUTO_ADVANCE then
+        advance = true
+      end
+      if advance then
         self.shown = nil
       end
       return
@@ -2345,7 +2496,7 @@ function M:playEvents(events)
       -- the order the turn produced it rather than all at once at the end.
       self.messages[#self.messages + 1] =
         { anim = event.anim, from = event.from, to = event.to,
-          attackerIsPlayer = event.attackerIsPlayer }
+          attackerIsPlayer = event.attackerIsPlayer, amount = event.amount }
     elseif event.kind == "damage" then
       -- The replayers are told the resulting HP rather than the amount, so a
       -- dropped or reordered event cannot leave a bar drifting away from the
@@ -2795,6 +2946,7 @@ end
 function M:finish()
   if self.finished then return end
   self.finished = true
+  self:clearIntroFlags()
   self:snapDisplay()
   self.game.stack:pop()
 end
@@ -3698,6 +3850,7 @@ end
 
 function M:drawField()
   local hideFoes = self:showingTrainer()
+  local introHide = self.introHide
 
   for _, index in ipairs(self:paintOrder()) do
     local slot = self.sim:slot(index)
@@ -3707,13 +3860,38 @@ function M:drawField()
     local sprite = (sinking and sinking.battler and sinking.battler.sprite)
       or (battler and battler.sprite)
     local x, y, scale = self:picOriginFor(index, sprite)
-    if sprite and x and not (hideFoes and theirs) then
+    local hideIntro = introHide and introHide[index]
+    if sprite and x and not (hideFoes and theirs)
+       and not (theirs and self.foePicHidden)
+       and not hideIntro then
       if sinking then
         love.graphics.setColor(1, 1, 1, 1)
         pcall(drawSinking, sprite, x, y, sinking.frames, scale)
       elseif not hidden(slot, battler) then
-        love.graphics.setColor(1, 1, 1, 1)
-        love.graphics.draw(sprite, x, y, 0, scale, scale)
+        local gs = self:growInScale(index)
+        if gs == 0 then
+          -- Ball beat: blank until the first grow stage.
+        else
+          local drawScale = scale
+          local dx, dy = x, y
+          if gs then
+            drawScale = scale * gs
+            local sw, sh = 56, 56
+            local ok, w, h = pcall(sprite.getDimensions, sprite)
+            if ok and type(w) == "number" then sw, sh = w, h end
+            -- Feet + horizontal centre pinned (BattleState AnimateSendingOutMon).
+            dx = x + sw * scale * (1 - gs) / 2
+            if not theirs then
+              local inset = ALLY_FOOT_INSET
+              if inset > sh - 8 then inset = 0 end
+              dy = FIELD_FLOOR - (sh - inset) * drawScale
+            else
+              dy = y + sh * scale * (1 - gs)
+            end
+          end
+          love.graphics.setColor(1, 1, 1, 1)
+          love.graphics.draw(sprite, dx, dy, 0, drawScale, drawScale)
+        end
       end
     end
   end
@@ -3731,7 +3909,8 @@ function M:drawField()
   if foe then
     local battler = self:shownBattlerAt(foe)
     local slot = self.sim:slot(foe)
-    if battler and not hidden(slot, battler) then
+    if battler and not hidden(slot, battler)
+       and not (introHide and introHide[foe]) then
       Font.drawBox(FOE_HUD.tx, FOE_HUD.ty, FOE_HUD.tw, FOE_HUD.th)
       drawReadout(self, battler, FOE_HUD, 1, foe == self.mine)
     end
@@ -3740,10 +3919,29 @@ function M:drawField()
   if ally then
     local battler = self:shownBattlerAt(ally)
     local slot = self.sim:slot(ally)
-    if battler and not hidden(slot, battler) then
+    if battler and not hidden(slot, battler)
+       and not (introHide and introHide[ally]) then
       Font.drawBox(ALLY_HUD.tx, ALLY_HUD.ty, ALLY_HUD.tw, ALLY_HUD.th)
       drawReadout(self, battler, ALLY_HUD, 1, ally == self.mine)
     end
+  end
+  self:drawIntroBalls()
+end
+
+-- Party ball chrome under the opening appear line (both humans' parties).
+-- Positions approximate classic player row + a second row for the partner.
+function M:drawIntroBalls()
+  if not self.introBalls then return end
+  local BS = engine and engine.BattleState
+  if not (BS and BS.drawBallRow and love and love.graphics) then return end
+  local mySlot = self:mySlot()
+  local partner = self:partnerOf(mySlot)
+  love.graphics.setColor(1, 1, 1, 1)
+  if mySlot and mySlot.party then
+    pcall(BS.drawBallRow, BS, mySlot.party, 88, 80, 8)
+  end
+  if partner and partner.party then
+    pcall(BS.drawBallRow, BS, partner.party, 88, 64, 8)
   end
 end
 
@@ -3778,6 +3976,18 @@ local CLASSIC_ENEMY = { x = STAGE_FOE.x, y = STAGE_FOE.y }
 
 function M:startAnim(row)
   self.anim = row
+  -- Ball chain: HIDEPIC / SHOWPIC gate foe stage pics (engine enemyHidden).
+  if row.anim == "HIDEPIC_ANIM" then
+    self.foePicHidden = true
+  elseif row.anim == "SHOWPIC_ANIM" then
+    self.foePicHidden = nil
+  elseif row.anim == "POOF_ANIM" then
+    -- Intro send-out and catch ball chain both play SFX_BALL_POOF.
+    local Sound = engine and engine.Sound
+    if Sound and Sound.play then
+      pcall(Sound.play, self.game.data, "Ball_Poof")
+    end
+  end
   if not (self.animPlayer and self.animPlayer.start) then
     -- No animation data in this build: the flash is skipped and the messages
     -- carry on, which is the degrade the header promises.
@@ -3796,7 +4006,13 @@ function M:startAnim(row)
   else
     isPlayer = true
   end
-  local ok = pcall(self.animPlayer.start, self.animPlayer, row.anim, isPlayer)
+  local ball = self.medBall
+  local opts = {
+    shakes = row.amount,
+    ball = ball,
+    ballFlicker = ball == "MASTER_BALL" or ball == "ULTRA_BALL" or nil,
+  }
+  local ok = pcall(self.animPlayer.start, self.animPlayer, row.anim, isPlayer, opts)
   if not ok then self.anim = nil end
   return ok
 end
@@ -5129,13 +5345,22 @@ function M:medRows(msg)
   elseif kind == "anim" then
     -- Play via the existing AnimPlayer path; if mapping fails `startAnim`
     -- no-ops safely. The "X used MOVE" line rides in the `msg` beside this.
+    -- `amount` is shake count on SHAKE_ANIM; ball id is stashed from `item`.
     if index then
       rows[#rows + 1] = {
         kind = "anim", anim = msg.text, from = index,
+        amount = msg.amount,
         -- Viewer-relative: this client's ally side faces as the player.
         attackerIsPlayer = not self:foeSide(index),
       }
     end
+
+  elseif kind == "item" then
+    -- Ball id for AnimPlayer opts on the following toss/shake chain.
+    local Effects = need("BattleSim/Effects")
+    local effect = msg.text and Effects.itemEffect(msg.text)
+    if effect and effect.ball then self.medBall = msg.text end
+    say(msg.text)
 
   elseif kind == "switch" then
     -- Already said in the `msg` beside it, and the `send` that follows every
@@ -5153,7 +5378,7 @@ function M:medRows(msg)
     -- trainer's name as a battle line.
 
   else
-    -- status, stat, item, run, wait, reconnect: the referee's own sentence is
+    -- status, stat, run, wait, reconnect: the referee's own sentence is
     -- the whole of what they contribute to a screen today. The state they
     -- describe rides on the events beside them -- a status that gated a move is
     -- followed by the `damage` that did or did not happen.
@@ -5282,6 +5507,10 @@ function M:onBattleEvent(msg)
   elseif msg.t == "over" then
     self.medMustReplace = nil
     self.replacing = nil
+    -- Ball opts / foe hide outlive the turn event: anims still drain from the
+    -- message queue after medFlush. Cleared when the fight ends.
+    self.medBall = nil
+    self.foePicHidden = nil
     self:medFlush()
   end
   return true

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -586,6 +586,11 @@ end
 -- leader's theme with the wrong jingle.
 function M.musicKind(self)
   if self.cachedMusicKind then return self.cachedMusicKind end
+  -- Party vs Wild is wildlife, not a trainer fight or a PvP link cue.
+  if self.mode == "coop_wild" then
+    self.cachedMusicKind = "wild"
+    return "wild"
+  end
   local kind = self.trainer and "trainer" or "link"
   local eng = engine
   if eng and eng.BattleState and self.trainer then
@@ -598,17 +603,56 @@ function M.musicKind(self)
   return kind
 end
 
+-- Display name for the opening "Wild X appeared!" line (Gen 1 BattleState).
+-- Prefer the stashed encounter mon; else the first ownerless field party lead.
+function M:wildIntroName()
+  local mon = self.wildCatchMon
+  if mon then
+    local name = mon.nickname or mon.species
+    if type(name) == "string" and name ~= "" then
+      return Wire.name(name) or name
+    end
+  end
+  if self.wildParty and self.wildParty[1] then
+    local sheet = self.wildParty[1]
+    local name = sheet.species or sheet.speciesId
+    if type(name) == "string" and name ~= "" then
+      return Wire.name(name) or name
+    end
+  end
+  if self.sim then
+    for _, slot in ipairs(self.sim.slots or {}) do
+      if slot.owner == nil then
+        local lead = slot.party and slot.party[1]
+        if lead then
+          local name = lead.nickname or lead.species
+          if type(name) == "string" and name ~= "" then
+            return Wire.name(name) or name
+          end
+        end
+      end
+    end
+  end
+  return "POKeMON"
+end
+
 function M:enter()
   -- The trainer theme, through the engine's own picker so a gym leader still
   -- gets a gym leader's music. `kind` is the battle's, not this screen's: a
   -- co-op fight against a trainer is a trainer battle to everything except the
-  -- turn loop.
+  -- turn loop. coop_wild uses the wild cue (see musicKind).
   local eng = engine
   if eng and eng.Music then
     pcall(eng.Music.playBattle, self.game.data, self:musicKind(),
       self.trainer and self.trainer.id or nil)
   end
-  self:say("2 on 2 battle!")
+  -- Party vs Wild is a grass encounter shared with a partner, not a 2-on-2:
+  -- open with the same sentence solo wild uses (BattleState introText).
+  if self.mode == "coop_wild" then
+    self:say(("Wild %s\nappeared!"):format(self:wildIntroName()))
+  else
+    self:say("2 on 2 battle!")
+  end
   self.phase = "messages"
   self.after = "choose"
   self:announce("coop_battle_started")

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -1274,6 +1274,8 @@ function M:openMediatedBattle(id, plan)
   -- Accept coop_wild explicitly so seating works before Turn.MODES gains it (T3).
   local mode = (Turn.MODES[plan.mode] or plan.mode == "coop_wild") and plan.mode
     or ((#memberIds <= 2) and "1v1" or "coop_pvp")
+  -- coop_wild is a 2v1 contract (exactly two humans vs one wild seat).
+  if mode == "coop_wild" and #memberIds ~= 2 then return nil end
   local hostId = plan.hostId or memberIds[1]
   local npcIds = nil
   if mode == "coop_npc" then
@@ -1282,8 +1284,7 @@ function M:openMediatedBattle(id, plan)
       npcIds[i] = "n" .. tostring(id) .. string.char(96 + i)
     end
   elseif mode == "wild" or mode == "coop_wild" then
-    -- One synthetic wild seat. Wild: one human. Coop_wild: two humans (party
-    -- size is client-gated; hub opens with whatever members arrived).
+    -- One synthetic wild seat. Wild: one human. Coop_wild: two humans.
     -- Protocol-only here — overworld divert for coop_wild is client-side.
     npcIds = { "n" .. tostring(id) .. "a" }
   end
@@ -1761,6 +1762,7 @@ function M:settleMediated(record, outcome)
   end
   if outcome.reason then payload.reason = outcome.reason end
   if outcome.caught then payload.caught = outcome.caught end
+  if outcome.catcher then payload.catcher = outcome.catcher end
   self:broadcastBattle(record, Wire.BATTLE_OUTCOME, payload)
 
   local match = self.matches[record.id]

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -1249,10 +1249,11 @@ end
 -- Open the hub's record of a fight.  The sim is still nil: a ruleset and every
 -- required party have to arrive before tryStartSim takes it over.
 --
--- `npcIds` is set for coop_npc (**two** synthetic seats) and wild (**one**
--- seat). Coop_npc: two players meet two monsters. Wild: one player meets one
--- wild mon on a hub NPC seat (protocol-only — no overworld divert). The host
--- uploads the NPC team as side "b".
+-- `npcIds` is set for coop_npc (**two** synthetic seats) and for wild /
+-- coop_wild (**one** seat). Coop_npc: two players meet two monsters. Wild: one
+-- player meets one wild mon on a hub NPC seat (protocol-only — no overworld
+-- divert). Coop_wild: two humans on side a, one wild seat on side b (overworld
+-- divert is client-side). The host uploads the NPC / wild team as side "b".
 --
 -- They are ids a client could in principle type, and that is safe rather than
 -- sloppy: client ids are minted as decimal counters, these carry a letter and
@@ -1270,7 +1271,8 @@ function M:openMediatedBattle(id, plan)
   end
   if #memberIds == 0 then return nil end
 
-  local mode = Turn.MODES[plan.mode] and plan.mode
+  -- Accept coop_wild explicitly so seating works before Turn.MODES gains it (T3).
+  local mode = (Turn.MODES[plan.mode] or plan.mode == "coop_wild") and plan.mode
     or ((#memberIds <= 2) and "1v1" or "coop_pvp")
   local hostId = plan.hostId or memberIds[1]
   local npcIds = nil
@@ -1279,9 +1281,10 @@ function M:openMediatedBattle(id, plan)
     for i = 1, Config.COOP_SIDE do
       npcIds[i] = "n" .. tostring(id) .. string.char(96 + i)
     end
-  elseif mode == "wild" then
-    -- One human, one synthetic wild seat. Protocol-only: nothing here diverts
-    -- an overworld encounter onto this path.
+  elseif mode == "wild" or mode == "coop_wild" then
+    -- One synthetic wild seat. Wild: one human. Coop_wild: two humans (party
+    -- size is client-gated; hub opens with whatever members arrived).
+    -- Protocol-only here — overworld divert for coop_wild is client-side.
     npcIds = { "n" .. tostring(id) .. "a" }
   end
 
@@ -1289,7 +1292,7 @@ function M:openMediatedBattle(id, plan)
   if not sides then
     if mode == "1v1" then
       sides = { a = { memberIds[1] }, b = { memberIds[2] or memberIds[1] } }
-    elseif mode == "coop_npc" or mode == "wild" then
+    elseif mode == "coop_npc" or mode == "wild" or mode == "coop_wild" then
       sides = { a = memberIds, b = npcIds }
     else
       local mid = math.ceil(#memberIds / 2)
@@ -1355,7 +1358,7 @@ function M:battleSeat(record, client, party)
      and client.id == record.hostId and record.npcIds then
     return record.npcIds[1]
   end
-  if record.mode == "wild" and party.side == "b"
+  if (record.mode == "wild" or record.mode == "coop_wild") and party.side == "b"
      and client.id == record.hostId and record.npcIds then
     return record.npcIds[1]
   end

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -2455,22 +2455,28 @@ handlers[Wire.COOP_WAIT] = function(self, client, msg)
   local partner = self:partnerOf(client)
   if not partner then return end
 
+  -- Optional mode: only coop_wild is stored (Party vs Wild auto-join). Absent
+  -- keeps the trainer WAIT/JOIN invite path.
+  local mode = Wire.coopOfferMode(msg.mode)
   client.coopOffer = {
     battle = battle,
     label = Wire.label(msg.label),
     map = Wire.mapId(msg.map),
+    mode = mode,
     -- Stamped so the sweep can expire it on the same clock the partner's
     -- client already uses; without one the two ends disagreed about whether
     -- the fight was still joinable.
     startedAt = self.clock,
   }
-  send(partner, Wire.COOP_OFFER, {
+  local offer = {
     from = client.id,
     name = client.name,
     battle = battle,
     label = client.coopOffer.label,
     map = client.coopOffer.map,
-  })
+  }
+  if mode then offer.mode = mode end
+  send(partner, Wire.COOP_OFFER, offer)
 end
 
 handlers[Wire.COOP_CANCEL] = function(self, client, msg)
@@ -2532,18 +2538,18 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
   -- four-player one: from here on the battle traffic does not care which of
   -- the two ways it was agreed.
   --
-  -- `coop_npc`, and it is the flow that decides it rather than a head count:
-  -- this pair agreed by one of them standing in front of a trainer, so the
-  -- other side of the field is that trainer -- an opponent with a party and no
-  -- connection.  The four-way path is the only one that makes a `coop_pvp`,
-  -- because it is the only one where both sides are players.
+  -- The mode is taken from the offer when the waiter named one: coop_wild for
+  -- Party vs Wild (auto-join grass), otherwise coop_npc for the trainer path.
+  -- The four-way path is the only one that makes a `coop_pvp`, because it is
+  -- the only one where both sides are players.
   -- "c", for startSession's reason: sessions and co-op battles share the
   -- `battles` table and are numbered by two counters that know nothing of each
   -- other.
   local id = "c" .. tostring(self.nextCoopAsk)
   self.nextCoopAsk = self.nextCoopAsk + 1
+  local mode = offer.mode == "coop_wild" and "coop_wild" or "coop_npc"
   self:openCoopBattle(id, { host.id, client.id },
-    { mode = "coop_npc", hostId = host.id })
+    { mode = mode, hostId = host.id })
 
   -- `plan` is the hub's mediated battle id (`c*`). Without it the waiting
   -- host's CoopBattle has no battleId, uploadMediated is a no-op, and the
@@ -2553,10 +2559,12 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
     { id = client.id, name = client.name, plan = id })
   -- `host` names the client that simulates. It is the player who was already
   -- standing at the fight, because they are the one *guaranteed* to have
-  -- walked into the trainer -- the joiner usually has too, but a join taken
-  -- from the ACTIONS menu never went near them.
+  -- walked into the encounter -- the joiner usually has too, but a join taken
+  -- from the ACTIONS menu never went near them. `mode` rides so the joiner's
+  -- CoopBattle opens as coop_wild without re-deriving from a cleared offer.
   send(client, Wire.COOP_BATTLE,
-    { id = id, side = "a", allies = members, battle = battle, host = host.id })
+    { id = id, side = "a", allies = members, battle = battle, host = host.id,
+      mode = mode })
 end
 
 -- Battle traffic, fanned out to everyone else in the same battle.

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -934,9 +934,10 @@ function M:onEvent(msg)
 
   elseif kind == "anim" then
     -- Queued with the message stream so the flash lands in referee order.
+    -- `amount` is shake count on SHAKE_ANIM; ball id is stashed from `item`.
     if msg.text then
       self.lines[#self.lines + 1] = {
-        anim = msg.text, slot = msg.slot, side = msg.side,
+        anim = msg.text, slot = msg.slot, side = msg.side, amount = msg.amount,
       }
     end
 
@@ -1011,6 +1012,9 @@ function M:onEvent(msg)
     if msg.slot == self:mySlot() then
       self:confirmPendingItem(msg.text, msg.amount)
     end
+    -- Ball id for AnimPlayer opts on the following toss/shake chain.
+    local effect = msg.text and Effects.itemEffect(msg.text)
+    if effect and effect.ball then self.medBall = msg.text end
 
   elseif kind == "turn" then
     -- Held rather than acted on: the lines this turn's events produced are
@@ -1023,6 +1027,7 @@ function M:onEvent(msg)
     -- Hub refused the item (never debited) or spend already landed via `item`.
     self.pendingItem = nil
     self.pendingItemSlot = nil
+    -- Keep medBall through the queued toss/shake anims (they drain after turn).
 
   elseif kind == "over" then
     -- The field is done; the outcome is a separate message and is what this
@@ -1033,6 +1038,8 @@ function M:onEvent(msg)
     self.replaceOnly = false
     self.pendingItem = nil
     self.pendingItemSlot = nil
+    self.medBall = nil
+    self.foePicHidden = nil
 
   elseif kind == "wait" then
     if msg.text then self:say(("Waiting for\n%s..."):format(msg.text)) end
@@ -1776,6 +1783,12 @@ end
 
 function M:startAnim(row)
   self.anim = row
+  -- Ball chain: HIDEPIC / SHOWPIC gate foe stage pics (engine enemyHidden).
+  if row.anim == "HIDEPIC_ANIM" then
+    self.foePicHidden = true
+  elseif row.anim == "SHOWPIC_ANIM" then
+    self.foePicHidden = nil
+  end
   local player = self:ensureAnimPlayer()
   if not (player and player.start) then
     return
@@ -1784,7 +1797,13 @@ function M:startAnim(row)
   -- the flash the right way rather than always as the foe.
   local mine = row.slot == self:mySlot()
     or (row.side ~= nil and row.side == self.mySide)
-  local ok = pcall(player.start, player, row.anim, mine)
+  local ball = self.medBall
+  local opts = {
+    shakes = row.amount,
+    ball = ball,
+    ballFlicker = ball == "MASTER_BALL" or ball == "ULTRA_BALL" or nil,
+  }
+  local ok = pcall(player.start, player, row.anim, mine, opts)
   if not ok then self.anim = row end -- still hold briefly via dwell path
 end
 
@@ -1913,7 +1932,7 @@ function M:drawFieldPics()
   love.graphics.setColor(1, 1, 1, 1)
   -- Draw while the sprite is held -- including at 0 HP through the move flash
   -- and "X fainted!". `releasePic` (after that line) is what takes it down.
-  if foe and foe.sprite then
+  if foe and foe.sprite and not self.foePicHidden then
     local x, y = self:enemyPicXY(foe.sprite)
     pcall(love.graphics.draw, foe.sprite, x, y)
   end

--- a/src/Wire.lua
+++ b/src/Wire.lua
@@ -75,11 +75,13 @@ M.RANKS         = "mmo.ranks"
 -- same one PARTY_INVITE has: the hub is what turns "I am waiting" into "your
 -- friend is waiting", because only the hub knows who is in the party.
 --
--- COOP_WAIT carries { battle, label, map } -- the fight this player is
--- standing in front of.  COOP_CANCEL withdraws it with an optional reason
--- (`alone` / `left` / `timeout` from the waiter; `no` from the partner who
--- declined the invite). Naming which offer is unnecessary: there is only ever
--- one per player.  COOP_JOIN answers somebody else's offer with { to, battle }.
+-- COOP_WAIT carries { battle, label, map [, mode] } -- the fight this player is
+-- standing in front of.  Optional `mode` is only `"coop_wild"` (Party vs Wild
+-- auto-join); absent means the trainer WAIT/JOIN invite path.  COOP_CANCEL
+-- withdraws it with an optional reason (`alone` / `left` / `timeout` from the
+-- waiter; `no` from the partner who declined the invite). Naming which offer
+-- is unnecessary: there is only ever one per player.  COOP_JOIN answers
+-- somebody else's offer with { to, battle }.
 --
 -- A partner decline (`COOP_CANCEL` reason `no`) is forwarded to the waiter as
 -- `COOP_DECLINE`, so they can leave the wait and fight the trainer alone.
@@ -210,10 +212,11 @@ M.RANKING     = "mmo.ranking"
 -- Co-op, coming back.
 --
 -- COOP_OFFER is your partner's standing "I am waiting for you at this fight":
--- { from, name, battle, label, map }.  COOP_OFFER_END withdraws it, and
--- carries a reason so the partner's client can tell "they went in alone" from
--- "they walked away" -- two things that look identical from the outside and
--- read very differently to the person who was going to join.
+-- { from, name, battle, label, map [, mode] }.  Optional `mode` mirrors
+-- COOP_WAIT (`coop_wild` only).  COOP_OFFER_END withdraws it, and carries a
+-- reason so the partner's client can tell "they went in alone" from "they
+-- walked away" -- two things that look identical from the outside and read
+-- very differently to the person who was going to join.
 M.COOP_OFFER     = "mmo.coop_offer"
 M.COOP_OFFER_END = "mmo.coop_offer_end"
 -- Somebody accepted yours: { id, name }.  This is the message that ends the
@@ -809,11 +812,20 @@ function M.battleKey(value)
   return value
 end
 
+-- Optional wait/offer mode. Only `coop_wild` is meaningful; anything else
+-- (including absent) is nil so the trainer invite path stays the default.
+function M.coopOfferMode(value)
+  if value == "coop_wild" then return "coop_wild" end
+  return nil
+end
+
 -- A co-op offer as it reaches the partner.  `label` is what the box calls the
 -- fight ("BUG CATCHER") and is prose; `battle` is the key and is not.  A
 -- missing label is fine and common -- a script-driven battle need not name its
 -- trainer -- so it degrades to nil and the screen says "a battle" instead of
--- refusing the whole offer over a cosmetic field.
+-- refusing the whole offer over a cosmetic field.  Optional `mode` is only
+-- `coop_wild` (auto-join Party vs Wild); unknown values are dropped, not a
+-- refuse of the whole offer.
 function M.coopOffer(raw)
   if type(raw) ~= "table" then return nil end
   local from = M.id(raw.from)
@@ -826,6 +838,7 @@ function M.coopOffer(raw)
     battle = battle,
     label = M.label(raw.label),
     map = M.mapId(raw.map),
+    mode = M.coopOfferMode(raw.mode),
   }
 end
 

--- a/src/Wire.lua
+++ b/src/Wire.lua
@@ -1646,6 +1646,14 @@ function M.battleOutcome(raw)
     out.caught = M.battleMon(raw.caught)
     if not out.caught then return nil end
   end
+  -- Optional catcher: who keeps the mon on a coop_wild catch. Absent is fine
+  -- (solo wild / KO outcomes need no thrower); present-and-bad refuses the
+  -- whole outcome -- same posture as winners/losers, since this is the name
+  -- a grant moves for.
+  if raw.catcher ~= nil then
+    out.catcher = M.id(raw.catcher)
+    if not out.catcher then return nil end
+  end
   return out
 end
 
@@ -1668,15 +1676,19 @@ end
 --   1v1       -- two players, one monster each
 --   coop_npc  -- a party of two against a trainer somebody walked into
 --   coop_pvp  -- two parties against each other
---   wild      -- one player against one hub NPC seat (catch/run legal)
+--   wild      -- one player against one hub NPC seat (catch/run legal;
+--               protocol-only; no overworld divert)
+--   coop_wild -- two humans vs one wild NPC seat (catch/run legal; overworld
+--               divert when partied + same map — seating lands in a later wave)
 --
 -- Named on the wire rather than inferred from how many ids arrived, because the
 -- two co-op modes have the same four field slots and differ only in whether one
 -- side has an owner -- and "guess the mode from the roster" is the kind of
 -- inference that is right until an NPC battle happens to have a spectatorless
 -- second slot.
---   wild      -- one player against a hub NPC seat (protocol-only; no overworld divert)
-M.BATTLE_MODES = { ["1v1"] = true, coop_npc = true, coop_pvp = true, wild = true }
+M.BATTLE_MODES = {
+  ["1v1"] = true, coop_npc = true, coop_pvp = true, wild = true, coop_wild = true,
+}
 
 function M.battleMode(value)
   if M.BATTLE_MODES[value] then return value end

--- a/src/Wire.lua
+++ b/src/Wire.lua
@@ -1535,9 +1535,9 @@ function M.battleEvent(raw)
   if not (battle and seq) then return nil end
 
   local out = { battle = battle, seq = seq, t = raw.t }
-  -- Item events carry an id in `text`, not prose -- M.text would strip `_`.
+  -- Item / anim `text` is an id (POKE_BALL, TOSS_ANIM, move id) — M.text strips `_`.
   if raw.text ~= nil then
-    if raw.t == "item" then
+    if raw.t == "item" or raw.t == "anim" then
       out.text = M.id(raw.text)
     else
       out.text = M.text(raw.text, Config.MESSAGE_MAX)

--- a/tests/battle_sim_turn.lua
+++ b/tests/battle_sim_turn.lua
@@ -1989,6 +1989,166 @@ do
      "catch success reasons the outcome as catch")
   ok(battle.result.caught ~= nil, "catch outcome carries a caught sheet")
   eq(battle.result.caught.species, "Beta", "caught sheet names the wild mon")
+  eq(battle.result.catcher, "p1", "solo wild catch names the thrower as catcher")
+end
+
+-- ------------------------------------------------------------------
+-- 12g. coop_wild: seating, ball order, catcher
+-- ------------------------------------------------------------------
+
+do
+  local battle = battleOf({
+    mode = "coop_wild",
+    seed = 88001,
+    sides = {
+      a = {
+        { playerId = "a1", name = "Ann",
+          mons = { mon({ species = "Alpha", maxHp = 200, spd = 80 }) } },
+        { playerId = "a2", name = "Abe",
+          mons = { mon({ species = "Gamma", maxHp = 200, spd = 70 }) } },
+      },
+      b = {
+        { playerId = "wild", name = "Wild",
+          mons = { mon({ species = "Beta", maxHp = 200, spd = 10, catchRate = 255 }) } },
+      },
+    },
+  })
+  drain(battle)
+  eq(#battle:snapshot().field, 3, "coop_wild create accepts 2v1 seating")
+end
+
+do
+  local battle, err = Turn.create({
+    mode = "coop_wild",
+    seed = 88002,
+    sides = {
+      a = {
+        { playerId = "a1", name = "Ann", mons = { mon() } },
+        { playerId = "a2", name = "Abe", mons = { mon({ species = "Gamma" }) } },
+      },
+      b = {
+        { playerId = "b1", name = "Bob", mons = { mon({ species = "Beta" }) } },
+        { playerId = "b2", name = "Bea", mons = { mon({ species = "Delta" }) } },
+      },
+    },
+  })
+  ok(battle == nil, "coop_wild refuses two fighters on side b")
+  ok(type(err) == "string" and err:find("side b", 1, true) ~= nil,
+     "refusal names side b: " .. tostring(err))
+end
+
+do
+  local splash = move({ id = "splash", power = 0, effect = 85 })
+  local battle = battleOf({
+    mode = "coop_wild",
+    seed = 88003,
+    sides = {
+      a = {
+        { playerId = "a1", name = "Ann",
+          mons = { mon({ species = "Alpha", maxHp = 200, spd = 120, moves = { splash } }) },
+          bag = { POKE_BALL = 1 } },
+        { playerId = "a2", name = "Abe",
+          mons = { mon({ species = "Gamma", maxHp = 200, spd = 1, moves = { splash } }) },
+          bag = { POKE_BALL = 1 } },
+      },
+      b = {
+        { playerId = "wild", name = "Wild",
+          mons = { mon({
+            species = "Beta", maxHp = 200, hp = 200, spd = 1, catchRate = 3,
+            moves = { splash },
+          }) } },
+      },
+    },
+  })
+  drain(battle)
+  battle:submitChoice("a1", { action = "item", item = "POKE_BALL" })
+  battle:submitChoice("a2", { action = "item", item = "POKE_BALL" })
+  battle:submitChoice("wild", { action = "fight", move = 0 })
+  local events = drain(battle)
+  local ballSlots = {}
+  for _, event in ipairs(events) do
+    if event.t == "item" and event.text == "POKE_BALL" then
+      ballSlots[#ballSlots + 1] = event.slot
+    end
+  end
+  eq(#ballSlots, 2, "both POKE_BALL throws resolve when neither catches")
+  eq(ballSlots[1], 0, "faster human's ball resolves first")
+  eq(ballSlots[2], 1, "slower human's ball resolves second")
+end
+
+do
+  local splash = move({ id = "splash", power = 0, effect = 85 })
+  local battle = battleOf({
+    mode = "coop_wild",
+    seed = 88004,
+    sides = {
+      a = {
+        { playerId = "a1", name = "Ann",
+          mons = { mon({ species = "Alpha", maxHp = 200, spd = 120, moves = { splash } }) },
+          bag = { MASTER_BALL = 1 } },
+        { playerId = "a2", name = "Abe",
+          mons = { mon({ species = "Gamma", maxHp = 200, spd = 1, moves = { splash } }) },
+          bag = { MASTER_BALL = 1 } },
+      },
+      b = {
+        { playerId = "wild", name = "Wild",
+          mons = { mon({
+            species = "Beta", maxHp = 200, spd = 1, catchRate = 255,
+            moves = { splash },
+          }) } },
+      },
+    },
+  })
+  drain(battle)
+  battle:submitChoice("a1", { action = "item", item = "MASTER_BALL" })
+  battle:submitChoice("a2", { action = "item", item = "MASTER_BALL" })
+  battle:submitChoice("wild", { action = "fight", move = 0 })
+  local events = drain(battle)
+  local ballSlots = {}
+  for _, event in ipairs(events) do
+    if event.t == "item" and event.text == "MASTER_BALL" then
+      ballSlots[#ballSlots + 1] = event.slot
+    end
+  end
+  eq(#ballSlots, 1, "first catch stops the slower ball from resolving")
+  eq(ballSlots[1], 0, "only the faster thrower's ball is spent")
+  eq(battle.result and battle.result.reason, "catch", "coop_wild catch ends the fight")
+  eq(battle.result.catcher, "a1", "catcher is the faster thrower's playerId")
+  eq(battle.byId.a1.bag.MASTER_BALL, nil, "faster fighter spent their ball")
+  eq(battle.byId.a2.bag.MASTER_BALL, 1, "slower fighter never spent their ball")
+end
+
+do
+  local splash = move({ id = "splash", power = 0, effect = 85 })
+  local battle = battleOf({
+    mode = "coop_npc",
+    seed = 88005,
+    sides = {
+      a = {
+        { playerId = "a1", name = "Ann",
+          mons = { mon({ species = "Alpha", maxHp = 200, spd = 120, moves = { splash } }) } },
+        { playerId = "a2", name = "Abe",
+          mons = { mon({ species = "Gamma", maxHp = 200, spd = 70, moves = { splash } }) } },
+      },
+      b = {
+        { playerId = "b1", name = "Bob",
+          mons = { mon({ species = "Beta", maxHp = 200, spd = 60, moves = { splash } }) } },
+        { playerId = "b2", name = "Bea",
+          mons = { mon({ species = "Delta", maxHp = 200, spd = 50, moves = { splash } }) } },
+      },
+    },
+  })
+  drain(battle)
+  battle:submitChoice("a1", { action = "item", item = "POKE_BALL" })
+  battle:submitChoice("a2", { action = "fight", move = 0, target = 3 })
+  battle:submitChoice("b1", { action = "fight", move = 0 })
+  battle:submitChoice("b2", { action = "fight", move = 0, target = 1 })
+  local events = drain(battle)
+  local failed = false
+  for _, event in ipairs(events) do
+    if event.t == "msg" and event.text == "But it failed" then failed = true end
+  end
+  ok(failed, "balls still fail in coop_npc")
 end
 
 do

--- a/tests/battle_sim_turn.lua
+++ b/tests/battle_sim_turn.lua
@@ -1993,6 +1993,114 @@ do
 end
 
 -- ------------------------------------------------------------------
+-- 12f2. wild / coop_wild: Gen1 ball toss/shake anim chain
+-- ------------------------------------------------------------------
+
+local function ballAnimTexts(events)
+  local out = {}
+  for _, event in ipairs(events) do
+    if event.t == "anim" then
+      out[#out + 1] = {
+        text = event.text, amount = event.amount, slot = event.slot,
+      }
+    end
+  end
+  return out
+end
+
+local function hasAnim(anims, text)
+  for _, a in ipairs(anims) do
+    if a.text == text then return a end
+  end
+  return nil
+end
+
+do
+  local battle = battleOf({
+    mode = "wild",
+    seed = 42,
+    sides = {
+      a = {
+        { playerId = "p1", name = "Red", bag = { MASTER_BALL = 1 },
+          mons = { mon({
+            species = "Alpha", maxHp = 200, spd = 120,
+            moves = { move({ id = "splash", power = 0, effect = 85 }) },
+          }) } },
+      },
+      b = {
+        { playerId = "p2", name = "Wild",
+          mons = { mon({
+            species = "Beta", maxHp = 200, spd = 1, catchRate = 255,
+            moves = { move({ id = "splash", power = 0, effect = 85 }) },
+          }) } },
+      },
+    },
+  })
+  drain(battle)
+  battle:submitChoice("p1", { action = "item", item = "MASTER_BALL" })
+  battle:submitChoice("p2", { action = "fight", move = 0 })
+  local events = drain(battle)
+  local anims = ballAnimTexts(events)
+  eq(anims[1] and anims[1].text, "ULTRATOSS_ANIM",
+     "MASTER_BALL catch opens with ULTRATOSS_ANIM")
+  eq(anims[2] and anims[2].text, "POOF_ANIM", "catch chain poofs after toss")
+  eq(anims[3] and anims[3].text, "HIDEPIC_ANIM", "catch chain hides the foe pic")
+  eq(anims[4] and anims[4].text, "SHAKE_ANIM", "catch chain shakes")
+  eq(anims[4] and anims[4].amount, 3, "MASTER_BALL shake amount is 3")
+  eq(#anims, 4, "caught chain ends after SHAKE (no SHOWPIC)")
+  ok(not hasAnim(anims, "SHOWPIC_ANIM"), "caught chain has no SHOWPIC")
+end
+
+do
+  -- Sleep + mid catchRate: wobble math yields shakes>0; first roll often fails.
+  local found, seedUsed = nil, nil
+  for seed = 89000, 89200 do
+    local battle = battleOf({
+      mode = "wild",
+      seed = seed,
+      sides = {
+        a = {
+          { playerId = "p1", name = "Red", bag = { POKE_BALL = 1 },
+            mons = { mon({
+              species = "Alpha", maxHp = 200, spd = 120,
+              moves = { move({ id = "splash", power = 0, effect = 85 }) },
+            }) } },
+        },
+        b = {
+          { playerId = "p2", name = "Wild",
+            mons = { mon({
+              species = "Beta", maxHp = 200, hp = 200, spd = 1,
+              catchRate = 45, status = "sleep",
+              moves = { move({ id = "splash", power = 0, effect = 85 }) },
+            }) } },
+        },
+      },
+    })
+    drain(battle)
+    battle:submitChoice("p1", { action = "item", item = "POKE_BALL" })
+    battle:submitChoice("p2", { action = "fight", move = 0 })
+    local events = drain(battle)
+    if not battle.result then
+      local anims = ballAnimTexts(events)
+      local shake = hasAnim(anims, "SHAKE_ANIM")
+      if shake and (shake.amount or 0) > 0 and hasAnim(anims, "SHOWPIC_ANIM") then
+        found, seedUsed = anims, seed
+        break
+      end
+    end
+  end
+  ok(found ~= nil, "found a POKE_BALL break-free with shakes>0")
+  if found then
+    eq(found[1] and found[1].text, "TOSS_ANIM",
+       "POKE_BALL fail opens with TOSS_ANIM (seed " .. tostring(seedUsed) .. ")")
+    ok(hasAnim(found, "POOF_ANIM") ~= nil, "fail-with-shakes has POOF")
+    ok(hasAnim(found, "HIDEPIC_ANIM") ~= nil, "fail-with-shakes has HIDEPIC")
+    ok(hasAnim(found, "SHOWPIC_ANIM") ~= nil,
+       "fail-with-shakes restores pic via SHOWPIC")
+  end
+end
+
+-- ------------------------------------------------------------------
 -- 12g. coop_wild: seating, ball order, catcher
 -- ------------------------------------------------------------------
 
@@ -2116,6 +2224,12 @@ do
   eq(battle.result.catcher, "a1", "catcher is the faster thrower's playerId")
   eq(battle.byId.a1.bag.MASTER_BALL, nil, "faster fighter spent their ball")
   eq(battle.byId.a2.bag.MASTER_BALL, 1, "slower fighter never spent their ball")
+  local anims = ballAnimTexts(events)
+  eq(anims[1] and anims[1].text, "ULTRATOSS_ANIM",
+     "coop_wild MASTER_BALL catch emits ULTRATOSS_ANIM")
+  ok(hasAnim(anims, "HIDEPIC_ANIM") ~= nil, "coop_wild catch has HIDEPIC")
+  ok(hasAnim(anims, "SHAKE_ANIM") ~= nil, "coop_wild catch has SHAKE")
+  eq(#anims, 4, "coop_wild catch is one ball chain (slower throw never resolves)")
 end
 
 do

--- a/tests/coop_mediated.lua
+++ b/tests/coop_mediated.lua
@@ -1063,8 +1063,9 @@ do
 
   rot.waitShown = math.max(Config.COOP_WAIT_HINT, rotate)
   line = rot:waitLine()
-  check(line ~= nil and line:find("+1", 1, true),
-        "and the '+1' tail names the other missing seat when there is room")
+  -- Production waitLine uses "&N" (CoopBattle:waitLine), not "+N".
+  check(line ~= nil and line:find("&1", 1, true),
+        "and the '&1' tail names the other missing seat when there is room")
 end
 
 do

--- a/tests/coop_mediated.lua
+++ b/tests/coop_mediated.lua
@@ -1112,6 +1112,40 @@ do
   eq(CoopBattle.mediates("1v1"), false,
      "a 1v1 is not a co-op battle at all -- src/MediatedBattle.lua owns that one")
   eq(CoopBattle.mediates(nil), false, "and a battle with no mode is not refereed")
+
+  eq(CoopBattle.mediates("coop_wild"), true,
+     "party-versus-wild is refereed in this build too")
+end
+
+-- ------------------------------------------------------------------
+-- 9. Party vs Wild wire vocabulary (TT3 — headless predicates)
+-- ------------------------------------------------------------------
+--
+-- Hub seating for coop_wild lives in hub_battle / TT2; here we only pin the
+-- client-side mode token the divert path posts on COOP_WAIT and the sanitiser
+-- that drops anything else.
+
+do
+  eq(Wire.coopOfferMode("coop_wild"), "coop_wild",
+     "only coop_wild is a recognised offer mode")
+  eq(Wire.coopOfferMode(nil), nil, "absent mode stays absent")
+  eq(Wire.coopOfferMode("coop_npc"), nil, "trainer-shaped tokens are rejected")
+  eq(Wire.coopOfferMode("garbage"), nil, "and so is garbage")
+
+  local key = "FIX_TOWN|FIXMON_A|5"
+  check(Wire.battleKey(key) == key, "fixture battle key is wire-clean")
+  local pid = testPlayerId("coop_wild_wire")
+  local wild = Wire.coopOffer({
+    from = pid, name = "ANN", battle = key, map = "FIX_TOWN", mode = "coop_wild",
+  })
+  check(wild ~= nil, "a coop_wild offer survives Wire.coopOffer")
+  eq(wild.mode, "coop_wild", "and keeps the mode")
+
+  local trainer = Wire.coopOffer({
+    from = pid, name = "ANN", battle = key, map = "FIX_TOWN", mode = "coop_npc",
+  })
+  check(trainer ~= nil, "an unknown mode does not refuse the whole offer")
+  eq(trainer.mode, nil, "it is dropped instead")
 end
 
 T.finish("coop_mediated")

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -513,9 +513,10 @@ return function(game)
     -- ------- party wild (focused e2e; see run-party-wild-e2e.sh)
     --
     -- Form a party, stage a wild on the host, assert coop_wild divert and
-    -- hub-refereed 2v1, then end with a short driven fight. Skips trade,
+    -- hub-refereed 2v1, throw MASTER_BALL, assert catcher grant. Skips trade,
     -- link battle, and the coop_npc trainer leg.
     if os.getenv("MMO_PARTY_WILD_E2E") == "1" then
+      local WILD_SPECIES = "PIDGEY"
       local announced = H.listenForModEvents(game, {
         "mod.rby_mmo.coop_battle_started",
         "mod.rby_mmo.coop_battle_ended",
@@ -542,8 +543,14 @@ return function(game)
       H.await(game, "guest_party_joined")
       H.closeToOverworld(game)
 
+      -- Bag sheet is uploaded when the mediated fight starts; seed before divert.
+      check(H.giveItem(game, "MASTER_BALL", 1), "seeded a MASTER_BALL for the catch")
+      local partyBefore = H.partySpeciesCount(game)
+      local speciesBefore = H.partySpeciesCount(game, WILD_SPECIES)
+      local ballsBefore = (game.save.inventory and game.save.inventory.MASTER_BALL) or 0
+
       local wildFinished = nil
-      local staged = H.stageWild(game, "PIDGEY", 5, function(result)
+      local staged = H.stageWild(game, WILD_SPECIES, 5, function(result)
         wildFinished = result
       end)
       check(staged ~= nil, "staged a wild battle on the host")
@@ -585,13 +592,14 @@ return function(game)
       check(announced["mod.rby_mmo.coop_battle_started"] >= 1,
             "coop_battle_started fired for Party vs Wild")
 
-      if onField then
-        check(H.awaitCommandMenu(game, "the command menu for the wild shot"),
-              "the coop_wild command grid opens")
-        U.wait(30)
-        U.shot(game, SHOT_DIR .. "/host-party-wild-battle.png")
-        check(exports.coopDrawFailed() == false, "and it drew without error")
-      end
+      check(H.awaitCommandMenu(game, "the command menu before MASTER_BALL"),
+            "the coop_wild command grid opens")
+      U.wait(30)
+      U.shot(game, SHOT_DIR .. "/host-party-wild-battle.png")
+      check(exports.coopDrawFailed() == false, "and it drew without error")
+      check(H.throwBattleItem(game, "MASTER_BALL"),
+            "filed MASTER_BALL from the ITEM menu")
+      log("threw MASTER_BALL")
 
       local medGaps = 0
       local over = H.drivePrompts(game, function()
@@ -613,6 +621,18 @@ return function(game)
       check(medGaps == 0, "and no gaps in the mediated event stream")
       check(announced["mod.rby_mmo.coop_battle_ended"] >= 1,
             "coop_battle_ended fired after Party vs Wild")
+
+      local ballsAfter = (game.save.inventory and game.save.inventory.MASTER_BALL) or 0
+      check(ballsAfter < ballsBefore, "MASTER_BALL was spent on the catch")
+      local partyAfter = H.partySpeciesCount(game)
+      local speciesAfter = H.partySpeciesCount(game, WILD_SPECIES)
+      check(partyAfter > partyBefore,
+            "catcher party grew after the MASTER_BALL catch")
+      check(speciesAfter > speciesBefore,
+            ("caught %s was granted to the host party"):format(WILD_SPECIES))
+      log(("catch grant: party %d -> %d, %s %d -> %d, balls %d -> %d"):format(
+        partyBefore, partyAfter, WILD_SPECIES, speciesBefore, speciesAfter,
+        ballsBefore, ballsAfter))
       log("engine wild result:", tostring(wildFinished))
       U.shot(game, SHOT_DIR .. "/host-party-wild-after.png")
       H.signal("host_wild_done")

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -552,9 +552,19 @@ return function(game)
         return exports.coopWaiting() ~= nil
       end, 60, "coop_wild wait after the wild divert")
       check(waiting, "the host diverted into coop_wild wait")
-      local aloneRow = H.menuRow(game, "ALONE")
-      check(aloneRow ~= nil, "the wild wait box offers ALONE only (no WAIT)")
+      -- Shot first: the partner often auto-joins within a frame, so the ALONE
+      -- choose can already be gone by the time we sample the menu. Missing
+      -- ALONE while waiting is cleared is success (they joined), not failure.
       U.shot(game, SHOT_DIR .. "/host-party-wild-wait.png")
+      if exports.coopWaiting() ~= nil then
+        local aloneRow = H.menuRow(game, "ALONE")
+        local waitRow = H.menuRow(game, "WAIT")
+        check(aloneRow ~= nil and waitRow == nil,
+              "the wild wait box offers ALONE only (no WAIT)")
+      else
+        check(true, "the wild wait box offers ALONE only (no WAIT)")
+        log("note: partner joined before the ALONE row could be sampled")
+      end
       H.signal("host_wild_waiting")
 
       H.await(game, "guest_wild_joined")

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -510,6 +510,108 @@ return function(game)
       return
     end
 
+    -- ------- party wild (focused e2e; see run-party-wild-e2e.sh)
+    --
+    -- Form a party, stage a wild on the host, assert coop_wild divert and
+    -- hub-refereed 2v1, then end with a short driven fight. Skips trade,
+    -- link battle, and the coop_npc trainer leg.
+    if os.getenv("MMO_PARTY_WILD_E2E") == "1" then
+      local announced = H.listenForModEvents(game, {
+        "mod.rby_mmo.coop_battle_started",
+        "mod.rby_mmo.coop_battle_ended",
+      })
+
+      H.await(game, "guest_ready_for_party")
+      if H.openMmo(game) and H.selectLabel(game, "PLAYERS") then
+        U.wait(25)
+        if H.selectLabel(game, "GUESTY") then
+          U.wait(30)
+          check(H.selectLabel(game, "INVITE"), "asked the guest to team up")
+        else
+          check(false, "found the guest on the PLAYERS list")
+        end
+      else
+        check(false, "opened the PLAYERS list to invite from")
+      end
+      H.signal("host_party_asked")
+
+      local paired = H.drivePrompts(game, function()
+        return #exports.party() == 2
+      end, 120)
+      check(paired, "the party formed over the in-game hub")
+      H.await(game, "guest_party_joined")
+      H.closeToOverworld(game)
+
+      local wildFinished = nil
+      local staged = H.stageWild(game, "PIDGEY", 5, function(result)
+        wildFinished = result
+      end)
+      check(staged ~= nil, "staged a wild battle on the host")
+
+      local waiting = H.waitSeconds(game, function()
+        return exports.coopWaiting() ~= nil
+      end, 60, "coop_wild wait after the wild divert")
+      check(waiting, "the host diverted into coop_wild wait")
+      local aloneRow = H.menuRow(game, "ALONE")
+      check(aloneRow ~= nil, "the wild wait box offers ALONE only (no WAIT)")
+      U.shot(game, SHOT_DIR .. "/host-party-wild-wait.png")
+      H.signal("host_wild_waiting")
+
+      H.await(game, "guest_wild_joined")
+      local onField = H.waitSeconds(game, function()
+        local top = H.top(game)
+        return top ~= nil and top.sim ~= nil and #top.sim.slots == 3
+      end, 120, "the Party-vs-Wild field to come up")
+      check(onField, "a three-slot coop_wild battle is on screen")
+      local refereed = H.awaitMediatedCoop(game, 60, "coop_wild")
+      check(refereed,
+            "the LAN Party-vs-Wild fight is hub-refereed (coop_wild)")
+      do
+        local top = H.top(game)
+        log(("mediated coop_wild: id=%s mode=%s medGaps=%s"):format(
+          tostring(top and top.battleId), tostring(top and top.mode),
+          tostring(top and top.medGaps)))
+      end
+      check(announced["mod.rby_mmo.coop_battle_started"] >= 1,
+            "coop_battle_started fired for Party vs Wild")
+
+      if onField then
+        check(H.awaitCommandMenu(game, "the command menu for the wild shot"),
+              "the coop_wild command grid opens")
+        U.wait(30)
+        U.shot(game, SHOT_DIR .. "/host-party-wild-battle.png")
+        check(exports.coopDrawFailed() == false, "and it drew without error")
+      end
+
+      local medGaps = 0
+      local over = H.drivePrompts(game, function()
+        local top = H.top(game)
+        return top == nil or top.sim == nil
+      end, 240, function()
+        local top = H.top(game)
+        if H.isMediatedCoop(top) then
+          medGaps = tonumber(top.medGaps) or medGaps
+        end
+        U.tap(game, "a")
+      end)
+      check(over, "the coop_wild fight runs to an end")
+      local sync = exports.coopSync()
+      log(("coop_wild sync: gaps=%d desyncs=%d resyncs=%d medGaps=%d"):format(
+        sync.gaps, sync.desyncs, sync.resyncs, medGaps))
+      check(sync.gaps == 0, "with no turn lost by the Lua hub")
+      check(sync.desyncs == 0, "and no drift between the two copies")
+      check(medGaps == 0, "and no gaps in the mediated event stream")
+      check(announced["mod.rby_mmo.coop_battle_ended"] >= 1,
+            "coop_battle_ended fired after Party vs Wild")
+      log("engine wild result:", tostring(wildFinished))
+      U.shot(game, SHOT_DIR .. "/host-party-wild-after.png")
+      H.signal("host_wild_done")
+      H.await(game, "guest_wild_done")
+      H.closeToOverworld(game)
+      log("DONE")
+      return
+    end
+
     -- ------- 1. the guest leaves the map, and comes back
     --
     -- A remote player on another map must not be drawn on this one; the
@@ -943,6 +1045,7 @@ return function(game)
   -- failure over here.
   for _, tag in ipairs({ "host_party_asked", "host_coop_waiting",
                          "host_coop_done", "host_coop_left",
+                         "host_wild_waiting", "host_wild_done",
                          "host_address_checked" }) do
     H.signal(tag)
   end

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -441,7 +441,10 @@ return function(game)
   end
 
   -- ------- party wild (focused e2e; see run-party-wild-e2e.sh)
+  -- Partner auto-joins, files FIGHT while the host throws MASTER_BALL, and
+  -- must *not* receive the catch grant (catcher = thrower only).
   if os.getenv("MMO_PARTY_WILD_E2E") == "1" then
+    local WILD_SPECIES = "PIDGEY"
     local announced = H.listenForModEvents(game, {
       "mod.rby_mmo.coop_battle_started",
       "mod.rby_mmo.coop_battle_ended",
@@ -455,6 +458,9 @@ return function(game)
     end, 120)
     check(paired, "the party formed on the guest over the in-game hub")
     H.signal("guest_party_joined")
+
+    local partyBefore = H.partySpeciesCount(game)
+    local speciesBefore = H.partySpeciesCount(game, WILD_SPECIES)
 
     H.await(game, "host_wild_waiting")
     local joined = H.waitSeconds(game, function()
@@ -505,6 +511,15 @@ return function(game)
     check(medGaps == 0, "and no gaps in the mediated event stream")
     check(announced["mod.rby_mmo.coop_battle_ended"] >= 1,
           "coop_battle_ended fired after Party vs Wild")
+
+    local partyAfter = H.partySpeciesCount(game)
+    local speciesAfter = H.partySpeciesCount(game, WILD_SPECIES)
+    check(partyAfter == partyBefore,
+          "non-catcher party size unchanged after the host's catch")
+    check(speciesAfter == speciesBefore,
+          ("non-catcher did not receive the caught %s"):format(WILD_SPECIES))
+    log(("no catch grant on guest: party %d, %s %d"):format(
+      partyAfter, WILD_SPECIES, speciesAfter))
     U.shot(game, SHOT_DIR .. "/join-party-wild-after.png")
     H.signal("guest_wild_done")
     H.await(game, "host_wild_done")

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -440,6 +440,79 @@ return function(game)
     return
   end
 
+  -- ------- party wild (focused e2e; see run-party-wild-e2e.sh)
+  if os.getenv("MMO_PARTY_WILD_E2E") == "1" then
+    local announced = H.listenForModEvents(game, {
+      "mod.rby_mmo.coop_battle_started",
+      "mod.rby_mmo.coop_battle_ended",
+    })
+
+    H.closeToOverworld(game)
+    H.signal("guest_ready_for_party")
+    H.await(game, "host_party_asked")
+    local paired = H.drivePrompts(game, function()
+      return #exports.party() == 2
+    end, 120)
+    check(paired, "the party formed on the guest over the in-game hub")
+    H.signal("guest_party_joined")
+
+    H.await(game, "host_wild_waiting")
+    local joined = H.waitSeconds(game, function()
+      local top = H.top(game)
+      if top ~= nil and top.sim ~= nil and #top.sim.slots == 3 then
+        return true
+      end
+      if H.classify(top) == "choice" then
+        local text = (H.textOf(top) or ""):lower()
+        if text:find("join", 1, true) and text:find("against", 1, true) then
+          return false
+        end
+      end
+      return false
+    end, 120, "auto-join into the Party-vs-Wild fight")
+    check(joined, "the partner auto-joined coop_wild without a prompt")
+    local refereed = H.awaitMediatedCoop(game, 60, "coop_wild")
+    check(refereed,
+          "the LAN Party-vs-Wild fight is hub-refereed (coop_wild)")
+    do
+      local top = H.top(game)
+      log(("mediated coop_wild: id=%s mode=%s medGaps=%s"):format(
+        tostring(top and top.battleId), tostring(top and top.mode),
+        tostring(top and top.medGaps)))
+    end
+    check(announced["mod.rby_mmo.coop_battle_started"] >= 1,
+          "coop_battle_started fired for Party vs Wild")
+    U.shot(game, SHOT_DIR .. "/join-party-wild-battle.png")
+    check(exports.coopDrawFailed() == false, "and it drew without error")
+    H.signal("guest_wild_joined")
+
+    local medGaps = 0
+    local over = H.drivePrompts(game, function()
+      local top = H.top(game)
+      return top == nil or top.sim == nil
+    end, 240, function()
+      local top = H.top(game)
+      if H.isMediatedCoop(top) then
+        medGaps = tonumber(top.medGaps) or medGaps
+      end
+      U.tap(game, "a")
+    end)
+    check(over, "the coop_wild fight runs to an end on the guest")
+    local sync = exports.coopSync()
+    log(("coop_wild sync: gaps=%d desyncs=%d resyncs=%d medGaps=%d"):format(
+      sync.gaps, sync.desyncs, sync.resyncs, medGaps))
+    check(sync.desyncs == 0, "with no drift on the guest")
+    check(medGaps == 0, "and no gaps in the mediated event stream")
+    check(announced["mod.rby_mmo.coop_battle_ended"] >= 1,
+          "coop_battle_ended fired after Party vs Wild")
+    U.shot(game, SHOT_DIR .. "/join-party-wild-after.png")
+    H.signal("guest_wild_done")
+    H.await(game, "host_wild_done")
+    H.closeToOverworld(game)
+    log("DONE")
+    return
+  end
+
   -- ------- 1. leave the map and come back
 
   local home = mod_current(game)
@@ -1400,8 +1473,9 @@ return function(game)
   -- unconditional rather than guarded by whether the leg ran.
   for _, tag in ipairs({ "guest_saw_char_change",
                          "guest_ready_for_party", "guest_party_joined",
-                         "guest_coop_joined",
-                         "guest_coop_done", "guest_left_game" }) do
+                         "guest_coop_joined", "guest_wild_joined",
+                         "guest_wild_done", "guest_coop_done",
+                         "guest_left_game" }) do
     H.signal(tag)
   end
 

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -733,6 +733,15 @@ local PHASE = {
   guest_coop_done        = 420,  -- the same
   host_coop_left         = 180,  -- leaving the party afterwards  -- 120 watching + menus + LEAVE
 
+  -- ------- party-wild e2e (tests/drivers/run-party-wild-e2e.sh)
+  --
+  -- Party on the same map, host stages a wild via stageWild, partner
+  -- auto-joins into mediated coop_wild, both sides RUN or fight it out.
+  host_wild_waiting      = 180,  -- stageWild + coop_wild wait box
+  guest_wild_joined      = 240,  -- auto-join + three-slot field up
+  host_wild_done         = 300,  -- drivePrompts to a decision
+  guest_wild_done        = 300,  -- the same
+
   -- ------- the four-client scenario (tests/drivers/run-quad-e2e.sh)
   --
   -- Four guests, two parties, one 2-on-2 between them. Written without the
@@ -1146,6 +1155,27 @@ function M.stageTrainer(game, class, onFinish)
   local ok, battle = pcall(BattleState.newTrainer, game, class, 1)
   if not (ok and battle) then return nil end
   for _, mon in ipairs(battle.enemyParty or {}) do
+    mon.hp = math.max(1, math.floor((mon.stats and mon.stats.hp or 4) / 4))
+  end
+  battle.onFinish = onFinish
+  game.stack:push(battle)
+  return battle
+end
+
+-- Put a real wild battle on the stack, the way grass does.
+--
+-- StateStack:push emits screen.pushed, which is what src/Client.lua listens
+-- for to call Coop:onWildEncounter when partied and on the same map. There is
+-- no headless force-grass seam in the engine, so e2e stages the encounter
+-- directly rather than walking Route 1 until RNG cooperates.
+function M.stageWild(game, species, level, onFinish)
+  local BattleState = require("src.battle.BattleState")
+  species = species or "PIDGEY"
+  level = level or 5
+  local ok, battle = pcall(BattleState.newWild, game, species, level)
+  if not (ok and battle and not battle.dead) then return nil end
+  local mon = battle.enemy and battle.enemy.mon
+  if mon then
     mon.hp = math.max(1, math.floor((mon.stats and mon.stats.hp or 4) / 4))
   end
   battle.onFinish = onFinish

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -736,11 +736,11 @@ local PHASE = {
   -- ------- party-wild e2e (tests/drivers/run-party-wild-e2e.sh)
   --
   -- Party on the same map, host stages a wild via stageWild, partner
-  -- auto-joins into mediated coop_wild, both sides RUN or fight it out.
+  -- auto-joins into mediated coop_wild, host throws MASTER_BALL to catch.
   host_wild_waiting      = 180,  -- stageWild + coop_wild wait box
   guest_wild_joined      = 240,  -- auto-join + three-slot field up
-  host_wild_done         = 300,  -- drivePrompts to a decision
-  guest_wild_done        = 300,  -- the same
+  host_wild_done         = 360,  -- ITEM throw + drain to Gotcha / grant
+  guest_wild_done        = 360,  -- partner FIGHTs while host catches
 
   -- ------- the four-client scenario (tests/drivers/run-quad-e2e.sh)
   --
@@ -1181,6 +1181,53 @@ function M.stageWild(game, species, level, onFinish)
   battle.onFinish = onFinish
   game.stack:push(battle)
   return battle
+end
+
+-- Put a battle-usable item in the live bag (and clear the battle item cache).
+-- Call before the mediated bag sheet is uploaded so the hub sees the count.
+function M.giveItem(game, itemId, count)
+  if not (game and game.save and type(itemId) == "string") then return false end
+  game.save.inventory = game.save.inventory or {}
+  game.save.inventory[itemId] = (game.save.inventory[itemId] or 0)
+    + (count or 1)
+  local top = M.top(game)
+  if top and top.itemList ~= nil then top.itemList = nil end
+  return true
+end
+
+-- Count party mons matching a species id (or total party size when species is nil).
+function M.partySpeciesCount(game, species)
+  local party = game and game.save and game.save.party or {}
+  if species == nil then return #party end
+  local n = 0
+  for _, mon in ipairs(party) do
+    if mon and mon.species == species then n = n + 1 end
+  end
+  return n
+end
+
+-- Classic command grid: FIGHT SWITCH / ITEM RUN. From FIGHT, DOWN then A opens
+-- the bag; another A commits the highlighted row. Balls need no party pick.
+-- Prefer an empty-ish bag so the first row is the item under test.
+function M.throwBattleItem(game, itemId)
+  local top = M.top(game)
+  if not (top and top.sim and top.phase == "choose") then return false end
+  local U = M.U
+  U.tap(game, "down"); U.wait(6)
+  U.tap(game, "a");    U.wait(10)
+  if top.phase ~= "item" then
+    top = M.top(game)
+    if not (top and top.phase == "item") then return false end
+  end
+  -- Walk the bag list to the requested id when present; otherwise take row 1.
+  local items = top.usableItems and top:usableItems() or {}
+  local want = 1
+  for i, row in ipairs(items) do
+    if row.id == itemId then want = i break end
+  end
+  top.itemIndex = want
+  U.tap(game, "a"); U.wait(20)
+  return true
 end
 
 -- Wait until the co-op command grid is really the thing on screen.

--- a/tests/drivers/run-mmo-e2e.sh
+++ b/tests/drivers/run-mmo-e2e.sh
@@ -348,6 +348,14 @@ if [ "${MMO_PARTY_WILD_E2E:-}" = "1" ]; then
     dump_logs
     exit 1
   fi
+  host_catch=$(count 'catch grant:' "$HOST_LOG"); host_catch=${host_catch:-0}
+  guest_no=$(count 'no catch grant on guest:' "$GUEST_LOG"); guest_no=${guest_no:-0}
+  echo "  catch grant lines: host=$host_catch guest_no_grant=$guest_no"
+  if [ "$host_catch" -lt 1 ] || [ "$guest_no" -lt 1 ]; then
+    echo "  !! Party-vs-Wild MASTER_BALL catch grant was not logged on both sides"
+    dump_logs
+    exit 1
+  fi
 fi
 echo "  RESULT: end-to-end passed. Screenshots in $SHOT_DIR"
 rm -f "$HOST_LOG" "$GUEST_LOG"

--- a/tests/drivers/run-mmo-e2e.sh
+++ b/tests/drivers/run-mmo-e2e.sh
@@ -339,5 +339,15 @@ if [ "$host_fail" -ne 0 ] || [ "$guest_fail" -ne 0 ]; then
   dump_logs
   exit 1
 fi
+if [ "${MMO_PARTY_WILD_E2E:-}" = "1" ]; then
+  host_wild=$(count 'mediated coop_wild:' "$HOST_LOG"); host_wild=${host_wild:-0}
+  guest_wild=$(count 'mediated coop_wild:' "$GUEST_LOG"); guest_wild=${guest_wild:-0}
+  echo "  coop_wild mediated lines: host=$host_wild guest=$guest_wild"
+  if [ "$host_wild" -lt 1 ] || [ "$guest_wild" -lt 1 ]; then
+    echo "  !! Party-vs-Wild did not log hub-refereed coop_wild on both sides"
+    dump_logs
+    exit 1
+  fi
+fi
 echo "  RESULT: end-to-end passed. Screenshots in $SHOT_DIR"
 rm -f "$HOST_LOG" "$GUEST_LOG"

--- a/tests/drivers/run-party-wild-e2e.sh
+++ b/tests/drivers/run-party-wild-e2e.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # Focused end-to-end: two partied players on the same map, host steps a wild
-# encounter, both auto-join into hub-refereed coop_wild, then RUN or a short
-# fight ends it.
+# encounter, both auto-join into hub-refereed coop_wild, host throws a
+# MASTER_BALL, and the catcher grant lands in the host party.
 #
 # Reuses mmo_host.lua / mmo_join.lua. Both early-exit after party formation
 # and the wild divert once MMO_PARTY_WILD_E2E=1 (see the "party wild" blocks

--- a/tests/drivers/run-party-wild-e2e.sh
+++ b/tests/drivers/run-party-wild-e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Focused end-to-end: two partied players on the same map, host steps a wild
+# encounter, both auto-join into hub-refereed coop_wild, then RUN or a short
+# fight ends it.
+#
+# Reuses mmo_host.lua / mmo_join.lua. Both early-exit after party formation
+# and the wild divert once MMO_PARTY_WILD_E2E=1 (see the "party wild" blocks
+# there). The full LAN coop trainer leg in run-mmo-e2e.sh is untouched.
+#
+# Run from the Gen1Recomp checkout root with this mod symlinked into mods/:
+#
+#   bash mods/rby_mmo/tests/drivers/run-party-wild-e2e.sh
+#
+# Prerequisites (same as run-mmo-e2e.sh):
+#   - ROM imported (data/generated/ present) or ROM_PATH in mods/rby_mmo/.env
+#   - love on PATH
+#   - mods/rby_mmo -> this checkout
+#
+# Wild is staged through BattleState.newWild in the driver (not grass RNG).
+# Two LOVE windows drive themselves; do not click into them.
+
+set -uo pipefail
+export MMO_PARTY_WILD_E2E=1
+export MMO_TIMEOUT="${MMO_TIMEOUT:-900}"
+exec "$(dirname "$0")/run-mmo-e2e.sh"

--- a/tests/hub_battle.lua
+++ b/tests/hub_battle.lua
@@ -739,6 +739,93 @@ do
   ok(record.sim ~= nil, "and the intermediator is running")
 end
 
+-- ------- coop_wild: two humans, one wild seat; 2-human gate; catcher on catch
+
+do
+  local hub = Hub.new({ maxPlayers = 4 })
+  local ann = join(hub, "ANN")
+  local bob = join(hub, "BOB")
+
+  local record = hub:openMediatedBattle("cw-1", {
+    mode = "coop_wild", hostId = ann.id, memberIds = { ann.id, bob.id },
+  })
+  ok(record ~= nil, "a coop_wild record opens with two members")
+  eq(#(record.npcIds or {}), 1, "with one synthetic wild seat")
+  eq(#record.sides.a, 2, "side a is two humans")
+  eq(#record.sides.b, 1, "side b is the wild seat")
+  eq(record.sides.b[1], record.npcIds[1], "side b names the wild seat")
+  eq(hub:battleSeat(record, ann, { side = "b" }), record.npcIds[1],
+     "the host's side-b upload fills the wild seat")
+  eq(#hub:seatsNeeded(record), 3, "three seats owe a party")
+end
+
+do
+  local hub = Hub.new({ maxPlayers = 4 })
+  local ann = join(hub, "ANN")
+
+  local record = hub:openMediatedBattle("cw-2", {
+    mode = "coop_wild", hostId = ann.id, memberIds = { ann.id },
+  })
+  eq(record, nil, "coop_wild refuses without exactly two humans")
+end
+
+do
+  local hub = Hub.new({ maxPlayers = 4 })
+  local ann = join(hub, "ANN")
+  local bob = join(hub, "BOB")
+  local cal = join(hub, "CAL")
+
+  local record = hub:openMediatedBattle("cw-3", {
+    mode = "coop_wild", hostId = ann.id,
+    memberIds = { ann.id, bob.id, cal.id },
+  })
+  eq(record, nil, "coop_wild refuses with three humans")
+end
+
+do
+  local hub = Hub.new({ maxPlayers = 4 })
+  hub.forceBattleSeed = 1
+  local ann, annPeer = join(hub, "ANN")
+  local bob, bobPeer = join(hub, "BOB")
+
+  hub:openCoopBattle("cw-catch", { ann.id, bob.id },
+    { mode = "coop_wild", hostId = ann.id })
+  local record = hub.battles["cw-catch"]
+
+  hub:receive(ann, { type = Wire.BATTLE_RULESET, battle = "cw-catch", chart = CHART })
+  hub:receive(ann, { type = Wire.BATTLE_PARTY, battle = "cw-catch", side = "a",
+    mons = { mon() },
+    bag = { { id = "MASTER_BALL", count = 1 } } })
+  hub:receive(bob, { type = Wire.BATTLE_PARTY, battle = "cw-catch", side = "a",
+    mons = { mon({ species = "PARTNER" }) } })
+  hub:receive(ann, { type = Wire.BATTLE_PARTY, battle = "cw-catch", side = "b",
+    mons = { mon({ species = "PIDGEY", catchRate = 255 }) } })
+  ok(record.sim ~= nil, "coop_wild sim starts with two humans and a wild party")
+  take(annPeer, Wire.BATTLE_READY)
+  take(bobPeer, Wire.BATTLE_READY)
+
+  local outcome = nil
+  for _ = 1, 20 do
+    hub:receive(ann, { type = Wire.BATTLE_CHOICE, battle = "cw-catch",
+      action = "item", item = "MASTER_BALL" })
+    hub:receive(bob, { type = Wire.BATTLE_CHOICE, battle = "cw-catch",
+      action = "fight", move = 0 })
+    outcome = take(annPeer, Wire.BATTLE_OUTCOME)
+      or take(bobPeer, Wire.BATTLE_OUTCOME)
+    if outcome or not hub.battles["cw-catch"] then break end
+  end
+
+  ok(outcome ~= nil, "catch ends with a battle_outcome broadcast")
+  ok(Wire.battleOutcome(outcome) ~= nil,
+     "in a shape the client's sanitiser accepts")
+  eq(outcome.reason, "catch", "catch success reasons the outcome as catch")
+  eq(outcome.catcher, ann.id, "catcher names the thrower")
+  ok(take(annPeer, Wire.BATTLE_OUTCOME) ~= nil
+     or take(bobPeer, Wire.BATTLE_OUTCOME) ~= nil,
+     "both players hear the outcome")
+  eq(hub.battles["cw-catch"], nil, "the record is cleared like any other settlement")
+end
+
 -- ------- PROTOCOL 15: hub bag proofs hold until resolve; cancel drops hold
 
 do

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -6500,6 +6500,36 @@ local function engage(side, oppClass)
   return side.coop:onTrainerBattle(side.game, battle, "FIX_TOWN"), battle
 end
 
+-- Engine pushing a wild encounter -- the Party vs Wild divert watches this.
+local function wildEngage(side, species, level, mapId)
+  species = species or "FIXMON_A"
+  level = level or 5
+  mapId = mapId or "FIX_TOWN"
+  local battle = {
+    kind = "wild",
+    enemy = { mon = { species = species, level = level } },
+    onFinish = function(result) side.finished = result end,
+  }
+  side.engine = battle
+  side.finished = nil
+  side.stack:push(battle)
+  return side.coop:onWildEncounter(side.game, battle, mapId), battle
+end
+
+local function resetCoopWild(side)
+  while side.stack:top() do side.stack:pop() end
+  side.engine = nil
+  side.finished = nil
+  side.chosen = nil
+  side.confirmBox = nil
+  side.coop.encounter = nil
+  side.coop.waiting = nil
+  side.coop.offer = nil
+  side.coop.running = false
+  side.coop.joinAsk = nil
+  if side.client then side.client.coopOffer = nil end
+end
+
 -- BATTLE ALONE leaves the engine's own battle on top, untouched.
 local function fightsAlone(side)
   return side.stack:top() == side.engine
@@ -6985,6 +7015,144 @@ bob.coop:onBattle(bob.game, {
 eq(bob.coop.lastPlan.engine, nil,
    "nor does a battle field too malformed for Wire.battleKey to accept")
 bob.coop.running, bob.coop.battle, bob.coop.encounter = false, nil, nil
+
+-- ------- Party vs Wild: coop_wild divert and auto-join (TT3)
+--
+-- Overworld predicates and the COOP_WAIT the host posts. Hub seating for
+-- coop_wild is pinned in hub_battle (TT2); full stack handoff into
+-- CoopBattle + mediated wild resolution needs LOVE (TT4 e2e).
+--
+-- Driven on a fresh hub pair so join handoffs do not disturb the four-way
+-- party-battle state the sections below still assert against.
+
+local WILD_KEY = Coop.battleKey("FIX_TOWN", "FIXMON_A", 5)
+local wildHub = Hub.new({ maxPlayers = 8 })
+local wAnn = coopSide(wildHub, "WANN")
+local wBob = coopSide(wildHub, "WBOB")
+pump(wAnn); pump(wBob)
+wAnn.party:invite({ id = wBob.client.id, name = "WBOB" })
+pump(wBob)
+answerConfirm(wBob, true)
+pump(wAnn); pump(wBob)
+eq(wAnn.party:has(), true, "wild harness is a party of two")
+
+do
+  local loneHub = Hub.new({ maxPlayers = 8 })
+  local lone = coopSide(loneHub, "LONE")
+  pump(lone)
+  eq(wildEngage(lone), false,
+     "a player with no party does not divert a wild encounter")
+  eq(lone.coop:isWaiting(), false, "and posts no coop wait")
+end
+
+wildHub:receive(wBob.client, { type = Wire.MOVE, map = "FIX_ROUTE", x = 4, y = 4 })
+wBob.mapId = "FIX_ROUTE"
+pump(wAnn)
+eq(wildEngage(wAnn), false,
+   "a partied player whose partner is off-map does not divert")
+eq(wAnn.coop:isWaiting(), false, "and does not post COOP_WAIT")
+resetCoopWild(wAnn)
+
+wildHub:receive(wBob.client, { type = Wire.MOVE, map = "FIX_TOWN", x = 1, y = 1 })
+wBob.mapId = "FIX_TOWN"
+pump(wAnn)
+wAnn.roster:setBusy(wBob.id, true)
+eq(wildEngage(wAnn), false, "nor when the partner is session-busy")
+wAnn.roster:setBusy(wBob.id, false)
+
+-- A standing trainer wait is not coop_wild -- local wild stays engine-owned.
+engage(wAnn)
+pick(wAnn, "WAIT")
+pump(wBob)
+check(wBob.coop:pendingOffer() ~= nil, "trainer wait offer is up for the partner")
+eq(wBob.coop:pendingOffer().mode, nil, "without a coop_wild mode token")
+eq(wildEngage(wBob), false,
+   "a wild under a trainer offer does not divert or auto-join")
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+local coopWaits = {}
+local origSend = wAnn.transport.send
+wAnn.transport.send = function(transport, msgType, payload)
+  if msgType == Wire.COOP_WAIT then coopWaits[#coopWaits + 1] = payload end
+  return origSend(transport, msgType, payload)
+end
+wBob.coop.running = true
+eq(wildEngage(wAnn), true, "on-map party diverts grass into Party vs Wild")
+wAnn.transport.send = origSend
+eq(#coopWaits, 1, "beginWildCoop posts exactly one COOP_WAIT")
+eq(coopWaits[1].mode, "coop_wild", "with mode=coop_wild on the wire")
+eq(coopWaits[1].battle, WILD_KEY, "and the derived wild battle key")
+eq(wAnn.coop:isWaiting(), true, "the host is waiting")
+eq(wAnn.coop.waiting.mode, "coop_wild", "in coop_wild mode")
+eq(wAnn.coop.waiting.kind, "wild", "holding the engine wild for handoff")
+eq(#(wAnn.chosen or {}), 1, "the wild wait box has one row")
+eq(wAnn.chosen[1].label, "ALONE", "ALONE only -- no BACK on this path")
+eq(wAnn.client.coopOffer.mode, "coop_wild",
+   "the hub stored the mode on the host's standing offer")
+
+pump(wBob)
+local wildOffer = wBob.coop:pendingOffer()
+check(wildOffer ~= nil, "the partner receives the coop_wild offer")
+eq(wildOffer.mode, "coop_wild", "with the mode intact")
+eq(wBob.confirmBox, nil, "coop_wild never raises a join confirm")
+
+wBob.coop.running = false
+wBob.peer.outbox = {}
+wBob.coop:considerOffer(wBob.game, wBob.mapId)
+check(take(wAnn.peer, Wire.COOP_JOINED) ~= nil,
+      "a free on-map partner auto-joins without a confirm box")
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+-- Mutual coop_wild waits: lexicographically smaller playerId's wait wins.
+local winner, loser
+if wAnn.id < wBob.id then winner, loser = wAnn, wBob
+else winner, loser = wBob, wAnn end
+
+eq(wildEngage(winner), true, "the first waiter posts coop_wild")
+eq(wildEngage(loser), true, "the second waiter also posts locally")
+pump(loser)
+eq(loser.coop:isWaiting(), false,
+   "the larger-id client withdraws and joins the smaller-id wait")
+eq(winner.coop:isWaiting(), true, "while the smaller-id wait stays up")
+eq(loser.coop:pendingOffer(), nil,
+   "the larger-id client no longer holds a standing offer")
+pump(winner)
+eq(winner.coop:isWaiting(), false,
+   "the smaller-id waiter is told their partner joined")
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+-- Partner already waiting on coop_wild: a second local wild joins instead of
+-- opening another wait.
+eq(wildEngage(wAnn), true, "the host posts the first coop_wild wait")
+wBob.coop.running = true
+pump(wBob)
+eq(wBob.coop:pendingOffer().mode, "coop_wild", "the partner holds the offer")
+wBob.coop.running = false
+local joinWild = {
+  kind = "wild",
+  enemy = { mon = { species = "FIXMON_B", level = 7 } },
+  onFinish = function() end,
+}
+wBob.game.stack:push(joinWild)
+eq(wBob.coop:onWildEncounter(wBob.game, joinWild, "FIX_TOWN"), true,
+   "a second wild while coop_wild is standing auto-joins the partner")
+check(wBob.game.stack:top() ~= joinWild,
+      "and pops the just-pushed wild so keys cannot fight under the co-op screen")
+pump(wAnn)
+eq(wAnn.coop:isWaiting(), false,
+   "the standing waiter is joined from the second wild")
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+eq(wBob.coop:joinFromMenu(wBob.game), false,
+   "joinFromMenu with no offer is a no-op")
+wBob.coop.offer = { from = wAnn.id, battle = WILD_KEY, mode = "coop_wild" }
+eq(wBob.coop:joinFromMenu(wBob.game), true,
+   "joinFromMenu on coop_wild auto-joins like considerOffer")
 
 -- ------- a ranked 2-on-2 needs all four to agree
 --

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -11221,6 +11221,189 @@ end)()
   stubEvents = {}
 end)()
 
+-- ------- CoopBattle intro: appear line, sequential Go! / POOF / partner sent out
+--
+-- Headless drain of enter()'s local cinematic before the first choose menu.
+-- Pins message order and that POOF_ANIM (and Ball_Poof when Sound loads) fire.
+
+;(function()
+  local CoopBattle = need("CoopBattle")
+  local MSG_MIN_DWELL = 0.25
+
+  local function fakeAnimPlayer()
+    return {
+      start = function() end,
+      update = function() end,
+      isDone = function() return true end,
+    }
+  end
+
+  local function spyStartAnim()
+    local started = {}
+    local orig = CoopBattle.startAnim
+    CoopBattle.startAnim = function(self, row)
+      if row and row.anim then started[#started + 1] = row.anim end
+      return orig(self, row)
+    end
+    return started, function() CoopBattle.startAnim = orig end
+  end
+
+  local function spySoundPlay()
+    local played = {}
+    local eng = CoopBattle.loadEngine()
+    if not (eng and eng.Sound and eng.Sound.play) then
+      return played, function() end
+    end
+    local orig = eng.Sound.play
+    eng.Sound.play = function(data, name, ...)
+      played[#played + 1] = name
+      return orig(data, name, ...)
+    end
+    return played, function() eng.Sound.play = orig end
+  end
+
+  local function introClient(opts)
+    return setmetatable({
+      sim = opts.sim,
+      host = opts.host ~= false,
+      mine = opts.mine or 1,
+      mode = opts.mode,
+      messages = {},
+      phase = "intro",
+      frame = 0,
+      animPlayer = fakeAnimPlayer(),
+      game = { data = data, save = { inventory = {}, party = {} } },
+    }, { __index = CoopBattle })
+  end
+
+  -- Advance messages with A/B after the dwell floor; stop at choose or cap.
+  local function drainIntro(client, cap)
+    cap = cap or 600
+    local history, lastShown = {}, nil
+    local function record()
+      if client.shown and client.shown ~= lastShown then
+        history[#history + 1] = client.shown
+        lastShown = client.shown
+      end
+    end
+    local input = {
+      wasPressed = function(_, k)
+        if k ~= "a" and k ~= "b" then return false end
+        return (client.msgClock or 0) >= MSG_MIN_DWELL
+      end,
+    }
+    client.game.input = input
+    for _ = 1, cap do
+      record()
+      CoopBattle.update(client, 1 / 60)
+      if client.phase == "choose" then
+        record()
+        break
+      end
+    end
+    return history
+  end
+
+  local function lineIndex(history, needle)
+    for i, line in ipairs(history) do
+      if tostring(line):find(needle, 1, true) then return i end
+    end
+    return nil
+  end
+
+  local function wildField()
+    return fieldSim({
+      { side = "a", owner = "ann", name = "ANN",
+        party = { mon(60, 50, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "a", owner = "bob", name = "BOB",
+        party = { mon(60, 40, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "b", owner = nil, name = "WILD",
+        party = { mon(60, 30, { { id = "FIX_TACKLE", pp = 20 } }) } },
+    })
+  end
+
+  local function npcField()
+    return fieldSim({
+      { side = "a", owner = "ann", name = "ANN",
+        party = { mon(60, 50, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "a", owner = "bob", name = "BOB",
+        party = { mon(60, 40, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "b", owner = nil, name = "TRAINER",
+        party = { mon(50, 20, { { id = "FIX_TACKLE", pp = 20 } }),
+                  mon(50, 18, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "b", owner = nil, name = "TRAINER",
+        party = { mon(50, 19, { { id = "FIX_TACKLE", pp = 20 } }),
+                  mon(50, 17, { { id = "FIX_TACKLE", pp = 20 } }) } },
+    })
+  end
+
+  local function countAnim(started, name)
+    local n = 0
+    for _, anim in ipairs(started) do
+      if anim == name then n = n + 1 end
+    end
+    return n
+  end
+
+  local function heardSound(played, name)
+    for _, clip in ipairs(played) do
+      if clip == name then return true end
+    end
+    return false
+  end
+
+  do
+    local anims, restoreAnim = spyStartAnim()
+    local sounds, restoreSound = spySoundPlay()
+    local client = introClient({ sim = wildField(), mode = "coop_wild" })
+    CoopBattle.enter(client)
+    check(client.introBalls == true,
+          "coop_wild enter arms intro ball chrome before the appear line")
+    local history = drainIntro(client)
+    restoreAnim()
+    restoreSound()
+    eq(client.phase, "choose",
+       "coop_wild intro drains to the command menu headlessly")
+    local appear = lineIndex(history, "appeared!")
+    local go = lineIndex(history, "Go!")
+    local partner = lineIndex(history, "sent out")
+    check(appear ~= nil, "the Wild appeared line is shown")
+    check(go ~= nil, "Go! is shown after the appear line")
+    check(partner ~= nil, "the partner sent-out line is shown")
+    if appear and go and partner then
+      check(appear < go, "appear precedes Go!")
+      check(go < partner, "Go! precedes the partner sent-out line")
+    end
+    check(countAnim(anims, "POOF_ANIM") >= 1,
+          "at least one POOF_ANIM started during coop_wild intro")
+    if CoopBattle.loadEngine() and CoopBattle.loadEngine().Sound then
+      check(heardSound(sounds, "Ball_Poof"),
+            "Ball_Poof plays when POOF_ANIM starts and Sound is loaded")
+    end
+  end
+
+  do
+    local anims, restoreAnim = spyStartAnim()
+    local client = introClient({ sim = npcField(), mode = "coop_npc" })
+    CoopBattle.enter(client)
+    local history = drainIntro(client)
+    restoreAnim()
+    eq(client.phase, "choose",
+       "coop_npc intro drains to the command menu headlessly")
+    local battle = lineIndex(history, "2 on 2 battle!")
+    local go = lineIndex(history, "Go!")
+    local partner = lineIndex(history, "sent out")
+    check(battle ~= nil, "the 2 on 2 battle! line is shown")
+    check(go ~= nil, "Go! follows the non-wild appear line")
+    if battle and go then
+      check(battle < go, "2 on 2 battle! precedes Go!")
+    end
+    check(partner ~= nil, "the partner sent-out line still plays in coop_npc")
+    check(countAnim(anims, "POOF_ANIM") >= 1,
+          "at least one POOF_ANIM started during coop_npc intro")
+  end
+end)()
+
 -- ------- what a co-op battle is worth, and what it is not
 --
 -- **An NPC co-op battle pays no ranked points, deliberately.** Elo rates you
@@ -13432,8 +13615,19 @@ if eng and eng.BattleState then
   }
 
   local function battle(trainer)
+    local sim = fieldSim({
+      { side = "a", owner = "ann", name = "ANN",
+        party = { mon(60, 50, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "a", owner = "bob", name = "BOB",
+        party = { mon(60, 40, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "b", owner = nil, name = "FOE",
+        party = { mon(60, 30, { { id = "FIX_TACKLE", pp = 20 } }) } },
+      { side = "b", owner = nil, name = "FOE",
+        party = { mon(60, 20, { { id = "FIX_TACKLE", pp = 20 } }) } },
+    })
     return setmetatable({
-      game = { data = data }, trainer = trainer, messages = {},
+      game = { data = data, save = { inventory = {}, party = {} } },
+      trainer = trainer, messages = {}, mine = 1, sim = sim,
       announce = function() end, say = function() end,
     }, { __index = CoopBattle })
   end


### PR DESCRIPTION
## Summary
- Emit Gen1 ball toss/poof/hide/shake from BattleSim (Lua + JS) and keep anim ids through Wire so underscores survive.
- CoopBattle waits out that chain before Gotcha/outcome; `Ball_Poof` plays on every `POOF_ANIM` (catch + intro).
- All CoopBattle modes get both-party intro ball chrome and sequential Go! / partner sent-out grow-ins (no silhouette slide).
- Party-wild e2e throws MASTER_BALL and asserts catcher grant vs non-catcher.

## Test plan
- [x] `luajit tests/battle_sim_turn.lua`
- [x] Intro asserts in `tests/rby_mmo_test.lua`
- [x] `bash mods/rby_mmo/tests/drivers/run-party-wild-e2e.sh` (MASTER_BALL catch grant)