### PR TITLE
spike: run under the engine's mod sandbox

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -126,6 +126,16 @@ docs/plans/nire-back-sprite-pixel-ratio.md
 docs/plans/non-blocking-avatars.md
 docs/plans/coop-joiner-refights-the-trainer.md
 docs/plans/in-game-notifications.md
+# The upstream issue behind the mod-sandbox migration: a request for storage
+# scoped to the copy rather than to one playthrough. Same footing as the plans
+# above -- it argues with the engine about Storage.lua, and a player who
+# unpacks this archive has no use for that argument. Listed by name, because a
+# bare docs/upstream/ line would do nothing.
+docs/upstream/machine-level-storage.md
+# And the small one that raising game_version to the current engine turned up:
+# the mod manager is the one of three call sites that does not skip the engine
+# version check on a 0.0.0-dev build. Same footing as the file above.
+docs/upstream/manager-missing-dev-engine-exemption.md
 # The upstream RFC behind co-op battles. It is a proposal against the *engine*,
 # not mod content -- a player unpacking this archive has no use for a document
 # arguing about BattleState's battler slots. Listed by name for the same reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,45 @@ here must match `manifest.version`.
   engine-rate two-clock HP drain (`max(1, maxHp/96)` per frame); victory
   music keeps waiting for drains and faints to finish.
 
+### Changed
+
+- **The mod runs under the engine's new mod sandbox.** Mod code no longer has
+  `io`, the environment, or love's filesystem module, and `_G` is private per
+  mod. Three stores that kept a JSON file beside the save — the recent-hubs
+  list, the friends lists and the persistent player id — now go through
+  `mod.storage` via one shared `src/Store.lua`; `"filesystem"` is gone from
+  `manifest.permissions` (there is no such permission any more, and under
+  `api: 2` an unknown one is a hard load error, so this line alone would have
+  stopped the mod loading). The two-mirror design is unchanged: `mod.save`
+  still takes every write and is still read first, which is also what carries
+  an existing list or player id forward — **nobody loses a friends list or a
+  rank identity by updating.**
+- **`RBY_MMO_PORT` is now a `HOST PORT` option row.** A sandboxed mod cannot
+  read the environment, and this one read it while `Config` was still loading,
+  which would have taken the whole mod down rather than merely losing a
+  setting. The port an in-game host binds is set in the mod manager instead —
+  visible to the player who actually needs it, which an env var never was.
+  Takes effect on the next launch. The end-to-end drivers pass it through
+  `options.lua`, the same bucket the manager writes.
+- **`game_version` floors at the current engine, `>=0.1.86 <2.0.0`.** It was
+  `>=0.0.0-0`, which claimed this mod runs on every engine ever released --
+  true when it kept its own files, false now that the three stores need
+  `mod.storage`. On an older engine the mod would load and then quietly forget
+  the server list, the friends lists and the player id between launches; a
+  loader that refuses with a version it can name is the better failure. Dev
+  checkouts are unaffected — the loader skips this gate on a `0.0.0-dev`
+  engine. `mod.card`'s `compat.engine` moved with it.
+
+### Removed
+
+- **A recents list, friends list or player id is no longer shared between save
+  files on one copy.** `mod.storage` is scoped per playthrough, and a file was
+  not. Starting a second game gives it its own hub list, its own friends and
+  **its own player id** — so a hub, and the rank board, see two players where
+  there was one. This is a real loss and it is not one this mod can fix from
+  its side; the case is written up for upstream in
+  `docs/upstream/machine-level-storage.md`.
+
 ### Fixed
 
 - **A hub that accepts and never answers is given up on.** The transport's

--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ front of a friend's nickname, because being somebody's friend is true at the
 same time as `PARTY`, `BUSY` and wherever they're standing.
 
 A friendship is **a pair of trainer names on one hub** — the same identity the
-ranking claims — kept in your own copy's `rby_mmo_friends.json`, filed under
-the hub *and* the name you play it as, so two people sharing a machine keep two
-lists. It's client-side on purpose: a friends table on the hub would work on a
+ranking claims — kept in your own game's mod storage, filed under the hub
+*and* the name you play it as, so two people sharing a machine keep two lists.
+(One set of lists per save file: the engine's mod sandbox scopes a mod's
+storage per playthrough, so a second game starts with an empty one.) It's client-side on purpose: a friends table on the hub would work on a
 dedicated server and lose everything on a game hosted from inside somebody's
 copy, which has no disk to keep one on. `UNFRIEND` takes it off **both** sides,
 so the two lists can't quietly disagree.
@@ -482,8 +483,9 @@ score, which the `RANK` screen tells them in as many words. Nobody is thrown
 out for it: a friend who lost their save shouldn't lose the hub.
 
 Be clear about what that is worth. PROTOCOL 16 seats you under a **persistent
-player id** the mod mints once (`rby_mmo_player_id.json`) — that id is the
-rank-board key and the wire presence id. Display names can collide; ids
+player id** the mod mints once — that id is the rank-board key and the wire
+presence id, and it is per save file (the mod sandbox scopes a mod's storage
+per playthrough, so a second game is a second player to the board). Display names can collide; ids
 cannot, and a second live connection with the same id is refused. Mid-ranked
 battle drops still forfeit after reconnect grace (intermediator), not a
 no-score draw. It is closer to an account than the old per-hub claim ticket,
@@ -1182,8 +1184,8 @@ hosts, one joins, and both sides assert:
   winner is on the leaderboard when `RANK` is opened
 - ✅ a guest LEAVEs and keeps playing
 - 🎫 **and can come back as themselves** — the guest rejoins through the real
-  menus under the same persistent player id (`rby_mmo_player_id.json`), and
-  finds its rating where it left it
+  menus under the same persistent player id, and finds its rating where it
+  left it
 
 The dedicated-hub run — `run-hub-e2e.sh`, two guests and a real Node hub, no
 in-game host anywhere — adds the party leg on top of all of that:

--- a/docs/upstream/machine-level-storage.md
+++ b/docs/upstream/machine-level-storage.md
@@ -1,0 +1,101 @@
+# Upstream issue draft — mod storage that belongs to the copy, not the playthrough
+
+**For:** `bryanthaboi/gen1recomp`, against the mod sandbox release.
+**From:** `rby_mmo` (RBY MMO), which has moved off the filesystem and is
+shipping under the sandbox with a regression it cannot fix from this side.
+
+Filed the way the announcement asked for it — "if there is a real thing mods
+need to do that the sandbox blocks, that is a gap in the API and we want to fix
+it properly, with a scoped engine call rather than a hole." This is a request
+for a scoped call, not for filesystem access. **We do not want a `filesystem`
+permission back and we are not asking for paths.**
+
+## What we did
+
+Everything the announcement asked for, and it was mostly one line per site:
+
+| Was | Is |
+|---|---|
+| `love`'s filesystem module × 3 stores | `mod.storage` via one shared `src/Store.lua` |
+| `os.getenv("RBY_MMO_PORT")` | a `port` row in `mod.options` |
+| `"filesystem"` in `manifest.permissions` | removed |
+
+The grep in the announcement is clean, `modkit validate --base imported`,
+`lint` and `pack` are green, and the mod's own suite gained 33 checks for the
+durable half — which, ironically, is now *easier* to test than it was as a
+file, because a four-method facade is something a headless stub can stand up.
+
+No complaints about any of that. The sandbox is the right call and the
+migration was cheap.
+
+## The gap
+
+`mod.storage` is scoped `mod_storage/<gameVersion>/<playthroughId>/<modId>`,
+and `Storage:_scope` answers `not_in_playthrough` outside an identified save.
+That is exactly right for what RFC 0003 set out to hold — replay captures,
+checkpoint histories, recovery records. All of those *are* facts about one
+playthrough.
+
+We have three stores that are not, and never were:
+
+| Store | What it is | Why it is not per-playthrough |
+|---|---|---|
+| Recent hubs | addresses this copy has connected to | you type an address on a d-pad once; a second save file should not have to retype it |
+| Friends lists | people you agreed to keep, per hub | a friendship is between two humans, not between two save files |
+| **Player id** | 16 random bytes, `client.id` on the wire | **the hub seats you under it, the rank board keys on it, and a duplicate live connection is refused by it** |
+
+The player id is the one that actually hurts. It is closer to an account than
+to progress. Under per-playthrough scoping, one human with two save files is
+two players as far as any hub is concerned: two rows on the leaderboard, two
+histories, and — because a hub refuses a second live connection with the same
+id — the *absence* of the check that stops one person occupying two seats.
+
+There is also a smaller ordering problem: `START > MMO > SERVERS` is reachable
+before the engine has an identified playthrough, and the recents list is one of
+the few things a player wants to see *before* deciding which game to load.
+`not_in_playthrough` is the correct answer from the current API and the wrong
+answer for the screen.
+
+## What we are asking for
+
+A sibling scope, not a new capability. Everything else about `mod.storage` —
+data-only tables, engine-owned encoding, no paths, no handles, per-mod
+namespacing — is what we want and should not change.
+
+The shape that would close it, keeping the existing call's ergonomics:
+
+```lua
+-- Same four methods, same value contract, one scope up: keyed by mod id and
+-- game version, with no playthrough segment.
+mod.storage:writeShared(game, "identity", { id = playerId })
+local saved = mod.storage:readShared(game, "identity")
+```
+
+Or, if a second method set is unappealing, an options table on the existing
+calls (`{ scope = "copy" }`), defaulting to the current behaviour so nothing
+that compiles today changes meaning.
+
+Two properties we would need either way:
+
+1. **Readable without an identified playthrough.** The recents list is asked
+   for from a menu that can be reached before a save is chosen. If that is
+   genuinely impossible, we would rather be told so than guess — we can move
+   the menu.
+2. **Still data-only and still engine-scoped.** We do not need to know where it
+   lands, and we would rather not be able to find out.
+
+We are not asking for cross-*mod* sharing. `mod.exports` covers that and covers
+it better.
+
+## What we are doing meanwhile
+
+Shipping on `mod.storage` as it stands, with the regression documented in the
+CHANGELOG and in `src/Store.lua`, and with the `mod.save` mirror each of these
+three stores already keeps doing double duty as the upgrade path — a player
+updating the mod keeps whatever their last save holds, so nobody loses a player
+id or a friends list by installing the sandbox release. What they lose is the
+sharing *between* save files, quietly, and there is no sentence we can put in
+front of them that makes that a setting rather than a surprise.
+
+Happy to write the patch against `Storage.lua` / `Loader.lua` and the RFC that
+extends 0003, if the shape above is one you would take.

