### PR TITLE
fix: evolve and save a POKéMON traded over the MMO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,20 @@ here must match `manifest.version`.
   degrades to applying the evolution outright with a line saying so: the
   trade is committed on both sides by then, and there is no second chance
   at a trade evolution.
+- **A finished trade is now written to disk, twice, the way the cable club
+  writes it.** pokered's `cable_club.asm` calls `SaveSAVtoSRAM` straight
+  after every trade so the swap is on the cartridge before the animation
+  runs, and the engine's `LinkState` does the same and then writes again
+  once the evolution movie ends (gen1recomp #222). A hub trade did neither:
+  the received POKéMON lived only in memory until the player happened to
+  open START > SAVE, so a force-quit lost it *and* handed back the one that
+  was traded away — two of the same POKéMON in the world, which is exactly
+  the duplication this session's teardown exists to prevent, arriving by the
+  back door. Worse here than on a cable, because finishing locally
+  deliberately does not end the session: this side sits in `settling` while
+  the peer acknowledges. Both writes are guarded and never raise — a build
+  with no `writeSave` is not a failure, and a refused or throwing write
+  leaves the swap in memory and names START > SAVE as the way out.
 - **A hub that accepts and never answers is given up on.** The transport's
   idle timeout measures silence *since the last message*, so it never covered
   a connection that had never had one: a listener that took the socket and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-08-17
+
 ### Added
 
 - **The battle theatre is not a Gen 1 feature any more.** Gold gets the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,24 @@ here must match `manifest.version`.
 
 ### Fixed
 
+- **A POKéMON traded over the MMO now evolves.** KADABRA stayed KADABRA,
+  MACHOKE stayed MACHOKE, and Gold's held-item trades stayed put — on both
+  transports and in both games. Neither TradeSession was at fault: both
+  answer *whether* the received mon evolves and hand it back as a second
+  return, and turning that answer into a screen has always been the caller's
+  job. On the cable club the caller is the engine's `LinkState`; nothing in
+  this mod was its opposite number, so the answer was dropped on the floor
+  with nothing logged on either side. `src/Sessions.lua` is now that caller:
+  the movie follows the "was traded over!" line rather than opening under it,
+  Gen 1 goes through `Evolution.evolve` with `via="TRADE"` so B cannot cancel
+  it, and Gold pushes the engine's own `Gen2EvolutionAnim` (row, party slot
+  and pop included) the way `Game2:afterRareCandy` does. `src/Trade2.lua`
+  stopped scanning for a TRADE row by hand and asks the engine's Gen 2
+  evolution module instead, so an Everstone refuses and a KING'S ROCK row
+  demands — and gets eaten by — its held item. A screen that cannot open
+  degrades to applying the evolution outright with a line saying so: the
+  trade is committed on both sides by then, and there is no second chance
+  at a trade evolution.
 - **A hub that accepts and never answers is given up on.** The transport's
   idle timeout measures silence *since the last message*, so it never covered
   a connection that had never had one: a listener that took the socket and

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.0.0](https://img.shields.io/badge/version-1.0.0-3aa757?style=for-the-badge)
+![v1.0.8](https://img.shields.io/badge/version-1.0.8-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -1333,7 +1333,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.0.0` (`experimental: false` — on by default when installed). The full
+It's `1.0.8` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Sessions.lua
+++ b/src/Sessions.lua
@@ -3,11 +3,20 @@
 -- **The two kinds part company here, and have since PROTOCOL 10.**
 --
 -- A *trade* is still the engine's own machinery: Protocol.TradeSession is a
--- symmetric state machine -- trade evolutions, the OT bookkeeping that marks a
+-- symmetric state machine -- the swap itself, the OT bookkeeping that marks a
 -- mon as traded, all of it -- driven over a SessionNet whose payloads the hub
 -- forwards unread.  So for a trade this module carries the request, runs the
 -- engine's real hello/verdict handshake, hands the session to TradeSession,
 -- and tears it down when either side leaves.
+--
+-- **One thing TradeSession decides but does not do: the trade evolution.**
+-- `apply` answers what the received mon becomes and hands that back as its
+-- second return; on the cable-club path src/link/LinkState.lua is what turns
+-- the answer into a screen.  A hub trade has no LinkState, so this module is
+-- that screen's opposite number -- see M:evolveTraded.  Reading the header
+-- above as "TradeSession does evolutions too" is exactly the mistake that
+-- left every MMO-traded MACHOKE a MACHOKE: the second return was dropped on
+-- the floor here and nothing errored, on either side.
 --
 -- A *battle* no longer touches any of that.  The intermediator -- the Node hub
 -- or a LAN host running src/BattleSim/ -- resolves the fight itself, so both
@@ -853,7 +862,12 @@ function M:advanceTrade(game, session)
 
   elseif trade.stage == "done" and not session.applied then
     session.applied = true
-    local ok, received = pcall(function() return trade:apply(game) end)
+    -- The slot the received mon lands in, read before apply so the evolution
+    -- below writes back into the party position the swap actually used
+    -- rather than searching for the record afterwards.
+    local slot = trade.myPick
+    local ok, received, evolveTo, evoEntry =
+      pcall(function() return trade:apply(game) end)
 
     -- Reaching "done" means two things at once: the peer's confirm is in
     -- hand, and this side's own confirm went out before the machine could
@@ -874,7 +888,24 @@ function M:advanceTrade(game, session)
 
     if ok then
       local name = received and tostring(received.species) or "a POKéMON"
-      self.ui:say(("%s was\ntraded over!"):format(name))
+      -- The evolution follows the line, never sits under it: the cable club
+      -- prints "Trade completed!" and only then flashes the mon, and a movie
+      -- opening on top of a box the player is still reading would bury it.
+      --
+      -- Runs immediately when nothing was pushed to wait on -- a build with
+      -- no UI, or a harness whose `say` is a stub -- because the trade is
+      -- committed on both sides by now and there is no second chance at it.
+      -- The guard is what keeps a stub that *both* calls back and returns
+      -- nothing from evolving the same mon twice.
+      local evolved = false
+      local function evolve()
+        if evolved then return end
+        evolved = true
+        self:evolveTraded(game, received, evolveTo, evoEntry, slot)
+      end
+      if not self.ui:say(("%s was\ntraded over!"):format(name), evolve) then
+        evolve()
+      end
     else
       -- The peer has our confirm and will apply regardless, so there is no
       -- undo to offer; what there is, is a way to see what actually landed.
@@ -888,6 +919,129 @@ function M:advanceTrade(game, session)
     self:endSession(trade.error and ("The trade stopped:\n" .. trade.error)
       or "The trade was\ncancelled.")
   end
+end
+
+-- ------- trade evolutions
+
+-- KADABRA into ALAKAZAM, on the side that just received it.
+--
+-- Both TradeSessions answer *whether* a received mon evolves and stop there
+-- (src/link/Protocol.lua's `evolveTo`, src/Trade2.lua's row) -- turning that
+-- answer into a screen has always been the caller's job, and on the cable
+-- club the caller is src/link/LinkState.lua.  This is the hub trade's half
+-- of that, and until it existed the answer went nowhere.
+--
+-- Two games, two screens, one shape:
+--
+--   * **Gen 1** goes through `Evolution.evolve`, which owns the
+--     EvolutionState push, and is handed via="TRADE" so B cannot cancel it
+--     (pokered skips the flash B-poll under LINK_STATE_TRADING, #213).
+--   * **Gold** has no link trade of its own, so this pushes the engine's
+--     Gen2EvolutionAnim the way src/core/Game2.lua's afterRareCandy does --
+--     including the pop, because that screen reports through `onDone` and
+--     leaves the stack to whoever pushed it.  B is left working there: the
+--     engine's screen only refuses a cancel for `force` (a stone), and
+--     inventing a second rule for it here is not this module's call.
+--
+-- Nothing raises: a missing module, an unregistered screen or a push that
+-- throws all fall through to applying the evolution outright, because the
+-- trade is committed on both sides by the time this runs and a mon left as
+-- the wrong species is permanent -- there is no second chance at a trade
+-- evolution.  The player is told what they missed rather than what broke.
+function M:evolveTraded(game, mon, evolveTo, entry, slot)
+  if not (game and type(mon) == "table" and evolveTo) then return false end
+
+  local isGen2 = Gen.generation(game) == 2
+  local ok, Evolution = pcall(require,
+    isGen2 and "src.core.gen2.Evolution" or "src.pokemon.Evolution")
+  if not (ok and type(Evolution) == "table") then
+    mod.log:warn("the engine's evolution module is unavailable, so the "
+      .. "POKéMON just traded over did not evolve -- update gen1recomp "
+      .. "(dev branch); the trade itself is safe")
+    return false
+  end
+
+  -- Gold's screen is driven by the row rather than by a species id; a build
+  -- whose TradeSession only answered the species still gets a usable one.
+  if isGen2 and type(entry) ~= "table" then
+    entry = { method = "EVOLVE_TRADE", into = evolveTo }
+  end
+
+  local shown
+  if isGen2 then
+    shown = self:showGen2Evolution(game, mon, entry, slot)
+  else
+    shown = pcall(Evolution.evolve, game, mon, evolveTo, nil, "TRADE")
+  end
+  if shown then return true end
+
+  -- No screen went up.  `evolve` applies before it prints on its headless
+  -- branch, so a mon already carrying the new species is one that got there
+  -- -- re-applying would rebuild its stats a second time for nothing.
+  if mon.species == evolveTo then return true end
+
+  -- Gold's `apply` builds a new record and answers nil when it cannot -- an
+  -- unknown target species, a dataset with no base stats behind it -- so the
+  -- fallback is only a success when something came back.  Gen 1 mutates in
+  -- place, and the species is the same statement of it.
+  local ran, applied = pcall(function()
+    if not isGen2 then
+      Evolution.apply(game, mon, evolveTo, "TRADE")
+      return mon.species == evolveTo
+    end
+    local evolvedMon = Evolution.apply(game.data, mon, entry)
+    if not evolvedMon then return false end
+    local party = game.save and game.save.party
+    if party and slot and party[slot] == mon then party[slot] = evolvedMon end
+    if Evolution.markPokedex then
+      Evolution.markPokedex(game.save, evolvedMon.species)
+    end
+    return true
+  end)
+  if ran and applied then
+    mod.log:warn("could not open the evolution screen, so %s evolved into "
+      .. "%s without one -- the POKéMON is fine; report the line above",
+      tostring(mon.nickname or mon.species), tostring(evolveTo))
+    return true
+  end
+
+  mod.log:warn("%s did not evolve after the trade -- trade it again to give "
+    .. "the evolution another chance", tostring(mon.nickname or mon.species))
+  return false
+end
+
+-- The Gen 2 push, split out because it carries the slot bookkeeping the Gen
+-- 1 path does not need: EvolutionAnim builds a *new* party record and files
+-- it at `index`, so a wrong index would write the evolved mon over somebody
+-- else's slot.  `slot` is what the trade filed the mon into; it is verified
+-- against the party rather than trusted, and searched for if the party moved
+-- under us between the swap and the box being dismissed.
+function M:showGen2Evolution(game, mon, entry, slot)
+  local party = game.save and game.save.party
+  if type(party) ~= "table" then return false end
+  if party[slot] ~= mon then
+    slot = nil
+    for i, member in ipairs(party) do
+      if member == mon then
+        slot = i
+        break
+      end
+    end
+    if not slot then return false end
+  end
+
+  local ok, pushed = pcall(mod.ui.push, game, "Gen2EvolutionAnim", {
+    mon = mon,
+    entry = entry,
+    index = slot,
+    party = party,
+    save = game.save,
+    onDone = function()
+      local stack = game.stack
+      if stack and stack.pop then stack:pop() end
+    end,
+  })
+  return ok and type(pushed) == "table"
 end
 
 -- ------- per-tick

--- a/src/Sessions.lua
+++ b/src/Sessions.lua
@@ -887,6 +887,11 @@ function M:advanceTrade(game, session)
     session.net:send({ type = APPLIED })
 
     if ok then
+      -- On the cartridge before anything is drawn -- see M:saveTrade.  First,
+      -- and ahead of the box: the swap is already in game.save.party, and
+      -- every frame it is only there is a frame a force-quit can undo it in.
+      self:saveTrade(game)
+
       local name = received and tostring(received.species) or "a POKéMON"
       -- The evolution follows the line, never sits under it: the cable club
       -- prints "Trade completed!" and only then flashes the mon, and a movie
@@ -919,6 +924,48 @@ function M:advanceTrade(game, session)
     self:endSession(trade.error and ("The trade stopped:\n" .. trade.error)
       or "The trade was\ncancelled.")
   end
+end
+
+-- ------- committing the trade to disk
+
+-- The swap, on the cartridge, the moment it happens -- and again once the
+-- evolution that followed it has settled.
+--
+-- Both saves are the cable club's (src/link/LinkState.lua's "done" branch,
+-- gen1recomp #222): pokered's engine/link/cable_club.asm calls SaveSAVtoSRAM
+-- straight after every trade, so the trade is committed before the animation
+-- runs, and the second write is what keeps the *evolved* species on disk
+-- rather than the pre-evo `apply` landed.  Without them the received mon
+-- lives only in memory until the player happens to open START > SAVE: a
+-- force-quit loses it outright, and a reset gives back the one that was
+-- traded away -- so the pair of them are now two copies of the same mon in
+-- the world, which is the duplication this session's whole teardown exists
+-- to prevent, arriving by the back door.
+--
+-- **A hub trade holds that window open longer than a cable trade does.**
+-- Finishing locally is deliberately not what ends the session here: this
+-- side sits in "settling" for as long as SETTLE_TIMEOUT while the peer
+-- acknowledges, and the player is free to walk away, be dropped, or quit
+-- during it.
+--
+-- Guarded and pcall'd rather than called flat.  A build with no writeSave --
+-- the headless suites, the LinkBattle-shaped fake games the engine's own
+-- call site names -- is not a failure, and a save that throws must not take
+-- the trade down with it: the swap has happened in memory either way, and
+-- the honest thing to do is say so and name the way out.  `false` is a
+-- refusal rather than a throw (src/script/Commands.lua reads it that way for
+-- a tool session that vetoes writes) and is reported the same.
+function M:saveTrade(game)
+  if type(game) ~= "table" or type(game.writeSave) ~= "function" then
+    return false
+  end
+  local ok, wrote = pcall(game.writeSave, game)
+  if ok and wrote ~= false then return true end
+  mod.log:warn("could not save after the trade (%s) -- the POKéMON is in "
+    .. "the party, but save from START > SAVE before quitting or it will "
+    .. "not be there next time",
+    ok and "the game refused the write" or tostring(wrote))
+  return false
 end
 
 -- ------- trade evolutions
@@ -967,11 +1014,16 @@ function M:evolveTraded(game, mon, evolveTo, entry, slot)
     entry = { method = "EVOLVE_TRADE", into = evolveTo }
   end
 
+  -- The second write of the pair M:saveTrade documents, on the far side of
+  -- the movie: what `apply` committed to disk was the pre-evo, and this is
+  -- what puts the species the player is now looking at there instead.
+  local function persist() self:saveTrade(game) end
+
   local shown
   if isGen2 then
-    shown = self:showGen2Evolution(game, mon, entry, slot)
+    shown = self:showGen2Evolution(game, mon, entry, slot, persist)
   else
-    shown = pcall(Evolution.evolve, game, mon, evolveTo, nil, "TRADE")
+    shown = pcall(Evolution.evolve, game, mon, evolveTo, persist, "TRADE")
   end
   if shown then return true end
 
@@ -999,6 +1051,8 @@ function M:evolveTraded(game, mon, evolveTo, entry, slot)
     return true
   end)
   if ran and applied then
+    -- The movie is what the player lost, not the evolution and not the save.
+    persist()
     mod.log:warn("could not open the evolution screen, so %s evolved into "
       .. "%s without one -- the POKéMON is fine; report the line above",
       tostring(mon.nickname or mon.species), tostring(evolveTo))
@@ -1016,7 +1070,11 @@ end
 -- else's slot.  `slot` is what the trade filed the mon into; it is verified
 -- against the party rather than trusted, and searched for if the party moved
 -- under us between the swap and the box being dismissed.
-function M:showGen2Evolution(game, mon, entry, slot)
+--
+-- `onDone` is the caller's second save, run beside the pop rather than
+-- handed to the screen: Gen2EvolutionAnim reports and then waits to be taken
+-- down, so both belong to whoever pushed it.
+function M:showGen2Evolution(game, mon, entry, slot, onDone)
   local party = game.save and game.save.party
   if type(party) ~= "table" then return false end
   if party[slot] ~= mon then
@@ -1039,6 +1097,9 @@ function M:showGen2Evolution(game, mon, entry, slot)
     onDone = function()
       local stack = game.stack
       if stack and stack.pop then stack:pop() end
+      -- After the pop, so the write sees the party the screen finished
+      -- filing rather than one mid-commit.
+      if onDone then onDone() end
     end,
   })
   return ok and type(pushed) == "table"