--- a/docs/upstream/manager-missing-dev-engine-exemption.md
+++ b/docs/upstream/manager-missing-dev-engine-exemption.md
@@ -1,0 +1,52 @@
+# Upstream issue draft — the mod manager doesn't honour the dev-engine exemption
+
+**For:** `bryanthaboi/gen1recomp`. Small, and probably a two-line fix.
+**Found by:** `rby_mmo`, taking the advice to floor `game_version` at the
+current engine release (`>=0.1.86 <2.0.0`).
+
+## The inconsistency
+
+Three places compare `Version.engine` against a mod's `game_version`. Two of
+them deliberately skip the check on a working-tree build, where `Version.engine`
+is the `0.0.0-dev` placeholder that CI only stamps into the packed `game.love`:
+
+- `src/mods/Loader.lua:496` — `elseif manifest.game_version and not devEngine()`
+- `src/mods/LauncherMods.lua:78` — `Version.engine:match("^0%.0%.0%-") == nil`
+
+The third does not:
+
+- `src/mods/ManagerState.lua:114` —
+  `if m.game_version and not Semver.satisfies(Version.engine, m.game_version)`
+
+So on any developer checkout, a mod whose `game_version` has a real floor
+loads fine (Loader exempts it) and shows no warning in the launcher
+(LauncherMods exempts it), but **toggling it on in the F10 mod manager files a
+`badVersion` and lands in `openBlocked`** — `0.0.0-dev` satisfies no range with
+a nonzero floor.
+
+## Why it bites now
+
+Before the advice to floor `game_version` at the current release, most mods
+carried something like `>=0.0.0-0`, which `0.0.0-dev` happens to satisfy — so
+the missing exemption was invisible. Every mod that takes the advice trips it,
+and it trips exactly the person best placed to be confused by it: someone
+running the mod from a checkout, where the other two call sites have already
+agreed the check does not apply.
+
+## Suggested fix
+
+Give `ManagerState` the same guard the other two have. If the intent is that
+the manager should be stricter than the loader — enabling something the loader
+would then refuse is a fair thing to warn about — then the dev case still needs
+to be distinguished from the real mismatch, because on a dev engine the loader
+will *not* refuse and the manager's block is simply wrong.
+
+Either way, `devEngine()` currently lives as a local in `Loader.lua` and is
+open-coded in `LauncherMods.lua`. Three call sites and two spellings is how the
+third one came to be missed; `Version.isDev()` would make it one fact.
+
+## Not a blocker for us
+
+We are shipping `>=0.1.86 <2.0.0` regardless. Our end-to-end drivers enable the
+mod through `options.lua` rather than the manager, so they are unaffected, and
+the mod loads normally in a checkout. It is only the F10 path on a dev build.

--- a/manifest.json
+++ b/manifest.json
@@ -7,11 +7,10 @@
   "profile": "content",
   "category": "MECHANIC",
   "games": ["gen1", "gen2"],
-  "game_version": ">=0.0.0-0 <2.0.0",
+  "game_version": ">=0.1.86 <2.0.0",
   "priority": 50,
   "permissions": [
     "network",
-    "filesystem",
     "engine_internals"
   ],
   "affects_link": false,