--- a/src/Trade2.lua
+++ b/src/Trade2.lua
@@ -160,12 +160,32 @@ local function packParty2(party, indices)
   return mons
 end
 
-local function tradeEvolveTo(data, received)
+-- What a received mon evolves into, and the EvosAttacks row that said so.
+--
+-- Gold's own rules, through the engine's Gen 2 evolution module: `ctx.link`
+-- is what turns the EVOLVE_TRADE rows on and every other method off, and it
+-- is also what brings the conditions a hand-rolled scan cannot see -- an
+-- Everstone refusing, a KING'S ROCK row demanding its held item, and the
+-- EvosAttacks order that makes Poliwhirl's stone row beat its trade row.
+--
+-- **The row is returned as well as the species**, because src/Sessions.lua
+-- drives Gen2EvolutionAnim with it: that screen reads `entry.into` and eats
+-- the held item itself, so handing it a species id would lose both.
+--
+-- The scan below is the fallback for an engine without the module -- the
+-- same first-TRADE-row answer, minus the conditions it has no way to weigh.
+local function tradeEvolution(data, received)
+  local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+  if ok and type(Evolution) == "table" and Evolution.checkMon then
+    local entry = Evolution.checkMon(data, received, { link = true })
+    if entry then return entry.into, entry end
+    return nil
+  end
   local def = data and data.pokemon and data.pokemon[received.species]
   for _, evo in ipairs((def and def.evolutions) or {}) do
     local method = evo.method
     if method == "TRADE" or method == "EVOLVE_TRADE" then
-      return evo.species or evo.into
+      return evo.species or evo.into, evo
     end
   end
   return nil
@@ -341,7 +361,8 @@ function TradeSession:advance()
   end
 end
 
--- Apply into Gen 2 party + party mail. Returns received mon, evolveTo.
+-- Apply into Gen 2 party + party mail. Returns received mon, evolveTo, and
+-- the evolution row that decided it (nil when nothing evolves).
 function TradeSession:apply(game)
   game = game or self.game
   if self.stage ~= "done" then
@@ -367,10 +388,10 @@ function TradeSession:apply(game)
   if game and game.save then
     markDex(game.save, received.species)
   end
-  local evolveTo = tradeEvolveTo(self.data, received)
+  local evolveTo, evoEntry = tradeEvolution(self.data, received)
   emit("trade.completed",
     { sent = sent, received = received, evolveTo = evolveTo })
-  return received, evolveTo
+  return received, evolveTo, evoEntry
 end
 
 return M

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -4950,7 +4950,14 @@ local function tradeSide(hub, name, species)
     isReady = function() return true end,
   }
   side.ui = {
-    say = function(_, text) side.said[#side.said + 1] = text end,
+    -- A real say pushes a box the player has to dismiss and hands it back,
+    -- which is what the trade evolution waits on: the movie follows the
+    -- "traded over!" line rather than opening underneath it.
+    say = function(_, text, onDone)
+      side.said[#side.said + 1] = text
+      side.sayDone = onDone
+      return { kind = "text" }
+    end,
     confirm = function(_, _, text, cb)
       side.confirmText = text
       side.confirmBox = cb
@@ -5015,6 +5022,13 @@ local function answerConfirm(side, yes)
   local box = side.confirmBox
   side.confirmBox = nil
   box(yes)
+end
+
+-- A on the last line this side was shown.
+local function dismissSay(side)
+  local box = side.sayDone
+  side.sayDone = nil
+  if box then box() end
 end
 
 -- Two players, paired through the hub, driven as far as both confirm boxes
@@ -5212,6 +5226,89 @@ orphan:onRelay({ from = "1", payload = {} })
 eq(#warns, 1, "a relay with no session open is logged exactly once")
 
 stubMod.log.warn = function() end
+
+-- ------- the trade evolution
+--
+-- TradeSession answers what a received mon becomes and stops there; turning
+-- that answer into a screen has always been the caller's job, and on the
+-- cable club the caller is src/link/LinkState.lua.  Nothing here was that
+-- caller, so `apply`'s second return went on the floor and an MMO-traded
+-- KADABRA stayed a KADABRA -- silently, on both sides.
+--
+-- Driven against the engine's own Evolution.evolve, recorded rather than
+-- run: what is worth pinning is that the seam is reached at all, for the mon
+-- that just landed, with the `via` that stops B working.  The movie itself
+-- is the engine's and has the engine's tests.
+--
+-- In a `do` block of its own: the chunk this sits in is already close to
+-- LuaJIT's 200-active-local ceiling, and a scoped block hands its slots back.
+
+do
+
+local Evolution = require("src.pokemon.Evolution")
+local realEvolve = Evolution.evolve
+local fixtureEvos = Data.pokemon.FIXMON_C.evolutions
+Data.pokemon.FIXMON_C.evolutions = { { method = "TRADE", species = "FIXMON_A" } }
+
+local evolveCall
+Evolution.evolve = function(_, mon, species, _, via)
+  evolveCall = { mon = mon, species = species, via = via }
+end
+
+local _, ann9, bob9 = pairAtConfirm()
+answerConfirm(ann9, true)
+pump(ann9); pump(ann9)
+pump(bob9)
+answerConfirm(bob9, true)
+pump(bob9); pump(ann9); pump(bob9); pump(ann9)
+
+eq(partyOf(ann9), "FIXMON_C", "ANN receives the POKéMON with a trade row on it")
+eq(evolveCall, nil, "and nothing evolves while the trade box is still up")
+
+dismissSay(ann9)
+check(evolveCall ~= nil, "dismissing that box is what starts the evolution")
+eq(evolveCall.mon, ann9.game.save.party[1],
+   "for the record that just landed in the party, not the sheet off the wire")
+eq(evolveCall.species, "FIXMON_A", "into what the engine said it becomes")
+eq(evolveCall.via, "TRADE", "as a trade evolution, which B cannot cancel")
+
+evolveCall = nil
+dismissSay(bob9)
+eq(evolveCall, nil, "while the side holding a POKéMON with no trade row evolves nothing")
+
+-- ------- ...and a screen that will not open does not cost the evolution
+--
+-- The trade is committed on both sides by the time this runs, and there is
+-- no second chance at a trade evolution: a mon left as the wrong species is
+-- left that way forever.  So the movie failing degrades to applying it
+-- outright, with a line saying so, rather than to nothing at all.
+
+local evoWarns = {}
+stubMod.log.warn = function(_, fmt, ...)
+  local okFmt, line = pcall(string.format, fmt, ...)
+  evoWarns[#evoWarns + 1] = okFmt and line or tostring(fmt)
+end
+Evolution.evolve = function() error("no evolution screen in this build", 0) end
+
+local _, ann10, bob10 = pairAtConfirm()
+answerConfirm(ann10, true)
+pump(ann10); pump(ann10)
+pump(bob10)
+answerConfirm(bob10, true)
+pump(bob10); pump(ann10); pump(bob10); pump(ann10)
+dismissSay(ann10)
+
+eq(partyOf(ann10), "FIXMON_A", "the POKéMON evolved even with no screen to do it in")
+eq(#ann10.game.save.party, 1, "and the party did not grow while doing it")
+eq(ann10.game.save.pokedex.owned.FIXMON_A, true, "with the dex told about it")
+check(#evoWarns > 0 and evoWarns[1]:find("evolution screen"),
+      "and a line naming what the player missed rather than what broke")
+
+Evolution.evolve = realEvolve
+Data.pokemon.FIXMON_C.evolutions = fixtureEvos
+stubMod.log.warn = function() end
+
+end
 
 -- ------- a ranked battle's paperwork survives the session it belonged to
 --

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -4973,6 +4973,7 @@ local function tradeSide(hub, name, species)
     ctx = {},
   }
   side.sessions = Sessions.new(side.transport, side.ui)
+  side.saves = 0
   side.game = {
     data = Data,
     save = {
@@ -4980,6 +4981,17 @@ local function tradeSide(hub, name, species)
       player = { name = name },
       pokedex = { seen = {}, owned = {} },
     },
+    -- The cable club commits a trade to the cartridge the instant it lands
+    -- (gen1recomp #222); this counts the same writes on the hub path, and
+    -- snapshots the party at each one so a test can say *what* was saved
+    -- rather than only that something was.
+    writeSave = function(self)
+      side.saves = side.saves + 1
+      local names = {}
+      for _, mon in ipairs(self.save.party) do names[#names + 1] = mon.species end
+      side.savedParty = table.concat(names, ",")
+      return true
+    end,
   }
   hub:receive(side.client, { type = Wire.HELLO, proto = Config.PROTOCOL,
       playerId = testPlayerId("anon14_" .. name),
@@ -5085,6 +5097,22 @@ eq(#ann.game.save.party, 1, "ANN's party did not grow")
 eq(#bob.game.save.party, 1, "nor did BOB's")
 eq(ann.sessions.active, nil, "and the session is closed on ANN's side")
 eq(bob.sessions.active, nil, "and on BOB's")
+
+-- ------- and it is on disk, not just in memory
+--
+-- The cable club writes the save the instant the swap commits (pokered's
+-- cable_club.asm calls SaveSAVtoSRAM after every trade; gen1recomp #222).
+-- Nothing here did, so a force-quit between the trade and the player's next
+-- visit to START > SAVE lost the mon they received and gave back the one
+-- they sent -- two of the same POKéMON in the world, which is precisely the
+-- duplication the rest of this section exists to prevent, arriving by the
+-- back door.  A hub trade holds that window open longer than a cable trade
+-- does: this side sits in "settling" while the peer acknowledges.
+
+check(ann.saves >= 1, "the trade is committed to disk rather than left in memory")
+eq(ann.savedParty, "FIXMON_C", "with the swap already in the party that was written")
+check(bob.saves >= 1, "and the same on the other side of it")
+eq(bob.savedParty, "FIXMON_B", "carrying his half of the swap")
 
 -- ------- the other ordering, which used to decide who lost a POKéMON
 
@@ -5251,8 +5279,8 @@ local fixtureEvos = Data.pokemon.FIXMON_C.evolutions
 Data.pokemon.FIXMON_C.evolutions = { { method = "TRADE", species = "FIXMON_A" } }
 
 local evolveCall
-Evolution.evolve = function(_, mon, species, _, via)
-  evolveCall = { mon = mon, species = species, via = via }
+Evolution.evolve = function(_, mon, species, onDone, via)
+  evolveCall = { mon = mon, species = species, via = via, done = onDone }
 end
 
 local _, ann9, bob9 = pairAtConfirm()
@@ -5271,6 +5299,17 @@ eq(evolveCall.mon, ann9.game.save.party[1],
    "for the record that just landed in the party, not the sheet off the wire")
 eq(evolveCall.species, "FIXMON_A", "into what the engine said it becomes")
 eq(evolveCall.via, "TRADE", "as a trade evolution, which B cannot cancel")
+
+-- The second write of the pair: what the swap committed was the pre-evo, so
+-- the movie ending has to put the species the player is now looking at on
+-- disk instead.  The engine applies before it calls back, so the stub does.
+local savedBefore = ann9.saves
+check(type(evolveCall.done) == "function",
+      "and the engine is handed something to call when the movie ends")
+evolveCall.mon.species = "FIXMON_A"
+evolveCall.done()
+eq(ann9.saves, savedBefore + 1, "which writes the save a second time")
+eq(ann9.savedParty, "FIXMON_A", "with the evolved species on it, not the pre-evo")
 
 evolveCall = nil
 dismissSay(bob9)
@@ -5301,6 +5340,9 @@ dismissSay(ann10)
 eq(partyOf(ann10), "FIXMON_A", "the POKéMON evolved even with no screen to do it in")
 eq(#ann10.game.save.party, 1, "and the party did not grow while doing it")
 eq(ann10.game.save.pokedex.owned.FIXMON_A, true, "with the dex told about it")
+eq(ann10.savedParty, "FIXMON_A",
+   "and the evolved species reached the disk too -- the movie is what was "
+   .. "lost, not the evolution and not the save")
 check(#evoWarns > 0 and evoWarns[1]:find("evolution screen"),
       "and a line naming what the player missed rather than what broke")
 

--- a/tests/trade2.lua
+++ b/tests/trade2.lua
@@ -260,10 +260,12 @@ do
 
   local other = { species = "TOTODILE", level = 5 }
   local evolving = { species = "CYNDAQUIL", level = 10 }
+  local saves = 0
   local evoGame = {
     data = { pokemon = { CYNDAQUIL = {}, QUILAVA = {} } },
     save = { generation = 2, party = { other, evolving } },
     stack = { pop = function(stack) stack.popped = true end },
+    writeSave = function() saves = saves + 1 return true end,
   }
   local entry = { method = "EVOLVE_TRADE", into = "QUILAVA" }
   local sessions = Sessions.new({}, {})
@@ -275,8 +277,12 @@ do
   eq(pushes[1].opts.mon, evolving, "for the mon that landed there")
   eq(pushes[1].opts.entry, entry, "driven by the row, not by a species id")
   eq(pushes[1].opts.party, evoGame.save.party, "writing back into the real party")
+  eq(saves, 0, "nothing is written while the movie is still playing")
   pushes[1].opts.onDone({})
   eq(evoGame.stack.popped, true, "and the screen is popped by whoever pushed it")
+  -- The trade's own write landed the pre-evo; this is what replaces it with
+  -- the species the player ends up holding (gen1recomp #222's second save).
+  eq(saves, 1, "with the evolved Gold party committed to disk on the way out")
 
   -- A party that moved under us between the swap and the box being dismissed
   -- is searched rather than trusted; the wrong index is the one thing here
@@ -286,6 +292,26 @@ do
   check(sessions:evolveTraded(evoGame, evolving, "QUILAVA", entry, 2),
     "a stale slot still finds the mon")
   eq(pushes[1].opts.index, 1, "at where it actually sits now")
+
+  -- ------- and a save that cannot happen is said out loud, not swallowed
+  --
+  -- The swap has already happened in memory by the time any of this runs, so
+  -- a throwing or refusing writeSave must not take the trade down with it --
+  -- but the player has to be told, because the way out is theirs to take.
+  -- `false` is a refusal rather than a throw (a tool session vetoing writes)
+  -- and reads the same from here.
+  local before = #warns
+  eq(sessions:saveTrade({ save = {} }), false,
+    "a build with no writeSave at all is not a failure")
+  eq(#warns, before, "and says nothing about it")
+
+  eq(sessions:saveTrade({ writeSave = function() return false end }), false,
+    "a refused write is reported")
+  eq(sessions:saveTrade({ writeSave = function() error("disk full", 0) end }), false,
+    "and so is one that throws")
+  eq(#warns, before + 2, "one line each")
+  check(warns[#warns]:find("START") ~= nil,
+    "naming somewhere the player can go from")
 
   stubMod.ui = nil
   Gen.generation = realGen

--- a/tests/trade2.lua
+++ b/tests/trade2.lua
@@ -137,6 +137,44 @@ session.stage = "done"
 session:apply(game)
 eq(game.save.mail.party[1], nil, "absent peer mail clears the slot")
 
+-- ------- the trade evolution, and the row that decides it
+--
+-- apply answers what the received mon becomes; src/Sessions.lua is what puts
+-- that on screen.  The row travels with the species because Gold's
+-- EvolutionAnim is driven by the row -- it reads `into` and eats a demanded
+-- held item itself -- so a species id alone would lose both.
+
+do
+  local def = game.data.pokemon.CYNDAQUIL
+  def.evolutions = { { method = "EVOLVE_TRADE", into = "QUILAVA" } }
+  game.data.pokemon.QUILAVA = { name = "QUILAVA", evolutions = {} }
+
+  local evoSession = Trade2.TradeSession.new(game, { peerName = "ANN" })
+  evoSession.stage = "done"
+  evoSession.myPick = 1
+  evoSession.theirPick = 1
+  evoSession.theirParty = { { species = "CYNDAQUIL", level = 10 } }
+  evoSession.theirMail = {}
+  local _, evolveTo, evoEntry = evoSession:apply(game)
+  eq(evolveTo, "QUILAVA", "a received mon with a trade row evolves")
+  check(type(evoEntry) == "table" and evoEntry.into == "QUILAVA",
+    "and the row that said so travels with it")
+
+  -- The whole reason this goes through the engine's module rather than a
+  -- scan of its own: an Everstone is a condition a scan cannot see.
+  local okEvo, Gen2Evolution = pcall(require, "src.core.gen2.Evolution")
+  if okEvo and type(Gen2Evolution) == "table" and Gen2Evolution.checkMon then
+    evoSession.stage = "done"
+    evoSession.theirParty =
+      { { species = "CYNDAQUIL", level = 10, item = Gen2Evolution.EVERSTONE } }
+    local _, stoned = evoSession:apply(game)
+    eq(stoned, nil, "an Everstone refuses the trade evolution")
+  end
+
+  def.evolutions = {}
+  game.data.pokemon.QUILAVA = nil
+end
+
 -- ------- capable() tracks Protocol.packMon2 when the engine has it
 
 local okP, Protocol = pcall(require, "src.link.Protocol")
@@ -204,6 +242,52 @@ do
       } })
   check(ended ~= nil, "Gen2 without packMon2 refuses the trade")
   Trade2.capable = realCapable
+
+  -- ------- and the Gen 2 evolution goes to the engine's own screen
+  --
+  -- Gold has no link trade of its own, so there is no LinkState to copy:
+  -- Sessions pushes Gen2EvolutionAnim the way src/core/Game2.lua's
+  -- afterRareCandy does.  The index matters more than anything else here --
+  -- that screen builds a NEW party record and files it at `index`, so a
+  -- wrong one writes the evolved mon over somebody else's slot.
+  local pushes = {}
+  stubMod.ui = {
+    push = function(_, id, opts)
+      pushes[#pushes + 1] = { id = id, opts = opts }
+      return { kind = "screen" }
+    end,
+  }
+
+  local other = { species = "TOTODILE", level = 5 }
+  local evolving = { species = "CYNDAQUIL", level = 10 }
+  local evoGame = {
+    data = { pokemon = { CYNDAQUIL = {}, QUILAVA = {} } },
+    save = { generation = 2, party = { other, evolving } },
+    stack = { pop = function(stack) stack.popped = true end },
+  }
+  local entry = { method = "EVOLVE_TRADE", into = "QUILAVA" }
+  local sessions = Sessions.new({}, {})
+  check(sessions:evolveTraded(evoGame, evolving, "QUILAVA", entry, 2),
+    "a Gen 2 trade evolution is put on screen")
+  eq(#pushes, 1, "exactly one screen")
+  eq(pushes[1].id, "Gen2EvolutionAnim", "the engine's own")
+  eq(pushes[1].opts.index, 2, "filed at the slot the trade landed in")
+  eq(pushes[1].opts.mon, evolving, "for the mon that landed there")
+  eq(pushes[1].opts.entry, entry, "driven by the row, not by a species id")
+  eq(pushes[1].opts.party, evoGame.save.party, "writing back into the real party")
+  pushes[1].opts.onDone({})
+  eq(evoGame.stack.popped, true, "and the screen is popped by whoever pushed it")
+
+  -- A party that moved under us between the swap and the box being dismissed
+  -- is searched rather than trusted; the wrong index is the one thing here
+  -- that would cost a player a different POKéMON.
+  pushes = {}
+  table.remove(evoGame.save.party, 1)
+  check(sessions:evolveTraded(evoGame, evolving, "QUILAVA", entry, 2),
+    "a stale slot still finds the mon")
+  eq(pushes[1].opts.index, 1, "at where it actually sits now")
+
+  stubMod.ui = nil
   Gen.generation = realGen
 end
 


### PR DESCRIPTION
## What was wrong

Neither TradeSession was broken. `Protocol.TradeSession:apply` (Gen 1) and `Trade2.TradeSession:apply` (Gold) both **decide** whether a received mon evolves and hand it back as a second return value — playing the movie has always been the *caller's* job, and on the cable club that caller is the engine's `src/link/LinkState.lua`. This mod had no counterpart, so `src/Sessions.lua:advanceTrade` did:

```lua
local ok, received = pcall(function() return trade:apply(game) end)
```

…and dropped `evolveTo` on the floor. A traded KADABRA stayed a KADABRA, silently, on both sides. The module header even claimed TradeSession handled "trade evolutions… all of it", which is the belief that let it sit.

Pulling that thread surfaced a second gap on the same code path: **the mod never called `game:writeSave()` after a trade.** pokered's `cable_club.asm` calls `SaveSAVtoSRAM` straight after every trade and `LinkState` ports that as two writes — one on commit, one after the evolution (gen1recomp #222). A hub trade did neither, so the received mon lived only in memory until the player happened to open START > SAVE. A force-quit lost it *and* restored the one that had been traded away — two copies of one mon across the two players, which is exactly the duplication this session's teardown exists to prevent, arriving by the back door. The window is wider here than on a cable, and by design: finishing locally deliberately doesn't end the session, so this side sits in `settling` while the peer acknowledges.

## What changed

**`src/Sessions.lua`**
- `M:evolveTraded` / `M:showGen2Evolution`, driven from the `"X was traded over!"` box's `onDone` so the movie follows the line instead of opening underneath it. Gen 1 goes through `Evolution.evolve(…, "TRADE")` so B can't cancel it (pokered skips the flash B-poll under `LINK_STATE_TRADING`); Gold pushes the engine's own `Gen2EvolutionAnim` with the row, party slot, and the pop that screen leaves to its caller — same shape as `Game2:afterRareCandy`. The slot is verified against the party rather than trusted, since that screen files a *new* record at `index`.
- No screen available → the evolution is applied outright with a line saying so. The trade is committed on both sides by then and there is no second chance at a trade evolution.
- `M:saveTrade` is the pair of writes: on commit, and again after the evolution settles (movie callback, Gold's post-pop, and the fallback). Guarded and `pcall`'d — a build with no `writeSave` is not a failure, and a refused (`false`, a tool-session veto) or throwing write leaves the swap in memory and names START > SAVE as the way out.

**`src/Trade2.lua`** — stopped scanning for a TRADE row by hand and asks `gen2.Evolution.checkMon(data, mon, { link = true })` instead, so an Everstone refuses and a KING'S ROCK-style row demands (and consumes) its held item. `apply` now returns the row alongside the species, because that's what the Gold screen reads.

**Release 1.0.8** — the manifest had been stuck at `1.0.0` since #31 while eight releases went out as tags alone, so the mod manager never moved and no `[1.0.0]` heading was ever stamped. This aligns the manifest with the tag scheme (`manifest.json`, `server/package.json`, README badge) and stamps everything that had accumulated under `[Unreleased]` as the 1.0.8 notes. The README's *"from 1.0.0 it is enabled by default"* line is left alone — it says when the behaviour started, not what version you're on.

## Compatibility

**No protocol bump, no server update.** `Config.PROTOCOL` stays 21 and nothing under `server/`, `src/Wire.lua`, `src/Transport.lua` or `src/Hub.lua` is touched — grepping the diff for `Wire.`, `net:send`, `transport:send` or `PROTOCOL` returns nothing. A trade rides `mmo.relay`, whose payloads the hub forwards unread, and everything added here happens *after* `apply` has already put the mon in `game.save.party`. Twin-parity suites still pass (9/9 constants+vocabulary, 26/26 hub protocol).

Mixed versions are fine: each side computes its own evolution from the mon already in its party, so a patched and an unpatched player trade successfully either way — the unpatched one just keeps the old behaviour on their own side. `affects_link` is still `false` and no link registry was written, so the fingerprint is unmoved.

## Testing

- Mod suite **4599/4599**, `tests/trade2.lua` **43/43**, T4 **35/35 suites**, `modkit validate` / `lint` / `pack` (warnings-fatal) clean.
- New coverage pins the box-then-evolve ordering, the mon, the species and the `via`; the no-screen fallback; the row travelling with the species; the Everstone refusal; the Gen 2 push's index/party/pop; and the save/refusal paths. The suite counts writes and snapshots the party at each one, so it asserts *what* reached the disk — the swap on both sides, then the evolved species and not the pre-evo. **Every new assertion was verified to fail with the change stashed.**
- All three real-LÖVE e2e transports re-run after the save change, 0 failures each: `run-mmo-e2e.sh` (Gen 1 LAN), `run-mmo-e2e-gen2.sh` (Gold), `run-hub-e2e.sh` (Node hub).

## Note for the merger

Nothing is tagged yet — `git tag v1.0.8` on merge to match the announced version.