--- a/mod.card
+++ b/mod.card
@@ -168,18 +168,20 @@ return {
         .. "them arriving is the same blue -- so a name worth noticing does "
         .. "not have to be read to be noticed. A friendship is a pair of "
         .. "trainer names on one hub (the same identity the ranking claims) "
-        .. "and lives in this copy's own rby_mmo_friends.json, so it survives "
-        .. "CONTINUE and save-slot switches and works identically on a "
-        .. "dedicated hub and a game hosted from inside the game. Removing "
+        .. "and is kept in this game's own mod storage, so it survives "
+        .. "CONTINUE and works identically on a dedicated hub and a game "
+        .. "hosted from inside the game. One list per save file, since the "
+        .. "engine's mod sandbox scopes a mod's storage that way. Removing "
         .. "one takes it off both sides.",
       "A SERVERS row on the disconnected menu, once you have connected "
         .. "anywhere before: every hub you have reached, favorites pinned "
         .. "above the rest and sorted by address descending otherwise, each "
         .. "with its own CONNECT / AUTOJOIN / FAVORITE-UNFAVORITE / "
         .. "EDIT HOST / EDIT CODE / RENAME submenu. Entries default-named by "
-        .. "address, rename up to 16 characters, and persist across quits, "
-        .. "CONTINUE and save-slot switches in rby_mmo_servers.json; the list "
-        .. "caps at 16 with the oldest non-favorite evicted first.",
+        .. "address, rename up to 16 characters, and persist across quits and "
+        .. "CONTINUE in this game's own mod storage -- one list per save "
+        .. "file, since the engine's mod sandbox scopes it that way; the "
+        .. "list caps at 16 with the oldest non-favorite evicted first.",
       "AUTOJOIN on any one of those rows (the official row included): this "
         .. "copy dials that hub by itself the next time you enter a game -- "
         .. "CONTINUE or NEW GAME, once the world is actually up, never at the "
@@ -247,11 +249,12 @@ return {
         .. "grace is a forfeit loss for the missing seat (not a dual-report "
         .. "draw). Display names are cosmetic; the board keys on the "
         .. "persistent player id PROTOCOL 16 mints once.",
-      "That player id lives in the save and in rby_mmo_player_id.json in the "
-        .. "game's save folder, and it crosses the same unencrypted link the "
-        .. "join code does -- anyone who can read either can steal the "
-        .. "rating. It is closer to an account than the old claim tickets, "
-        .. "and still not a real login.",
+      "That player id lives in the save and in this game's own mod storage, "
+        .. "and it crosses the same unencrypted link the join code does -- "
+        .. "anyone who can read either can steal the rating. It is closer to "
+        .. "an account than the old claim tickets, and still not a real "
+        .. "login. It is per save file: start a second game and the board "
+        .. "sees a second player.",
       "The locations `rby-mmo-hub players` prints are map ids with their "
         .. "underscores taken out (PALLET_TOWN reads as PALLET TOWN), not the "
         .. "names Kanto itself uses. The real ones live in the ROM, which a "
@@ -303,6 +306,11 @@ return {
   },
 
   compat_notes = {
+    "Needs engine 0.1.86 or newer. That floor is the mod sandbox: this "
+      .. "version keeps its server list, friends lists and player id in "
+      .. "mod.storage, which older engines do not have — on one of those "
+      .. "the mod would load and then quietly forget all three between "
+      .. "launches, which is worse than being told it does not fit.",
     "Runs on Gen 1 (Red/Blue/Yellow) and Gen 2 (Gold). Use a Gen 1 hub "
       .. "with a Gen 1 boot and a Gen 2 hub with a Gen 2 boot — hubs refuse "
       .. "cross-generation joins. Both carts get the same product: mediated "
@@ -328,5 +336,5 @@ return {
         .. "under the SIL Open Font License 1.1" },
   },
 
-  compat = { engine = ">=0.0.0-0 <2.0.0", modApi = 2 },
+  compat = { engine = ">=0.1.86 <2.0.0", modApi = 2 },
 }

--- a/server/README.md
+++ b/server/README.md
@@ -810,15 +810,16 @@ rather than refusing to run — a leaderboard is not a reason to take a hub off
 the air.
 
 Ratings are keyed by **player id**, not trainer name. The mod mints the id
-once (`rby_mmo_player_id.json` + save) and sends it on every hello; the hub
-seats you under that id and scores under it. Display names are cosmetic —
+once per playthrough (the client's own mod storage + the save) and sends it on
+every hello; the hub seats you under that id and scores under it. Display names are cosmetic —
 two players can both type `ASH` and both score. `rby-mmo-hub ranking` and
 the in-game RANK screen append `#` + the first four hex of the id when a
 name collides so you can tell them apart. Duplicate *live* connections with
 the same id are refused ("You're already connected."). It is closer to an
 account than the old claim-ticket scheme and still not a real login: the id
-lives in the save folder and crosses the same unencrypted link the passcode
-does. Deleting `ranking.json` clears the season. Legacy name-only rows
+lives on the player's own machine and crosses the same unencrypted link the
+passcode does. It is per playthrough, so one person with two save files is two
+players to the board. Deleting `ranking.json` clears the season. Legacy name-only rows
 without an `id` are skipped on load (season reset).
 
 The second is **`history.jsonl`**, the match ledger

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -10,6 +10,7 @@
 local need, mod = ...
 local Config = need("Config")
 local Wire = need("Wire")
+local Store = need("Store")
 local Sha256 = need("Sha256")
 local Transport = need("Transport")
 local Roster = need("Roster")
@@ -412,7 +413,7 @@ end
 -- setHostJoinCode drops its code.
 --
 -- The rank claim ticket is deliberately NOT cleared — PROTOCOL 16 identity
--- is the persistent playerId (PLAYER_ID_FILE / mod.save), not a per-hub
+-- is the persistent playerId (PLAYER_ID_KEY / mod.save), not a per-hub
 -- ticket. Deleting a bookmark must not cost a rating.
 --
 -- arg1 for the reason the setters above give: reached as
@@ -425,71 +426,69 @@ function M.forgetHub(a, b)
   return true
 end
 
-local jsonModule, jsonTried = nil, false
-
-local function filesystem()
-  if type(love) ~= "table" then return nil end
-  if type(love.filesystem) ~= "table" then return nil end
-  return love.filesystem
-end
-
--- src.link.Json is already this mod's encoder -- HostServer speaks the wire
--- with it -- so a file of our own is not a reason to carry a second one.
-local function json()
-  if jsonTried then return jsonModule end
-  jsonTried = true
-  local ok, module = pcall(require, "src.link.Json")
-  if ok and type(module) == "table" then jsonModule = module end
-  return jsonModule
-end
-
 -- ------- persistent playerId (PROTOCOL 16)
 --
--- One UUID-shaped hex string per LOVE save folder. Survives CONTINUE
--- (durable JSON + mod.save mirror). The hub seats you under this id; ranking
--- keys on it; a second live connection with the same id is refused.
+-- One UUID-shaped hex string, durable across CONTINUE (a mod.storage key plus
+-- the mod.save mirror). The hub seats you under this id; ranking keys on it; a
+-- second live connection with the same id is refused.
+--
+-- It was one id per LOVE save folder while it lived in a JSON file of its own.
+-- The mod sandbox removed love's filesystem module, and mod.storage -- the
+-- replacement -- is scoped to a playthrough, so it is one id per playthrough
+-- now. That is the sharpest edge of the sandbox change anywhere in this mod,
+-- because a player's rank history is filed under this string: a second game on
+-- the same copy is a second player as far as any hub is concerned. The mirror
+-- below is what keeps it from being worse than that -- it is read first, so
+-- nobody loses the id they already have by updating the mod, and src/Store.lua
+-- carries the upstream note.
 
 local playerIdStore = { loaded = false, id = nil, unreadable = false }
 
-local function loadPlayerIdFile()
+local function loadPlayerIdStore()
   if playerIdStore.loaded then
     return playerIdStore.id, playerIdStore.unreadable
   end
   playerIdStore.loaded = true
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return nil, false end
-  local ok, body = pcall(fs.read, Config.PLAYER_ID_FILE)
-  if not ok then
+  local stored, unreadable = Store.read(mod, Config.PLAYER_ID_KEY)
+  if unreadable then
     playerIdStore.unreadable = true
-    mod.log:warn("%s could not be read -- this copy will mint a player id "
-      .. "into mod.save only until the file is readable again; delete it "
-      .. "from the game's save folder to reset identity", Config.PLAYER_ID_FILE)
+    mod.log:warn("this playthrough's stored player id could not be read -- "
+      .. "this copy will keep an id in mod.save only until the store is "
+      .. "readable again, so a rank history may not follow you until it is")
     return nil, true
   end
-  if type(body) ~= "string" or body == "" then return nil, false end
-  local decoded
-  local dok, result = pcall(Json.decode, body)
-  if dok and type(result) == "table" then decoded = result end
-  if not decoded then
-    playerIdStore.unreadable = true
-    return nil, true
-  end
-  local id = Wire.playerId(decoded.id)
+  if type(stored) ~= "table" then return nil, false end
+  local id = Wire.playerId(stored.id)
   playerIdStore.id = id
   return id, false
 end
 
-local function storePlayerIdFile(id)
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return false end
+local function storePlayerId(id)
   if playerIdStore.unreadable then return false end
-  local encoded
-  local ok, result = pcall(Json.encode, { id = id })
-  if ok and type(result) == "string" then encoded = result end
-  if not encoded then return false end
-  local called, wrote = pcall(fs.write, Config.PLAYER_ID_FILE, encoded)
-  if not (called and wrote) then return false end
+  if not Store.write(mod, Config.PLAYER_ID_KEY, { id = id }) then return false end
   playerIdStore.loaded, playerIdStore.id = true, id
+  return true
+end
+
+-- Drop what the cache above is holding, so the next playerId() asks the store
+-- again.
+--
+-- **The cache is per process and what it caches is per playthrough**, and
+-- those were the same thing until the mod sandbox moved this out of a file the
+-- whole copy shared. Without this, a player who loads a different save -- or
+-- starts a new game -- and has no id mirrored in it is handed the *previous*
+-- playthrough's id, which is then written into the new save's mirror: two
+-- games playing as one player, on the one value a hub refuses duplicates of
+-- and a rank board files history under. It is also never written to the new
+-- playthrough's store, so the second game's identity would live only in the
+-- half a CONTINUE rewinds.
+--
+-- Reached from M.saveLoaded (save.loaded and save.created both) and from the
+-- suite, which has no other way in: playerIdStore is a local by design.
+function M.resetPlayerIdCache()
+  playerIdStore.loaded = false
+  playerIdStore.id = nil
+  playerIdStore.unreadable = false
   return true
 end
 
@@ -498,11 +497,22 @@ local playerIdSeq = 0
 -- Mint or recall the persistent player id. Never raises.
 function M.playerId()
   local fromSave = Wire.playerId(mod.save:get("playerId"))
-  if fromSave then return fromSave end
-  local fromFile = loadPlayerIdFile()
-  if fromFile then
-    mod.save:set("playerId", fromFile)
-    return fromFile
+  if fromSave then
+    -- Carry an id forward into the store, once. A player arriving from a build
+    -- that kept this in a JSON file has it in the mirror and nowhere this copy
+    -- can still open, and the mirror is the half a CONTINUE rewinds -- so
+    -- leaving it there would mean losing the identity, and the rank history
+    -- filed under it, at the first save reload. loadPlayerIdStore caches and
+    -- storePlayerId fills that cache, so a write that lands happens once per
+    -- playthrough; one that cannot land is retried on the next call, which is
+    -- what carries the id in as soon as the store will take it.
+    if not loadPlayerIdStore() then storePlayerId(fromSave) end
+    return fromSave
+  end
+  local fromStore = loadPlayerIdStore()
+  if fromStore then
+    mod.save:set("playerId", fromStore)
+    return fromStore
   end
   playerIdSeq = playerIdSeq + 1
   local raw = Hub.Entropy.shared:bytes(16)
@@ -523,7 +533,7 @@ function M.playerId()
     return nil
   end
   mod.save:set("playerId", id)
-  storePlayerIdFile(id)
+  storePlayerId(id)
   return id
 end
 
@@ -1532,6 +1542,17 @@ function M.saveLoaded()
   -- not heard it. Reset with the save -- and a fresh file counts: NEW GAME
   -- routes through here too, and its player has heard nothing at all.
   CoopBattle.saidUnranked = nil
+  -- The same mistake, on state that costs more than a missing sentence.
+  --
+  -- Both of these cache something the mod sandbox made per playthrough, in an
+  -- object that lives as long as the process. Left alone, the game the player
+  -- just opened would show the previous one's hub list and write it back into
+  -- its store, and could be handed the previous one's player id -- which is
+  -- what a hub seats them under and what a rank board files their history
+  -- against. Each holds the argument in full; both belong here because here is
+  -- where the engine says the save underneath us changed.
+  servers:reset()
+  M.resetPlayerIdCache()
 end
 
 -- ------- outgoing chat
@@ -1808,9 +1829,9 @@ handlers[Wire.WELCOME] = function(game, msg)
   --
   -- Wrapped, and the whole point of the wrapping is that this is bookkeeping
   -- on the one path every single connection takes. The store refuses rather
-  -- than raises, so nothing here is expected to throw -- but a save folder
-  -- this copy cannot write must never be the reason a player is not in the
-  -- game they just joined.
+  -- than raises, so nothing here is expected to throw -- but a store this copy
+  -- cannot write must never be the reason a player is not in the game they
+  -- just joined.
   if dialled then
     local kept, why = pcall(function()
       servers:record(dialled, authSent and M.joinCode(dialled) or nil)
@@ -2265,6 +2286,15 @@ function M.install()
     end
   end
 
+  -- Before the schema below, not after: the JOIN row defaults to
+  -- Config.DEFAULT_HUB, and defining it first would offer the player an
+  -- address on a port this copy is not about to listen on.
+  --
+  -- mod.options:get answers from the stored options.lua value whether or not a
+  -- schema has been defined yet -- the row two lines down exists so the player
+  -- can see and change it, not so this read works.
+  Config.applyPort(mod.options:get("port"))
+
   mod.options:define({
     -- The cap the host picks. min/max make the row itself refuse anything
     -- outside 2..64, so the clamp in Config is a backstop against a hand
@@ -2272,6 +2302,23 @@ function M.install()
     { key = "maxplayers", label = "MAX PLAYERS", type = "number",
       default = Config.DEFAULT_PLAYERS,
       min = Config.MIN_PLAYERS, max = Config.MAX_PLAYERS, step = 1 },
+    -- The port an in-game host binds. This replaced the RBY_MMO_PORT
+    -- environment variable, which the mod sandbox made unreadable -- and it is
+    -- the better home for it: 7788 is a guess, and the player whose router or
+    -- second program already holds it is exactly the player who cannot be
+    -- expected to set an env var. Changing it takes effect on the next launch,
+    -- because Config reads it once at install.
+    --
+    -- **Text, not a number row, and that is not a style choice.** The
+    -- manager's number row steps by one per press, and pressing A on it opens
+    -- QuantityBox -- which also steps by one and draws its value behind the
+    -- multiply glyph, so a port would read as "x7788" and 7788 would be seven
+    -- thousand presses from 1. The JOIN row above already takes a whole
+    -- host:port as text through the naming grid; this is the same input, and
+    -- Config.applyPort validates the string it gets (range, whole numbers,
+    -- junk) exactly as it would validate a number.
+    { key = "port", label = "HOST PORT", type = "text",
+      default = tostring(Config.DEFAULT_PORT_FALLBACK), maxLen = 5 },
     { key = "hub", label = "JOIN", type = "text", default = Config.DEFAULT_HUB },
     -- The standing join code, so it can be seen and changed deliberately
     -- rather than only when a hub happens to ask for it -- and, since the

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -134,23 +134,48 @@ M.PROTOCOL = 21
 -- The port an in-game host binds, and the one a bare address is completed
 -- with.
 --
--- Overridable by environment, which is not only a test affordance: 7788 is a
--- guess, and a player whose router or another program already has it needs a
--- way out that is not editing the mod. It is also what lets two end-to-end
--- runs -- two agents, two worktrees -- host at the same time on one machine
--- instead of one silently joining the other's game.
+-- Overridable, which is not only a test affordance: 7788 is a guess, and a
+-- player whose router or another program already has it needs a way out that
+-- is not editing the mod. It is also what lets two end-to-end runs -- two
+-- agents, two worktrees -- host at the same time on one machine instead of one
+-- silently joining the other's game.
 --
--- Read once, at load, and validated: a junk value falls back rather than
--- producing an address nothing can dial.
-local function portFromEnv(fallback)
-  local raw = os.getenv and os.getenv("RBY_MMO_PORT")
-  local n = tonumber(raw or "")
-  if n and n == math.floor(n) and n > 0 and n < 65536 then return n end
-  return fallback
-end
-
-M.DEFAULT_PORT = portFromEnv(7788)
+-- **The override used to be RBY_MMO_PORT and cannot be any more.** The mod
+-- sandbox removes the environment reader, and this file read its value at
+-- load -- so the old line was not merely a lost setting: it ran while Config
+-- was still being required, and a sandbox that raises rather than returning
+-- nil would have taken the whole mod down through main.lua's resolver.
+--
+-- The replacement is the
+-- PORT row in the options schema (src/Client.lua's install), which is the
+-- better channel anyway -- an env var is invisible to the player who needs it,
+-- and options.lua is where the end-to-end drivers already write this mod's
+-- settings per instance.
+--
+-- 7788 until applyPort is told otherwise, and validated there: a junk value
+-- falls back rather than producing an address nothing can dial.
+M.DEFAULT_PORT_FALLBACK = 7788
+M.DEFAULT_PORT = M.DEFAULT_PORT_FALLBACK
 M.DEFAULT_HUB = ("127.0.0.1:%d"):format(M.DEFAULT_PORT)
+
+-- Called once, from install, before the options schema is defined -- because
+-- the schema's JOIN row defaults to DEFAULT_HUB and would otherwise offer the
+-- player an address on a port this copy is not listening on.
+--
+-- A mutable constant is the smaller change than a Config.defaultPort() every
+-- one of the nine call sites has to learn: this value was already decided at
+-- runtime, and all that moves is which channel decides it. Returns the port in
+-- force so the caller can log it.
+function M.applyPort(value)
+  local n = tonumber(value or "")
+  if n and n == math.floor(n) and n > 0 and n < 65536 then
+    M.DEFAULT_PORT = n
+  else
+    M.DEFAULT_PORT = M.DEFAULT_PORT_FALLBACK
+  end
+  M.DEFAULT_HUB = ("127.0.0.1:%d"):format(M.DEFAULT_PORT)
+  return M.DEFAULT_PORT
+end
 
 -- The player cap the host picks when starting a game.
 --
@@ -596,11 +621,16 @@ M.FRIEND_HOLD = 7 * 24 * 3600
 M.FRIEND_HOLD_PER_NAME = 8
 M.FRIEND_HOLD_MAX = 1024
 
--- Where the list is kept, in the LOVE save directory beside the server list
--- and the rank tickets.  Its own file rather than a corner of mod.save for the
--- reason SERVERS_FILE is: friendship is machine-level state that has to
--- survive CONTINUE and belongs to every save slot on this copy at once.
-M.FRIENDS_FILE = "rby_mmo_friends.json"
+-- Where the list is kept: a mod.storage key of its own, beside the server list
+-- and the rank tickets, rather than a corner of mod.save -- for the reason
+-- SERVERS_KEY is, that friendship has to survive a CONTINUE and mod.save is
+-- the half a CONTINUE rewinds.
+--
+-- This was rby_mmo_friends.json until the mod sandbox took love's filesystem
+-- module away, and one thing changed with it that the sentence above used to
+-- also claim: a file belonged to every save slot on this copy at once, and a
+-- storage key belongs to one playthrough.  See src/Store.lua.
+M.FRIENDS_KEY = "friends"
 
 -- What a friend is drawn in: the nameplate over their head and the line in the
 -- corner when they arrive.
@@ -860,11 +890,20 @@ M.RANK_MAX = 9999
 -- How many rows the RANK screen asks for, and the brief's number.
 M.RANK_TOP = 10
 -- Persistent player identity (PROTOCOL 16): 16 random bytes as lowercase hex.
--- One per LOVE install / save folder — closer to an account than a per-hub
--- claim ticket. Sent on every hello; the hub uses it as client.id and as the
--- rank-board key. Duplicate live connections with the same id are refused.
+-- Closer to an account than a per-hub claim ticket. Sent on every hello; the
+-- hub uses it as client.id and as the rank-board key. Duplicate live
+-- connections with the same id are refused.
+--
+-- It was one id per LOVE install / save folder while it lived in
+-- rby_mmo_player_id.json. The mod sandbox took love's filesystem module away
+-- and the replacement is scoped to a playthrough, so it is one id per
+-- playthrough now -- the sharpest edge of that change anywhere in the mod,
+-- because it is what a rank history is filed under. The mod.save mirror is
+-- read first and carries an existing id forward, so no player loses one by
+-- upgrading; a player who starts a second game gets a second identity.
+-- src/Store.lua.
 M.PLAYER_ID_HEX = 32
-M.PLAYER_ID_FILE = "rby_mmo_player_id.json"
+M.PLAYER_ID_KEY = "identity"
 -- How long a pairing stays "recently played" for the rematch discount, and
 -- how many meetings inside it take a win to nothing (halving each time, so
 -- the sixth rematch in the window is already worth zero).
@@ -923,10 +962,15 @@ M.SERVER_NAME_MAX = 16
 -- has not yet reached the end of what is kept, and nobody realistically plays
 -- on more hubs than that without favouriting the ones they mean to keep.
 M.SERVER_LIST_MAX = 16
--- Where the list is kept, in the LOVE save directory beside the rank tickets
--- and the engine's own save files. Its own file rather than a corner of
--- mod.save because a server list is machine-level state: it must survive
--- CONTINUE, and it belongs to every save slot on this copy at once.
-M.SERVERS_FILE = "rby_mmo_servers.json"
+-- Where the list is kept: a mod.storage key of its own rather than a corner of
+-- mod.save, because a recents list must survive a CONTINUE and mod.save is
+-- exactly the half a CONTINUE rewinds.
+--
+-- This was rby_mmo_servers.json in the LOVE save directory until the mod
+-- sandbox took love's filesystem module away. One promise did not survive the
+-- move: a file belonged to every save slot on this copy at once, and a storage
+-- key belongs to one playthrough. src/Store.lua carries the whole of that
+-- story.
+M.SERVERS_KEY = "servers"
 
 return M

--- a/src/Friends.lua
+++ b/src/Friends.lua
@@ -54,13 +54,14 @@
 --
 -- Shaped like src/Party.lua for the protocol half (a transport and a ui handed
 -- in, no engine modules, no love) and like src/Servers.lua for the storage
--- half (a file, mirrored into mod.save, both read through one sanitiser).
--- That is what lets the suite drive the whole handshake -- both sides of it --
--- and the persistence, under plain luajit.
+-- half (a mod.storage key, mirrored into mod.save, both read through one
+-- sanitiser). That is what lets the suite drive the whole handshake -- both
+-- sides of it -- and the persistence, under plain luajit.
 
 local need, chunkMod = ...
 local Config = need("Config")
 local Wire = need("Wire")
+local Store = need("Store")
 
 local M = {}
 M.__index = M
@@ -160,62 +161,35 @@ end
 -- engine happens to flush with the rest of a save, nothing in connecting
 -- writes one, and CONTINUE replaces the whole table -- so a friend made this
 -- session and never saved would be gone by the next launch, which is exactly
--- the case a friends list exists for.  Reads prefer the file, because a save
--- reload is precisely when mod.save holds the older answer.
+-- the case a friends list exists for.  Reads prefer the durable half, because
+-- a save reload is precisely when mod.save holds the older answer.
 --
--- love is absent under the headless test interpreter, and every path here
--- answers "no file" when it is, which leaves the mod.save half as the whole
--- behaviour there rather than failing.
+-- That durable half was rby_mmo_friends.json until the mod sandbox removed
+-- love's filesystem module, and is a mod.storage key now (src/Store.lua).  One
+-- property did not survive the move: a file was shared by every save slot on
+-- this copy, and a storage key belongs to one playthrough, so a second game
+-- keeps a
+-- second set of friends lists.
+--
+-- mod.storage is absent under the headless test interpreter and answers
+-- "nothing here" before a playthrough exists, and every path below reads both
+-- as "no store", which leaves the mod.save half as the whole behaviour there
+-- rather than failing.
 
-local function filesystem()
-  if type(love) ~= "table" then return nil end
-  if type(love.filesystem) ~= "table" then return nil end
-  return love.filesystem
-end
-
--- src.link.Json is already this mod's encoder, so a file of our own is not a
--- reason to carry a second one.  Resolved once and remembered, the failure
--- included: under the headless interpreter there is no engine to require from,
--- and asking again on every write would be a pcall per keypress.
-local jsonModule, jsonTried = nil, false
-local function json()
-  if jsonTried then return jsonModule end
-  jsonTried = true
-  local ok, module = pcall(require, "src.link.Json")
-  if ok and type(module) == "table" then jsonModule = module end
-  return jsonModule
-end
-
--- The whole file -- every bucket, not only ours -- and second whether it is
--- *there and unreadable*, which love.filesystem.read cannot say on its own: a
--- missing file and a failed read are the same nil.  The two want opposite
--- things from the writer, and getting that backwards is how a list is lost:
--- there is nothing to lose by writing over a file that is not there, and every
--- other save slot's friends to lose by writing over one that is and would not
--- open.
+-- The whole store -- every bucket, not only ours -- and second whether it is
+-- *there and unreadable*, which one nil cannot say on its own: a key never
+-- written and a key that will not decode look the same from here.  The two
+-- want opposite things from the writer, and getting that backwards is how a
+-- list is lost: there is nothing to lose by writing over a key that is not
+-- there, and every other hub's friends to lose by writing over one that is and
+-- would not open.
 function M:_read()
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return nil, false end
-
-  local ok, body = pcall(fs.read, Config.FRIENDS_FILE)
-  if not ok or type(body) ~= "string" then
-    local exists = false
-    if type(fs.getInfo) == "function" then
-      local asked, info = pcall(fs.getInfo, Config.FRIENDS_FILE)
-      exists = asked and type(info) == "table"
-    end
-    return nil, exists
-  end
-  -- An empty file is readable and says nothing, which is the same as no file.
-  if body == "" then return nil, false end
-
-  local decoded = Json.decode(body)
-  if type(decoded) ~= "table" then
-    self:_warn("%s is not readable as JSON -- delete it from the game's save "
-      .. "folder to reset this copy's friends lists", Config.FRIENDS_FILE)
+  local stored, unreadable = Store.read(self.mod, Config.FRIENDS_KEY)
+  if unreadable then return nil, true end
+  if type(stored) ~= "table" or type(stored.buckets) ~= "table" then
     return nil, false
   end
-  return decoded, false
+  return stored.buckets, false
 end
 
 function M:_saved()
@@ -241,13 +215,13 @@ end
 
 -- Replace our bucket in both mirrors, and only ours.
 --
--- The file is re-read first, because it holds every hub this copy plays on and
--- every trainer name it plays them under -- and a write of our cached table
--- alone would be a write that forgot all of them.
+-- The store is re-read first, because it holds every hub this playthrough
+-- plays on and every trainer name it plays them under -- and a write of our
+-- cached table alone would be a write that forgot all of them.
 --
 -- **The one thing this must never do is turn a read failure into a wipe.**  A
--- file that exists and would not open is left exactly as it is: the mirror
--- still took the change, and the file repairs itself the next time it reads.
+-- store that exists and would not open is left exactly as it is: the mirror
+-- still took the change, and the store repairs itself the next time it reads.
 function M:_persist()
   if not self.bucket then return false end
   local rows = self:_rows()
@@ -259,15 +233,13 @@ function M:_persist()
     pcall(save.set, save, SAVE_KEY, buckets)
   end
 
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return false end
+  if not Store.available(self.mod) then return false end
 
   local stored, unreadable = self:_read()
   if unreadable then
-    self:_warn("%s could not be read, so this session's friends were not "
-      .. "written to it and nothing in it was overwritten -- the list still "
-      .. "works for this game; delete the file from the game's save folder if "
-      .. "this repeats", Config.FRIENDS_FILE)
+    self:_warn("this copy's stored friends lists could not be read, so this "
+      .. "session's friends were not written over them and nothing in them "
+      .. "was lost -- the list still works for this game")
     return false
   end
 
@@ -279,19 +251,15 @@ function M:_persist()
   end
   out[self.bucket] = rows
 
-  local ok, encoded = pcall(Json.encode, out)
-  if not (ok and type(encoded) == "string") then
-    self:_warn("could not encode %s (%s) -- friends made this session will "
-      .. "not survive a relaunch; delete the file from the game's save folder "
-      .. "if this repeats", Config.FRIENDS_FILE, tostring(encoded))
-    return false
-  end
-
-  local called, wrote, why = pcall(fs.write, Config.FRIENDS_FILE, encoded)
-  if not (called and wrote) then
-    self:_warn("could not write %s (%s) -- friends made this session will be "
-      .. "forgotten on relaunch unless the game is saved while connected",
-      Config.FRIENDS_FILE, tostring(called and why or wrote))
+  local wrote, why = Store.write(self.mod, Config.FRIENDS_KEY, { buckets = out })
+  if not wrote then
+    -- Silent before a playthrough is identified, for src/Servers.lua's reason:
+    -- that state is the engine deciding which game this is, not a store that
+    -- refused, and the mirror above already took the change.
+    if why == Store.NO_PLAYTHROUGH then return false end
+    self:_warn("could not store the friends lists (%s) -- friends made this "
+      .. "session will be forgotten on relaunch unless the game is saved "
+      .. "while connected", tostring(why))
     return false
   end
   return true
@@ -303,9 +271,11 @@ end
 --
 -- Read here rather than lazily, because every question the screens ask is
 -- about *this* bucket and there is exactly one moment at which the bucket is
--- decided.  The save mirror goes in first and the file over the top of it, key
--- by key, because the file is the durable copy and mod.save is the one a
--- CONTINUE can rewind.
+-- decided.  The save mirror goes in first and the store over the top of it, key
+-- by key, because the store is the durable copy and mod.save is the one a
+-- CONTINUE can rewind -- which is also what carries a player forward off the
+-- old JSON file: an empty store and a populated mirror means the mirror is the
+-- whole answer, and the next friend made writes it into the store.
 function M:setHub(address, name)
   self:reset()
   local bucket = bucketKey(address, name)
@@ -413,7 +383,7 @@ end
 
 -- ------- writing the list
 
--- Add somebody, both halves of which are one moment: the row and the file.
+-- Add somebody, both halves of which are one moment: the row and the store.
 --
 -- Bounded by Config.FRIENDS_MAX, and refused rather than trimmed when it is
 -- reached -- dropping the oldest friend to make room for a new one would be

--- a/src/Rank.lua
+++ b/src/Rank.lua
@@ -55,7 +55,7 @@ Board.__index = Board
 --
 -- Keying on the connection id would reset everybody's rating on every
 -- reconnect. Keying on trainer name required claim tickets (not accounts).
--- A client-minted playerId that survives CONTINUE (durable file + mod.save)
+-- A client-minted playerId that survives CONTINUE (mod.storage + mod.save)
 -- is closer to an account: same id → same rating; duplicate live connections
 -- with the same id are refused at admit.
 --

--- a/src/Servers.lua
+++ b/src/Servers.lua
@@ -18,21 +18,28 @@
 -- the whole table with whatever was last written -- so a hub recorded this
 -- session and never saved would be gone by the next launch, which is exactly
 -- the case a recents list exists for. So the list is written to mod.save,
--- still, and to one file of this mod's own that a save reload cannot take
--- away. Reads prefer the file, because a save reload is precisely when
--- mod.save holds the older answer.
+-- still, and to a durable store of this mod's own that a save reload cannot
+-- take away. Reads prefer the durable half, because a save reload is precisely
+-- when mod.save holds the older answer.
 --
--- That also settles what the list *is*: machine-level state, shared by every
--- save slot on this copy, not a fact about one trainer's game.
+-- That durable half was a JSON file beside the save until the mod sandbox
+-- removed love's filesystem module; it is a mod.storage key now
+-- (src/Store.lua), and one sentence that used to be here went with the file:
+-- the list was machine-level state shared by every save slot on this copy, and
+-- storage is scoped per playthrough, so a second game keeps a second list.
+-- Everything else about the design is unchanged, including the rule the write
+-- path is built on -- a read failure must never become a wipe.
 --
--- love is absent under the headless test interpreter, and every path here
--- answers "no file" when it is -- which leaves the mod.save half as the whole
--- behaviour there rather than failing.
+-- mod.storage is absent under the headless test interpreter and answers
+-- "nothing here" before a playthrough exists, and every path below treats both
+-- as "no store" -- which leaves the mod.save half as the whole behaviour there
+-- rather than failing.
 
 local need, chunkMod = ...
 local Config = need("Config")
 local Gen = need("Gen")
 local Wire = need("Wire")
+local Store = need("Store")
 
 local M = {}
 M.__index = M
@@ -79,10 +86,30 @@ end
 -- list cannot rename the canonical copy in memory. The key is made by the
 -- same normaliser as every remembered hub, which is what lets ingestion and
 -- presentation recognise an old saved copy as the same server.
-local FEATURED_KEY = keyOf(Config.FEATURED_SERVER_HOST)
+--
+-- Resolved on first use and remembered, rather than computed while this chunk
+-- loads, because Config.DEFAULT_PORT is no longer settled by then: the PORT
+-- option is applied during install, after every module here has been read
+-- (Config.applyPort). A key baked at load would be keyed on the fallback port
+-- while every later keyOf() used the one the player set -- one hub filed under
+-- two keys, and isFeaturedAddress answering false for the official host.
+-- FEATURED_SERVER_HOST carries an explicit port today, which makes that
+-- harmless; this makes it harmless whatever that constant says next.
+--
+-- A table rather than a plain local so "not resolved yet" stays distinct from
+-- "resolved to nil", which is what a malformed FEATURED_SERVER_HOST gives.
+local featuredKeyMemo = {}
+local function featuredKey()
+  if not featuredKeyMemo.done then
+    featuredKeyMemo.done = true
+    featuredKeyMemo.key = keyOf(Config.FEATURED_SERVER_HOST)
+  end
+  return featuredKeyMemo.key
+end
+
 local function featuredEntry()
   return {
-    key = FEATURED_KEY,
+    key = featuredKey(),
     address = Config.FEATURED_SERVER_HOST,
     name = Config.FEATURED_SERVER_NAME,
     fav = false,
@@ -101,7 +128,7 @@ end
 -- that skipped the SERVERS menu.
 function M.isFeaturedAddress(address)
   local id = keyOf(address)
-  return id ~= nil and id == FEATURED_KEY
+  return id ~= nil and id == featuredKey()
 end
 
 -- What a hub is called before anybody names it.
@@ -167,15 +194,15 @@ function M.new(ctx)
     mod = (type(ctx) == "table" and ctx.mod) or chunkMod,
     entries = {},
     -- Keys this session removed on purpose -- evicted, or re-keyed by EDIT
-    -- HOST. The write below folds in rows it finds on disk that it has never
-    -- seen, and without this a row another copy still holds would walk back
-    -- in the moment it was dropped here.
+    -- HOST. The write below folds in rows it finds in the store that it has
+    -- never seen, and without this a row this session recorded a moment ago
+    -- would walk back in the instant it was dropped here.
     dropped = {},
     loaded = false,
-    -- Which of the file complaints below have already been said once. The
-    -- file is re-read on every write, so a broken one is a standing condition
+    -- Which of the store complaints below have already been said once. The
+    -- store is re-read on every write, so a broken one is a standing condition
     -- and not a blip: unlatched, a player toggling FAVORITE would be told
-    -- their save folder is unreadable once per keypress, which buries the
+    -- their server list is unreadable once per keypress, which buries the
     -- sentence that mattered under the sentence that mattered.
     said = {},
     -- Which hub this copy dials by itself on the way into a game -- one key,
@@ -189,6 +216,33 @@ function M.new(ctx)
     -- history -- be chosen, which a per-row flag could not.
     autoKey = nil,
   }, M)
+end
+
+-- Forget everything this instance is holding, so the next read starts over.
+--
+-- **This exists because the store is scoped to a playthrough and this object
+-- is not.** One Servers is built when the mod loads and lives as long as the
+-- process, while what it caches now belongs to whichever game is open: a
+-- player who loads a different save -- or starts a new one -- would otherwise
+-- keep seeing the previous playthrough's hubs, and the next hub they recorded
+-- would write that whole list into the new playthrough's store. Under the old
+-- machine-level file the cache and the data agreed and none of this was
+-- needed; per-playthrough storage is what made the lifetimes differ.
+--
+-- Client calls it from saveLoaded, which the engine reaches through
+-- save.loaded and through save.created -- NEW GAME emits only the second.
+-- Every field M.new sets except the facade, which is the one thing here that
+-- does belong to the process. autoKey included: which hub this copy dials on
+-- the way in is written into the store beside the rows, so it is as much a
+-- fact about one playthrough as they are -- and carrying it across would arm
+-- the new game with the old one's choice, then persist it there on the next
+-- write.
+function M:reset()
+  self.entries = {}
+  self.dropped = {}
+  self.said = {}
+  self.loaded = false
+  self.autoKey = nil
 end
 
 function M:_warn(fmt, ...)
@@ -206,62 +260,37 @@ end
 
 -- ------- persistence
 
-local function filesystem()
-  if type(love) ~= "table" then return nil end
-  if type(love.filesystem) ~= "table" then return nil end
-  return love.filesystem
-end
-
--- src.link.Json is already this mod's encoder, so a file of our own is not a
--- reason to carry a second one. Resolved once and remembered, including the
--- failure: under the headless interpreter there is no engine to require from
--- and asking again every write would be a pcall per keystroke.
-local jsonModule, jsonTried = nil, false
-local function json()
-  if jsonTried then return jsonModule end
-  jsonTried = true
-  local ok, module = pcall(require, "src.link.Json")
-  if ok and type(module) == "table" then jsonModule = module end
-  return jsonModule
-end
-
--- The file, and second whether it is *there and unreadable* -- which
--- love.filesystem.read cannot say on its own, because a missing file and a
--- failed read are the same nil. The two want opposite things from the writer:
--- there is nothing to lose by writing over a file that does not exist, and
--- everything to lose by writing over one that does and would not open.
+-- The stored rows, and second whether the store is *there and unreadable* --
+-- which one nil cannot say on its own, because a key that was never written
+-- and one that will not decode look the same from here. The two want opposite
+-- things from the writer: there is nothing to lose by writing over a key that
+-- does not exist, and everything to lose by writing over one that does and
+-- would not open.
 --
--- A file that will not decode is a third case and is treated as empty, so the
--- next hub recorded rewrites it whole and repairs it. Refusing to remember
--- anything until the player deletes a file nobody told them about would be a
--- worse answer than losing a list of addresses.
+-- This was a JSON file until the mod sandbox took love's filesystem module
+-- away, and the encoder went with it -- mod.storage hands back a decoded
+-- table, so the src.link.Json round trip this used to do is simply gone. What
+-- has not changed is the contract above, which the whole write path is built
+-- on.
+--
+-- A store that will not decode is Storage's problem before it is ours: it
+-- stages, verifies and keeps a backup generation, so the case that reaches
+-- here is one where every copy is gone. Treating that as "there, leave it
+-- alone" rather than as empty is the safe direction, and a list of addresses
+-- is the cheapest thing in the mod to lose if that judgement is ever wrong.
+-- Silent about the failure on purpose: _persist is the path that has to say
+-- something, because it is the one where the player's change is at stake, and
+-- one sentence said once beats the same sentence from both halves.
 function M:_read()
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return nil, false end
-
-  local ok, body = pcall(fs.read, Config.SERVERS_FILE)
-  if not ok or type(body) ~= "string" then
-    local exists = false
-    if type(fs.getInfo) == "function" then
-      local asked, info = pcall(fs.getInfo, Config.SERVERS_FILE)
-      exists = asked and type(info) == "table"
-    end
-    return nil, exists
-  end
-  -- An empty file is readable and says nothing, which is the same as no file.
-  if body == "" then return nil, false end
-
-  local decoded = Json.decode(body)
-  if type(decoded) ~= "table" then
-    self:_warnOnce("decode", "%s is not readable as JSON -- delete it from the "
-      .. "game's save folder to reset this copy's server list",
-      Config.SERVERS_FILE)
+  local stored, unreadable = Store.read(self.mod, Config.SERVERS_KEY)
+  if unreadable then return nil, true end
+  if type(stored) ~= "table" or type(stored.rows) ~= "table" then
     return nil, false
   end
-  return decoded, false
+  return stored.rows, false
 end
 
--- The rows the save mirror is holding, in the same shape the file uses so one
+-- The rows the save mirror is holding, in the same shape the store uses so one
 -- sanitiser covers both.
 function M:_saved()
   local save = self.mod and self.mod.save
@@ -276,17 +305,17 @@ end
 -- write path needs and the load path does not.
 --
 -- The auto-join key rides in on the same rows, as an `auto` flag on the one
--- row that carries it, so the mirror and the file stay a plain array of
--- servers and a build that predates this reads them exactly as it always did.
+-- row that carries it, so both mirrors stay a plain array of servers and a
+-- build that predates this reads them exactly as it always did.
 -- It is read off `raw` rather than kept on the sanitised entry deliberately:
 -- the store's answer to "which hub auto-joins" is self.autoKey and nothing
 -- else, and a second copy of it sitting on a row is a second copy that could
 -- disagree. Returned rather than assigned so _load can decide which reader's
 -- answer wins.
 --
--- Skipped entirely under `only`, which is the write path folding in another
--- save slot's rows: what this copy auto-joins is a setting this session is in
--- the middle of writing, and the rows being folded in are the older word.
+-- Skipped entirely under `only`, which is the write path folding in rows the
+-- store already holds: what this copy auto-joins is a setting this session is
+-- in the middle of writing, and the rows being folded in are the older word.
 function M:_ingest(rows, only)
   local auto = nil
   for _, raw in ipairs(rows or {}) do
@@ -299,7 +328,7 @@ function M:_ingest(rows, only)
     -- is neither loaded into the persisted store nor counted by eviction --
     -- but its `auto` flag above is still read, because the featured row is
     -- exactly the row that has nowhere else to record one.
-    if entry and entry.key ~= FEATURED_KEY then
+    if entry and entry.key ~= featuredKey() then
       local known = self.entries[entry.key] ~= nil or self.dropped[entry.key]
       if not (only and known) then self.entries[entry.key] = entry end
     end
@@ -353,9 +382,14 @@ local function evict(self, keep)
   end
 end
 
--- Read once a session. The save mirror goes in first and the file over the top
--- of it, key by key, because the file is the durable copy and mod.save is the
--- one a CONTINUE can rewind.
+-- Read once a session. The save mirror goes in first and the store over the
+-- top of it, key by key, because the store is the durable copy and mod.save is
+-- the one a CONTINUE can rewind.
+--
+-- That order is also the upgrade path off the old JSON file: a player arriving
+-- from a build that wrote one has an empty store and a populated mirror, so
+-- the mirror is the whole answer for one session and the next recorded hub
+-- writes it into the store.
 --
 -- Then the cap, because nothing so far has applied it: the two halves are
 -- merged key by key and either of them may be longer than the list is allowed
@@ -377,9 +411,9 @@ function M:_load()
   evict(self)
   -- A key that survived both readers but names no row is nothing this store
   -- can act on -- the row was evicted by the other half of the merge, or
-  -- deleted by another save slot. The featured row is the exception: it is
+  -- deleted in an earlier session. The featured row is the exception: it is
   -- synthetic and is always there to be dialled.
-  if self.autoKey and self.autoKey ~= FEATURED_KEY
+  if self.autoKey and self.autoKey ~= featuredKey()
       and not self.entries[self.autoKey] then
     self.autoKey = nil
   end
@@ -429,24 +463,28 @@ function M:_persistRows()
     if self.autoKey == entry.key then row.auto = true end
     out[#out + 1] = row
   end
-  if self.autoKey == FEATURED_KEY then
-    out[#out + 1] = { key = FEATURED_KEY,
+  if self.autoKey == featuredKey() then
+    out[#out + 1] = { key = featuredKey(),
                       address = Config.FEATURED_SERVER_HOST, auto = true }
   end
   return out
 end
 
--- Write both halves, and in that order: the mirror always, the file
+-- Write both halves, and in that order: the mirror always, the store
 -- best-effort.
 --
--- The file is re-read first, because another save slot -- or a second copy of
--- the game running under the same LOVE identity -- may have recorded a hub
--- since we last looked, and writing our cached table back over it would drop
--- theirs. Rows this session dropped on purpose are not folded back in.
+-- The store is re-read first. Under the old file that was load-bearing --
+-- another save slot could have recorded a hub since we last looked, and
+-- writing our cached table back over it would drop theirs. A storage key
+-- belongs to one playthrough, so that particular race is gone; the re-read
+-- stays because it costs a decode nobody notices and it is what makes this
+-- path safe against a second writer arriving later, which is the direction
+-- upstream would move if the machine-level gap is ever closed. Rows this
+-- session dropped on purpose are not folded back in.
 --
 -- **The one thing this must never do is turn a read failure into a wipe.** The
--- write is the whole list, so a file that exists and would not open is left
--- exactly as it is: the mirror still took the change, and the file repairs
+-- write is the whole list, so a store that exists and would not open is left
+-- exactly as it is: the mirror still took the change, and the store repairs
 -- itself the next time it reads.
 --
 -- `keep` is the caller's row, and it is here for the same reason it is on the
@@ -466,29 +504,23 @@ function M:_persist(keep)
   local save = self.mod and self.mod.save
   if save then pcall(save.set, save, SAVE_KEY, list) end
 
-  local fs, Json = filesystem(), json()
-  if not (fs and Json) then return false end
+  if not Store.available(self.mod) then return false end
   if unreadable then
-    self:_warnOnce("unreadable", "%s could not be read, so this session's "
-      .. "server list was not written to it and nothing in it was overwritten "
-      .. "-- the list still works for this game; delete the file from the "
-      .. "game's save folder if this repeats", Config.SERVERS_FILE)
+    self:_warnOnce("unreadable", "this copy's stored server list could not be "
+      .. "read, so this session's list was not written over it and nothing in "
+      .. "it was lost -- the list still works for this game")
     return false
   end
 
-  local ok, encoded = pcall(Json.encode, list)
-  if not (ok and type(encoded) == "string") then
-    self:_warn("could not encode %s (%s) -- the server list will not survive a "
-      .. "relaunch; delete the file from the game's save folder if this "
-      .. "repeats", Config.SERVERS_FILE, tostring(encoded))
-    return false
-  end
-
-  local called, wrote, why = pcall(fs.write, Config.SERVERS_FILE, encoded)
-  if not (called and wrote) then
-    self:_warn("could not write %s (%s) -- hubs you connect to will be "
-      .. "forgotten on relaunch unless the game is saved while connected",
-      Config.SERVERS_FILE, tostring(called and why or wrote))
+  local wrote, why = Store.write(self.mod, Config.SERVERS_KEY, { rows = list })
+  if not wrote then
+    -- Silent before a playthrough is identified: that is not a fault, it is
+    -- the engine still deciding which game this is, and the mirror above
+    -- already took the change.
+    if why == Store.NO_PLAYTHROUGH then return false end
+    self:_warn("could not store the server list (%s) -- hubs you connect to "
+      .. "will be forgotten on relaunch unless the game is saved while "
+      .. "connected", tostring(why))
     return false
   end
   return true
@@ -529,7 +561,7 @@ function M:menuList(game)
     -- `_ingest` and `record` already keep this key out of entries. Retain the
     -- guard at the projection boundary too: even a caller that has modified
     -- the public entries table cannot make the official server appear twice.
-    if entry.key ~= FEATURED_KEY then out[#out + 1] = entry end
+    if entry.key ~= featuredKey() then out[#out + 1] = entry end
   end
   return out
 end
@@ -542,7 +574,7 @@ function M:menuGet(key, game)
   self:_load()
   local id = keyOf(key)
   if not id then return nil end
-  if id == FEATURED_KEY then
+  if id == featuredKey() then
     if not featuredVisible(game) then return nil end
     return featuredEntry()
   end
@@ -644,7 +676,7 @@ function M:record(address, code)
   -- A welcome from the official hub proves the synthetic row works; it does
   -- not turn product configuration into player history. In particular this
   -- skips persistence and eviction, and keeps the configured code canonical.
-  if key == FEATURED_KEY then
+  if key == featuredKey() then
     self.entries[key] = nil
     return featuredEntry()
   end
@@ -671,7 +703,7 @@ end
 -- refused when nothing printable survives -- a blank row is a row nobody can
 -- tell from the one above it.
 function M:rename(key, name)
-  if keyOf(key) == FEATURED_KEY then
+  if keyOf(key) == featuredKey() then
     self:_warn("the featured server is built in and cannot be renamed")
     return nil
   end
@@ -697,7 +729,7 @@ function M:rename(key, name)
 end
 
 function M:setFavorite(key, fav)
-  if keyOf(key) == FEATURED_KEY then
+  if keyOf(key) == featuredKey() then
     self:_warn("the featured server is already pinned and cannot be changed")
     return nil
   end
@@ -725,7 +757,7 @@ end
 -- only answer that leaves one row per hub -- and the alternative, refusing the
 -- edit, would strand the player with two rows and no way to merge them.
 function M:setAddress(key, newAddress)
-  if keyOf(key) == FEATURED_KEY then
+  if keyOf(key) == featuredKey() then
     self:_warn("the featured server's address is built in and cannot be changed")
     return nil
   end
@@ -743,7 +775,7 @@ function M:setAddress(key, newAddress)
   end
 
   local id = clean:lower()
-  if entry.featured or id == FEATURED_KEY then
+  if entry.featured or id == featuredKey() then
     self:_warn("the featured server's address is built in and cannot be changed")
     return nil
   end
@@ -775,7 +807,7 @@ end
 -- through to the connect path and fail every challenge silently, which is the
 -- failure this validation exists to turn into a sentence.
 function M:setCode(key, code)
-  if keyOf(key) == FEATURED_KEY then
+  if keyOf(key) == featuredKey() then
     self:_warn("the featured server's join code is built in and cannot be changed")
     return nil
   end
@@ -803,17 +835,21 @@ end
 -- The player is finished with this hub.
 --
 -- Dropped rather than emptied, and marked as dropped for the same reason
--- eviction and EDIT HOST mark theirs: the write re-reads the file and folds
--- in rows it has never seen, so the copy of this row still sitting on disk --
--- written by another save slot, or by this session a moment ago -- would walk
--- straight back in on the very write that was meant to remove it. The mark is
--- what makes a delete a delete.
+-- eviction and EDIT HOST mark theirs: the write re-reads the store and folds
+-- in rows it has never seen, so the copy of this row still sitting in it --
+-- written by this session a moment ago -- would walk straight back in on the
+-- very write that was meant to remove it. The mark is what makes a delete a
+-- delete.
+--
+-- That list used to include "written by another save slot", and no longer
+-- can: a storage key belongs to one playthrough, so this session is the only
+-- writer. The mark is still load-bearing for the rest of it.
 --
 -- Nothing is handed to _persist as the row to keep, which every other mutator
 -- does: this is the one write that wants the list shorter, so the eviction
 -- that follows a fold-in has no row here to protect.
 function M:remove(key)
-  if keyOf(key) == FEATURED_KEY then
+  if keyOf(key) == featuredKey() then
     self:_warn("the featured server is built in and cannot be deleted")
     return nil
   end

--- a/src/Store.lua
+++ b/src/Store.lua
@@ -1,0 +1,121 @@
+-- Durable state that outlives a save reload, through the one door the mod
+-- sandbox leaves open.
+--
+-- From the sandbox release a mod cannot open a file: the io library is gone,
+-- so is love's filesystem module, and there is no permission that brings
+-- either back. What replaces them is mod.storage -- data-only tables, encoded
+-- by the engine, scoped to this mod and to the playthrough the player is in.
+-- Three stores used to keep a JSON file of their own beside the save (the
+-- recents list in src/Servers.lua, the friends lists in src/Friends.lua, the
+-- player id in src/Client.lua); all three come through here now, and the shape
+-- of the answer is deliberately the shape their old `_read` had, so the
+-- callers' "never turn a read failure into a wipe" rule survives the change
+-- unaltered.
+--
+-- What it costs, said plainly because those callers' comments used to promise
+-- otherwise: a file was machine-level and a storage key is not. Two save slots
+-- on one copy used to share one recents list, one friends list and one player
+-- id, and they now each carry their own. That is a real regression, it is not
+-- one this file can close, and it is written up for upstream in
+-- docs/upstream/machine-level-storage.md rather than worked around here.
+--
+-- The upgrade path is the mod.save mirror that every one of those callers
+-- already keeps and already reads first: a player coming from a build that
+-- wrote files still has their list in the last save they took, and the first
+-- write after that puts it into storage. Nothing is imported from the old
+-- files, because reading them is precisely what a sandboxed mod cannot do.
+--
+-- Nothing here raises. Every failure reads as "no store", which leaves the
+-- mod.save mirror as the whole behaviour -- the same answer the headless test
+-- interpreter has always got out of the file half.
+
+local need = ...            -- entry-chunk shape; this module resolves nothing
+
+local M = {}
+
+-- The engine scopes a storage key by the live Game, so every call needs one.
+--
+-- mod.game rather than a cached handle or src.core.Game: the loader resolves
+-- it per touch and per generation (the Gen 1 singleton, the Game2 instance
+-- Gold injects), and it is nil until the game is wired -- which is exactly
+-- when storage would answer not_in_playthrough anyway.
+local function gameOf(mod)
+  if type(mod) ~= "table" then return nil end
+  local ok, game = pcall(function() return mod.game end)
+  if ok and type(game) == "table" then return game end
+  return nil
+end
+
+-- The facade, or nil when there is none: an older engine, or a stub in the
+-- suite that has no reason to carry one.
+local function storageOf(mod)
+  if type(mod) ~= "table" then return nil end
+  local storage = mod.storage
+  if type(storage) ~= "table" then return nil end
+  if type(storage.read) ~= "function" or type(storage.write) ~= "function" then
+    return nil
+  end
+  return storage
+end
+
+-- Whether a write has anywhere to land. Callers use it the way they used to
+-- use `filesystem()`: to decide whether the durable half exists at all before
+-- doing the work of building what would be written to it.
+function M.available(mod)
+  return storageOf(mod) ~= nil and gameOf(mod) ~= nil
+end
+
+-- Read one key.
+--
+-- Two answers, for the reason the file readers returned two: the value, and
+-- whether the store is *there and would not open*. A missing key and a broken
+-- one are the same nil, and they want opposite things from the writer -- there
+-- is nothing to lose by writing over a key that was never there, and every
+-- other slot's rows to lose by writing over one that exists and did not
+-- decode.
+--
+-- `not_found` and `not_in_playthrough` are both "nothing here": the second is
+-- the ordinary answer at the title screen and under the headless interpreter,
+-- not a fault. Every other code is treated as the dangerous case, including
+-- ones this engine does not raise yet, because the safe direction for an
+-- unrecognised failure is to leave what is stored alone.
+function M.read(mod, key)
+  local storage, game = storageOf(mod), gameOf(mod)
+  if not (storage and game) then return nil, false end
+
+  local called, value, code = pcall(storage.read, storage, game, key)
+  if not called then return nil, false end
+  if type(value) == "table" then return value, false end
+  if code == "not_found" or code == "not_in_playthrough" then return nil, false end
+  return nil, true
+end
+
+-- Write one key, and say why not when it fails so the caller can name the
+-- remediation in its own words -- a friends list and a recents list lose
+-- different things and must not share one sentence.
+--
+-- Storage stages, verifies and keeps a backup generation of its own, so there
+-- is no torn-write case left for a caller to handle.
+--
+-- `not_in_playthrough` comes back as M.NO_PLAYTHROUGH and not as a failure
+-- code, because the read path above already treats that state as an ordinary
+-- "nothing here" and the two must agree. It is what storage answers before a
+-- playthrough is identified, and a caller that reported it would be telling a
+-- player their hubs are about to be forgotten because the engine has not
+-- finished deciding which game they are in -- once per keypress, in a sentence
+-- that is not true.
+M.NO_PLAYTHROUGH = "no_playthrough"
+
+function M.write(mod, key, value)
+  local storage, game = storageOf(mod), gameOf(mod)
+  if not (storage and game) then return false, "unavailable" end
+  if type(value) ~= "table" then return false, "encode_failed" end
+
+  local called, ok, code = pcall(storage.write, storage, game, key, value)
+  if not called then return false, "unavailable" end
+  if ok then return true end
+  if code == "not_in_playthrough" then return false, M.NO_PLAYTHROUGH end
+  return false, code or "write_failed"
+end
+
+return M

--- a/tests/drivers/run-mmo-e2e-gen2.sh
+++ b/tests/drivers/run-mmo-e2e-gen2.sh
@@ -85,6 +85,10 @@ fi
 RUN_ID="${MMO_RUN_ID:-$$}"
 ADDR_FILE="${MMO_ADDR_FILE:-/tmp/rby_mmo_gen2_addr-$RUN_ID.txt}"
 MMO_GAME_PORT="${RBY_MMO_PORT:-$(( 7600 + ($$ % 200) ))}"
+# Exported for the drivers, which are engine-level scripts and can still read
+# the environment; the game learns the port from each instance's options.lua
+# instead, because a sandboxed mod cannot. Same split as run-mmo-e2e.sh, which
+# carries the long version of this note.
 export RBY_MMO_PORT="$MMO_GAME_PORT"
 
 if [ -n "${MMO_JOIN_ADDRESS:-}" ] && [ "${MMO_JOIN_ADDRESS##*:}" != "$MMO_GAME_PORT" ]; then
@@ -196,8 +200,8 @@ enable_mod_for() {
   dir="$(save_dir_for "$1")"
   [ -n "$dir" ] || fail "could not determine LOVE's save directory for $1"
   mkdir -p "$dir"
-  printf 'return { mods = { rby_mmo = true%s }, modOptions = { rby_mmo = { hub = "%s", sprite = "%s" } } }\n' \
-    "$EXTRA_MODS" "$MMO_JOIN_ADDRESS" "$2" > "$dir/options.lua"
+  printf 'return { mods = { rby_mmo = true%s }, modOptions = { rby_mmo = { hub = "%s", sprite = "%s", port = "%s" } } }\n' \
+    "$EXTRA_MODS" "$MMO_JOIN_ADDRESS" "$2" "$MMO_GAME_PORT" > "$dir/options.lua"
   echo "$dir"
 }
 

--- a/tests/drivers/run-mmo-e2e.sh
+++ b/tests/drivers/run-mmo-e2e.sh
@@ -48,6 +48,12 @@ ADDR_FILE="${MMO_ADDR_FILE:-/tmp/rby_mmo_addr-$RUN_ID.txt}"
 # joining the first -- which is what a fixed 7788 did, and it looked like a
 # roster bug rather than a harness one.
 MMO_GAME_PORT="${RBY_MMO_PORT:-$(( 7500 + ($$ % 200) ))}"
+# Still exported, because the drivers themselves read it (tests/drivers/mmo_util.lua)
+# and they are engine-level scripts, not mod code. What changed with the mod
+# sandbox is how the *game* learns it: a mod can no longer read the
+# environment, so the port goes into each instance's options.lua below --
+# through the same modOptions bucket the mod manager writes, which is what
+# keeps this run exercising the real setting rather than a test-only door.
 export RBY_MMO_PORT="$MMO_GAME_PORT"
 
 # ...and the guest has to dial *that* port.
@@ -198,8 +204,8 @@ enable_mod_for() {
   dir="$(save_dir_for "$1")"
   [ -n "$dir" ] || fail "could not determine LOVE's save directory for $1"
   mkdir -p "$dir"
-  printf 'return { mods = { rby_mmo = true%s }, modOptions = { rby_mmo = { hub = "%s", sprite = "%s" } } }\n' \
-    "$EXTRA_MODS" "$MMO_JOIN_ADDRESS" "$2" > "$dir/options.lua"
+  printf 'return { mods = { rby_mmo = true%s }, modOptions = { rby_mmo = { hub = "%s", sprite = "%s", port = "%s" } } }\n' \
+    "$EXTRA_MODS" "$MMO_JOIN_ADDRESS" "$2" "$MMO_GAME_PORT" > "$dir/options.lua"
   echo "$dir"
 }
 HOST_SPRITE="${MMO_HOST_SPRITE:-SPRITE_RED}"

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -24407,4 +24407,346 @@ end
 
 end)()
 
+-- ------------------------------------------------------------------
+-- 18. The durable half, after the mod sandbox
+-- ------------------------------------------------------------------
+--
+-- The recents list, the friends lists and the player id each keep two
+-- copies: a mod.save mirror, and a durable store a save reload cannot
+-- rewind. That durable half was a JSON file beside the save until the
+-- engine's mod sandbox removed the filesystem module, and it is a
+-- mod.storage key now (src/Store.lua).
+--
+-- It was never covered here before, for a reason that stopped being true
+-- with the move: standing a love filesystem up under plain luajit is a
+-- second in-memory filesystem to reason about, and section 13 removes love
+-- rather than build one. mod.storage is a four-method facade, so the
+-- durable half is finally something a headless stub can drive -- and it is
+-- the half that carries a player's list across a CONTINUE, which is the
+-- whole reason it exists.
+--
+-- Driven against facades built here rather than the shared stubMod, which
+-- deliberately has no storage: attaching one there would make every earlier
+-- section dual-write into a store that outlives its `stubSave = {}` reset,
+-- and cross-contaminate blocks that are written to start from nothing.
+
+;(function()
+
+local ambientLove = _G.love
+_G.love = nil
+
+local Store = need("Store")
+local Servers = need("Servers")
+local Friends = need("Friends")
+local Client = need("Client")
+
+-- The engine's contract, small enough to state exactly (src/mods/Storage.lua):
+-- read hands back a decoded table, or nil plus a code; write answers true, or
+-- false plus a code. `broken` is the case the callers' whole write path is
+-- built around -- a store that is there and will not open.
+local function storageStub()
+  local self = { data = {}, writes = 0, broken = false, noPlaythrough = false }
+  self.facade = {
+    read = function(_, game, key)
+      if not game then return nil, "not_in_playthrough", "no game" end
+      -- What storage answers while the engine has not settled which game this
+      -- is: a real state, and deliberately not a fault on either path.
+      if self.noPlaythrough then
+        return nil, "not_in_playthrough", "no playthrough yet"
+      end
+      if self.broken then return nil, "verify_failed", "could not be verified" end
+      local hit = self.data[key]
+      if hit == nil then return nil, "not_found", "nothing stored" end
+      return hit
+    end,
+    write = function(_, game, key, value)
+      if not game then return false, "not_in_playthrough", "no game" end
+      if self.noPlaythrough then
+        return false, "not_in_playthrough", "no playthrough yet"
+      end
+      if type(value) ~= "table" then return false, "encode_failed", "not data" end
+      self.writes = self.writes + 1
+      self.data[key] = value
+      return true
+    end,
+    list = function() return {} end,
+    delete = function() return false, "not_found" end,
+  }
+  return self
+end
+
+-- A mod facade with a storage half and a save half of its own, so two of them
+-- can share one store the way two launches of the game do.
+local function facadeOn(storage, save)
+  save = save or {}
+  local warns = {}
+  return {
+    id = "rby_mmo",
+    game = {},
+    storage = storage and storage.facade or nil,
+    save = {
+      get = function(_, key, default)
+        local value = save[key]
+        if value == nil then return default end
+        return value
+      end,
+      set = function(_, key, value) save[key] = value end,
+    },
+    log = {
+      info = function() end,
+      warn = function(_, fmt, ...)
+        local ok, line = pcall(string.format, fmt, ...)
+        warns[#warns + 1] = ok and line or fmt
+      end,
+      error = function() end,
+    },
+  }, save, warns
+end
+
+-- ------- Store itself: the two answers a caller is allowed to act on
+
+do
+  local storage = storageStub()
+  local mod = facadeOn(storage)
+
+  local value, unreadable = Store.read(mod, "servers")
+  eq(value, nil, "an unwritten key reads as nothing")
+  eq(unreadable, false, "and not_found is not a store that would not open")
+
+  check(Store.write(mod, "servers", { rows = { 1 } }), "a data table writes")
+  local back = Store.read(mod, "servers")
+  eq(type(back) == "table" and back.rows[1], 1, "and reads back whole")
+
+  storage.broken = true
+  value, unreadable = Store.read(mod, "servers")
+  eq(value, nil, "a store that will not decode hands back nothing")
+  eq(unreadable, true, "and says so, which is what stops the writer")
+  storage.broken = false
+
+  -- The degradations, which are what every caller leans on: no facade at all
+  -- (an older engine, or the headless stub), and no game yet (the title
+  -- screen, before a playthrough exists). Both are "nothing here" and neither
+  -- is a fault.
+  local bare = facadeOn(nil)
+  eq(Store.available(bare), false, "no storage facade is no durable half")
+  eq(select(2, Store.read(bare, "servers")), false,
+     "and reads as nothing rather than as a store that would not open")
+
+  local titleScreen = facadeOn(storage)
+  titleScreen.game = nil
+  eq(Store.available(titleScreen), false, "no game yet is no durable half")
+  eq(select(2, Store.read(titleScreen, "servers")), false,
+     "and is an ordinary answer, not a failure")
+  eq(Store.write(titleScreen, "servers", { rows = {} }), false,
+     "and a write before a playthrough exists lands nowhere")
+end
+
+-- ------- the recents list survives a save reload
+
+do
+  local storage = storageStub()
+
+  local firstMod = facadeOn(storage)
+  local first = Servers.new({ mod = firstMod })
+  check(first:record("192.168.1.20:7788") ~= nil, "a hub is recorded")
+  eq(type(storage.data[Config.SERVERS_KEY]) == "table"
+     and #storage.data[Config.SERVERS_KEY].rows, 1,
+     "and lands in the durable store, not only in the mirror")
+
+  -- The second launch: the same store, an empty mirror. This is exactly what a
+  -- CONTINUE does to mod.save, and the case the durable half exists for.
+  local secondMod = facadeOn(storage)
+  local second = Servers.new({ mod = secondMod })
+  local rows = second:list()
+  eq(#rows, 1, "a fresh copy with an empty save mirror still has the hub")
+  eq(rows[1].address, "192.168.1.20:7788", "with the address it was recorded under")
+end
+
+-- ------- and a read failure never becomes a wipe
+
+do
+  local storage = storageStub()
+  local firstMod = facadeOn(storage)
+  local first = Servers.new({ mod = firstMod })
+  first:record("kept.example:7788")
+  local before = storage.data[Config.SERVERS_KEY]
+  eq(#before.rows, 1, "one hub is stored")
+
+  storage.broken = true
+  local mod, save, warns = facadeOn(storage)
+  local blind = Servers.new({ mod = mod })
+  blind:record("other.example:7788")
+
+  eq(storage.data[Config.SERVERS_KEY], before,
+     "a store that would not open is left exactly as it was")
+  eq(type(save.servers) == "table" and #save.servers, 1,
+     "while the mirror still took this session's change")
+  check(#warns > 0, "and the player is told once, in a sentence they can act on")
+end
+
+-- ------- friends: the same two halves, keyed per hub
+
+do
+  local storage = storageStub()
+
+  local firstMod = facadeOn(storage)
+  local first = Friends.new(nil, nil, { mod = firstMod })
+  first:setHub("hub.example:7788", "ASH")
+  check(first:_add("MISTY"), "a friend is added to the open bucket")
+  check(type(storage.data[Config.FRIENDS_KEY]) == "table",
+        "and the bucket lands in the durable store")
+
+  local secondMod = facadeOn(storage)
+  local second = Friends.new(nil, nil, { mod = secondMod })
+  second:setHub("hub.example:7788", "ASH")
+  eq(#second:list(), 1, "a fresh copy with an empty mirror still has the friend")
+  eq(second:list()[1].name, "MISTY", "under the name they were kept as")
+
+  -- Another trainer on the same hub is another bucket, and writing one must
+  -- not forget the other -- the rule the whole re-read-before-write path in
+  -- _persist exists for.
+  local thirdMod = facadeOn(storage)
+  local third = Friends.new(nil, nil, { mod = thirdMod })
+  third:setHub("hub.example:7788", "GARY")
+  third:_add("BROCK")
+
+  local backMod = facadeOn(storage)
+  local back = Friends.new(nil, nil, { mod = backMod })
+  back:setHub("hub.example:7788", "ASH")
+  eq(#back:list(), 1, "the first trainer's list survived the second's write")
+end
+
+-- ------- the port override, after the environment stopped being readable
+
+do
+  local before = Config.DEFAULT_PORT
+
+  eq(Config.applyPort(7799), 7799, "a valid port is taken")
+  eq(Config.DEFAULT_HUB, "127.0.0.1:7799", "and the default hub moves with it")
+  eq(Config.applyPort("7801"), 7801, "a numeric string is a number")
+  eq(Config.applyPort(nil), Config.DEFAULT_PORT_FALLBACK,
+     "an unset option falls back rather than producing an unusable address")
+  eq(Config.applyPort("nonsense"), Config.DEFAULT_PORT_FALLBACK, "so does junk")
+  eq(Config.applyPort(0), Config.DEFAULT_PORT_FALLBACK, "so does out of range")
+  eq(Config.applyPort(70000), Config.DEFAULT_PORT_FALLBACK, "at either end")
+  eq(Config.applyPort(7788.5), Config.DEFAULT_PORT_FALLBACK,
+     "and a port has to be whole")
+
+  -- Left as this suite found it: every section above is written against
+  -- Config.DEFAULT_PORT as a symbol, and leaving it moved would rewrite what
+  -- they mean.
+  Config.applyPort(before)
+  eq(Config.DEFAULT_PORT, before, "and the suite's port is restored")
+end
+
+-- ------- a write before a playthrough exists is not a complaint
+
+do
+  local storage = storageStub()
+  storage.noPlaythrough = true
+  local mod, save, warns = facadeOn(storage)
+  local store = Servers.new({ mod = mod })
+
+  check(store:record("quiet.example:7788") ~= nil, "the hub is still recorded")
+  eq(#warns, 0,
+     "a write before a playthrough is identified says nothing to the player")
+  eq(type(save.servers) == "table" and #save.servers, 1,
+     "and the mirror took the change, which is what carries the session")
+
+  -- The read path already treated this state as ordinary; the point of the
+  -- pair is that the write path agrees with it.
+  eq(select(2, Store.read(mod, Config.SERVERS_KEY)), false,
+     "the read half calls the same state nothing-here rather than unreadable")
+  eq(select(2, Store.write(mod, Config.SERVERS_KEY, { rows = {} })),
+     Store.NO_PLAYTHROUGH,
+     "and the write half names it, so a caller can stay quiet about it")
+end
+
+-- ------- one Servers outlives the playthrough it cached
+
+do
+  local storage = storageStub()
+  local mod, save = facadeOn(storage)
+  local store = Servers.new({ mod = mod })
+
+  check(store:record("first.example:7788") ~= nil, "a hub is recorded")
+  eq(#store:list(), 1, "and listed")
+
+  -- The save underneath changed: another playthrough is another store and
+  -- another mirror. This object is built once when the mod loads and lives as
+  -- long as the process, so nothing about that swap reaches it on its own.
+  storage.data = {}
+  save.servers = nil
+  eq(#store:list(), 1,
+     "left alone it would keep showing the previous game's hubs -- the bug")
+
+  store:reset()
+  eq(#store:list(), 0,
+     "reset is what makes the next read start from the game now open")
+  eq(store:record("second.example:7788") ~= nil, true, "and recording works after")
+  eq(#storage.data[Config.SERVERS_KEY].rows, 1,
+     "with only the new game's hub written to the new store")
+end
+
+-- ------- the player id, which is the one that costs a rank history
+
+do
+  local storage = storageStub()
+  -- Client holds the shared stubMod, not a facade of ours, so the storage half
+  -- is lent to it here and handed back below -- never left nil'd, which is the
+  -- rule every section that borrows a stubMod field follows.
+  local prevStorage, prevGame = stubMod.storage, stubMod.game
+  local prevSave = stubSave
+  stubMod.storage, stubMod.game = storage.facade, {}
+
+  local FIRST = string.rep("a1b2c3d4", 4)
+  local SECOND = string.rep("9f8e7d6c", 4)
+
+  -- Upgrading: a build that kept this in a JSON file left the id in the mirror
+  -- and nowhere this copy can still open.
+  stubSave = { playerId = FIRST }
+  Client.resetPlayerIdCache()
+  eq(Client.playerId(), FIRST, "the mirrored id is what the hub is told")
+  eq(type(storage.data[Config.PLAYER_ID_KEY]) == "table"
+     and storage.data[Config.PLAYER_ID_KEY].id, FIRST,
+     "and it is carried into the store, so a CONTINUE cannot take it away")
+  local writes = storage.writes
+  Client.playerId()
+  Client.playerId()
+  eq(storage.writes, writes, "asking again costs no further writes")
+
+  -- Recall: the store is the half a save reload cannot rewind.
+  storage.data[Config.PLAYER_ID_KEY] = { id = SECOND }
+  stubSave = {}
+  Client.resetPlayerIdCache()
+  eq(Client.playerId(), SECOND, "an id in the store is recalled when the mirror is empty")
+  eq(stubSave.playerId, SECOND, "and mirrored, so the rest of the session agrees")
+
+  -- The save underneath changed. Storage is per playthrough and this cache is
+  -- per process, so without the reset the new game is handed the old game's
+  -- identity -- and a hub would seat two games as one player.
+  local second = storageStub()
+  stubMod.storage = second.facade
+  stubSave = {}
+  eq(Client.playerId(), SECOND,
+     "left alone the cache hands a new playthrough the old id -- the bug")
+
+  Client.resetPlayerIdCache()
+  stubSave = {}
+  local minted = Client.playerId()
+  check(minted ~= SECOND,
+        "reset is what makes a second game a second player")
+  check(Wire.playerId(minted) ~= nil, "and what it mints is a well-formed id")
+  eq(second.data[Config.PLAYER_ID_KEY]
+     and second.data[Config.PLAYER_ID_KEY].id, minted,
+     "written to the store the new playthrough actually has")
+
+  stubMod.storage, stubMod.game = prevStorage, prevGame
+  stubSave = prevSave
+end
+
+_G.love = ambientLove
+
+end)()
+
 T.finish("rby_mmo")


### PR DESCRIPTION
## Why

The next Gen1Recomp release runs mod code in a restricted environment: no `io`, no environment access, no love filesystem module, and a private `_G` per mod. Three of this mod's stores kept a JSON file beside the save, and one constant was read out of the environment **while `Config` was still loading** — so that line would not merely have lost a setting, it would have taken the whole mod down through `main.lua`'s resolver.

The announcement's check is clean on shipped code:

```sh
grep -rnE '\bio\.|os\.(getenv|execute|remove|rename|exit|tmpname)|love\.(filesystem|thread|system|event)|require\("(io|os|debug|package|ffi|love\.)' main.lua src/ manifest.json mod.card
```

## What changed

- **`src/Store.lua`** wraps `mod.storage` for the recents list, the friends lists and the persistent player id. It keeps the old file readers' two-value `(value, unreadable)` shape, so the rule the whole write path is built on — *a read failure must never become a wipe* — carries over unaltered. `not_in_playthrough` is an ordinary "nothing here" on **both** halves; otherwise a write before the engine has identified the playthrough warns the player, once per keypress, about something that is not wrong.
- **The upgrade path is free.** All three already mirrored to `mod.save` and already read it first, so a player coming from a build that wrote files keeps whatever their last save holds. `Client.playerId()` now also carries a mirror-sourced id *into* the store, once, so an upgraded identity does not live only in the half a CONTINUE rewinds.
- **Cache lifetimes.** Storage is scoped per playthrough; `Servers` and `Client`'s `playerIdStore` were scoped per process. `Servers:reset()` and `Client.resetPlayerIdCache()` now run from `saveLoaded` (which fires on `save.loaded` *and* `save.created`, so NEW GAME is covered) — without them a second game showed the previous one's hubs, wrote them into its store, and could be seated under its player id. `autoKey` from #39 resets with them.
- **`RBY_MMO_PORT` → a `HOST PORT` option row**, `type = "text"` rather than `"number"`: the manager's number widget and the `QuantityBox` behind it both step by one across the whole port range and draw the value behind the multiply glyph. The e2e drivers pass the port through `options.lua`, the same bucket the mod manager writes.
- **`permissions` drops `"filesystem"`** — there is no such permission any more, and under `api: 2` an unknown one is a hard load error, so this line alone would have stopped the mod loading.
- **`game_version` floors at `>=0.1.86`.** On an older engine this would load and then quietly forget all three stores between launches; being refused with a version the loader can name is the better failure. Dev checkouts are unaffected (the loader skips the gate on `0.0.0-dev`).

## What it costs

A recents list, friends list or player id no longer spans save slots on one copy — `mod.storage` is per playthrough and a file was not. The player id is the sharp edge: a hub seats you under it and the rank board keys on it, so a second game is a second player. `docs/upstream/machine-level-storage.md` asks upstream for a sibling scope rather than working around it.

`docs/upstream/manager-missing-dev-engine-exemption.md` reports a smaller find: `ManagerState` is the one of three engine call sites that does not skip the `game_version` check on a `0.0.0-dev` build, so every mod that takes the "floor at the current release" advice trips it on the F10 path.

## Tests

The durable half was never covered as a file (standing up a fake love filesystem under plain luajit was more machinery than it was worth); a four-method facade is something a headless stub can drive, so it now has a section — round trips, the never-wipe rule, the pre-playthrough state, and guards that **fail if either cache reset is removed** (mutation-checked both ways).

- suite 4580 checks, T4 22/22, `validate --base imported` / `lint` / `pack` green, twin parity 9/9
- Gen 1 and Gen 2 e2e both pass; the Gen 1 run exercises #39's AUTOJOIN assertions against the storage-backed store, and a live run was confirmed writing `mod_storage/red/<playthroughId>/rby_mmo/{servers,friends,identity}.lua`
- `server/` `npm test` has two failures (`auth`, `server`) that reproduce identically on a pristine baseline — pre-existing, untouched here