### PR TITLE
fix: name, register and own a POKéMON caught in an MMO fight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The catcher can name what they caught.** A wild caught in an MMO fight —
+  the co-op `coop_wild` divert, or a mediated 1v1 wild — was granted straight
+  into the party or the PC, and that was the end of it: the catcher was the
+  one player in the game who never saw "Do you want to give a nickname to
+  X?". The engine asks it on its own catch path
+  (`BattleState:storeCaughtMon` → `askNicknameUI`); this mod grants MMO
+  catches itself (`grantCatch` on both battle screens) and had no equivalent.
+  - Both screens now record the prompt as *owed* on the grant and ask it when
+    the message queue runs dry — after "Gotcha!" and the line saying where the
+    monster went, and before the player is allowed off the battle, which is
+    the engine's own ordering. Asking at grant time would have put a letter
+    grid over a catch the player had not been told about yet.
+  - Boxed catches are asked too: `AddPartyMon` and `SendNewMonToBox` both call
+    `AskName` on the cart, so a full party costs the slot and not the naming.
+  - `src/Gen.lua` owns the generation split (`nicknameScreenId`,
+    `nicknamePromptText`, `askNickname`): Red opens `NamingScreen` with the
+    ROM's own `_DoYouWantToNicknameText`, Gold opens `Gen2NamingScreen` with
+    its species icon — and, the part that actually bites, Gen 1's grid pops
+    itself before calling back while Gold's does not, so this pops for Gold
+    and leaves Gen 1 alone.
+  - A build that cannot open either screen says so and lets the fight end
+    rather than holding the player on a finished battle.
+
+- **...and the rest of what a catch does.** Adding the monster was the only
+  thing an MMO grant did, so a caught POKéMON was owned by nobody, the
+  #DEX never moved, an UNOWN caught on Gold never unlocked its letter, and no
+  mod listening for a catch heard one. `Gen.recordCatch` now does what the
+  engine's own capture does to the save, before the monster is given a home
+  (which is the order `BattleState:storeCaughtMon` writes them in, and why a
+  catch with nowhere to go still counts as seen):
+  - **The #DEX** — seen plus owned, under `caught` on a Gold save and `owned`
+    on a Red one, the same pair `Gen.dexCounts` and `src/Trade2.lua` already
+    agree on. A species that was new says so on screen, in each game's own
+    words. The #DEX *entry page* the engine opens next is deliberately not
+    pushed: a battle screen with one queue and three other players still
+    leaving it is the wrong place for it.
+  - **The OT stamp** — through the engine's own `BattleState.stampOT` /
+    `Mon.stampOT`, so the fields (and the rule that a traded monster keeps the
+    id it arrived with) stay the engine's.
+  - **UNOWN** — `Unown.registerCatch` on Gold, which is what UNOWN MODE and
+    `VAR_UNOWNCOUNT` read.
+  - **`pokemon.caught`** — emitted under the engine's own name, with the same
+    payload keys both engine sites use (`mon`, `species`, `isNew`, `ball`,
+    `destination`, `game`), so a dex tracker or a shiny logger hears an MMO
+    catch exactly as it hears a solo one. This is the one place the mod
+    reaches past `mod.events:emit` (which namespaces a mod's events to
+    `mod.<id>.*`), and it is the same line `src/Trade2.lua` already draws for
+    `pokemon.received` / `trade.completed`: where this mod *stands in for* an
+    engine path, it says what that path says. Announcing under a private name
+    instead would make every catch-listening mod need an rby_mmo special case.
+    Only the catcher's client records or announces anything.
+
 ## [1.0.8] - 2026-08-17
 
 ### Added

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -865,6 +865,14 @@ M.CHAR_PALETTE_SOURCE = "ROM:SpriteSheetPointerTable[0]"
 
 M.NAME_MAX = 10
 
+-- What the nickname grid a catch opens will let you type (Gen 1).
+--
+-- The engine's own catch prompt opens NamingScreen with maxLen 10
+-- (BattleState:askNicknameUI), and a name typed in an MMO fight has to fit
+-- the same box every other nickname in the save does.  Gold carries its own
+-- limit on the screen's `nickname` type and is left to it.
+M.NICKNAME_MAX = 10
+
 -- ------- ranked PVP
 --
 -- The arithmetic these feed is in src/Rank.lua, and the reasoning about what

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -2357,6 +2357,9 @@ function M:startBattle(game, field)
   state, err = CoopBattle.new(game, {
     slots = slots,
     mine = mine,
+    -- Handed the screen pusher so the fight can put up the prompts it earns
+    -- -- today, the naming grid a coop_wild catch owes its catcher.
+    ui = self.ui,
     -- Carried from the battle the co-op one displaced: its trainer record is
     -- what the AI reads a class off, and its aiUses is the allowance the
     -- engine had already computed for it.

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -581,6 +581,10 @@ function M.new(game, opts)
     ranksPoints = opts.ranksPoints and true or false,
     net = opts.net,
     onDone = opts.onDone,
+    -- The mod's screen pusher, for the prompts this fight earns. Only the
+    -- catcher's naming grid uses it today, and a screen built without one
+    -- (the headless suite) simply never asks -- the catch is still granted.
+    ui = opts.ui,
     -- ------- the intermediator's half, all of it inert until it answers
     --
     -- `mediated` is the flag every cut below is gated on, and it is set by
@@ -1697,6 +1701,11 @@ function M:update(dt)
     -- on screen and nothing to wait for -- the next tick takes the row behind
     -- it rather than treating the queue as spent.
     if #self.messages > 0 then return end
+    -- The catch's naming prompt, owed since `grantCatch` and asked here:
+    -- everything the ending had to say has been read, and the screen is about
+    -- to pop. It takes this tick (the push makes it no longer the top of the
+    -- stack), and `finish` runs on the tick after the player answers.
+    if self.result and self:askOwedNickname() then return end
     if self.result then return self:finish() end
     -- The queue is empty and nobody is mid-effect, so whatever the bars were
     -- animating towards is simply where they are. Snapped rather than left to
@@ -8723,7 +8732,14 @@ function M:medRows(msg)
     -- Ball id for AnimPlayer opts on the following toss/shake chain.
     local Effects = need("BattleSim/Effects")
     local effect = msg.text and Effects.itemEffect(msg.text)
-    if effect and effect.ball then self.medBall = msg.text end
+    if effect and effect.ball then
+      self.medBall = msg.text
+      -- ...and the same id kept past the `over` that clears medBall, for the
+      -- `ball` field of the caught announcement. Our own throws only: three
+      -- other people may be throwing balls at the same wild, and the catcher
+      -- is the one whose ball worked.
+      if self:medSlotOf(msg) == self.mine then self.caughtBall = msg.text end
+    end
     say(msg.text)
 
   elseif kind == "switch" then
@@ -9142,17 +9158,89 @@ function M:grantCatch(msg)
   local game = self.game
   local save = game and game.save
   if not save then return end
+  -- What the naming prompt will ask about: the species record's display name,
+  -- because a wild that has just been caught has no nickname yet. Same choice
+  -- MediatedBattle:grantCatch makes, and the same one the engine's own catch
+  -- makes (it asks about `self.enemy.name`).
+  local label = M.caughtLabel(game, mon)
+  -- The #DEX, the OT stamp and (on Gold) the UNOWN form, before the monster is
+  -- put anywhere -- the order the engine's own capture writes them in.
+  local isNew = Gen.recordCatch(game, mon)
   local okParty, Party = pcall(require, "src.pokemon.Party")
-  if okParty and Party.add(save.party, mon) then
-    self:say((mon.nickname or mon.species or "It") .. " was\nadded to the party!")
-    return
-  end
   local okBoxes, Boxes = pcall(require, "src.pokemon.Boxes")
-  if okBoxes and Boxes.deposit(save, mon) then
-    self:say((mon.nickname or mon.species or "It") .. " was\nsent to the PC!")
+  local destination
+  if okParty and Party.add(save.party, mon) then
+    destination = "party"
+  elseif okBoxes and Boxes.deposit(save, mon) then
+    destination = "box"
+  else
+    self:say("But every BOX\nis full!")
     return
   end
-  self:say("But every BOX\nis full!")
+  -- In front of the line saying where it went, which is where the engine
+  -- prints it. The #DEX page that follows it there is deliberately not
+  -- opened -- see MediatedBattle:grantCatch for why.
+  if isNew then self:say(Gen.dexAddedText(game, label)) end
+  if destination == "party" then
+    self:say((mon.nickname or mon.species or "It") .. " was\nadded to the party!")
+  else
+    self:say((mon.nickname or mon.species or "It") .. " was\nsent to the PC!")
+  end
+  -- Boxed catches are named too: AddPartyMon and SendNewMonToBox both call
+  -- AskName on the cart, so a full party costs the slot and not the naming.
+  self:oweNickname(mon, label)
+  -- The engine's own `pokemon.caught`, through MediatedBattle's announcer --
+  -- shared rather than twinned, because unlike the grant itself there is
+  -- nothing co-op-shaped about it, and two copies of a *published event's*
+  -- payload is two ways for one contract to drift. Its header carries the
+  -- reasoning for emitting an engine name at all.
+  Mediated.announceCaught(self, game, mon, destination, isNew, self.caughtBall)
+end
+
+-- The species record's display name, falling back to the id.
+function M.caughtLabel(game, mon)
+  local data = game and game.data
+  local def = type(data) == "table" and type(data.pokemon) == "table"
+    and data.pokemon[mon.species] or nil
+  local name = def and def.name
+  if type(name) ~= "string" or name == "" then name = mon.species end
+  if type(name) ~= "string" or name == "" then return "POKeMON" end
+  return name
+end
+
+-- ------- the nickname the catcher is owed
+--
+-- MediatedBattle:oweNickname / askOwedNickname's twin, for the same reason
+-- grantCatch is one: this file owns the coop_wild path outright.
+--
+-- Recorded on the grant and asked once the message queue has run dry, which
+-- on this screen is the tick that would otherwise call `finish` and pop the
+-- battle (see `update`'s "messages" branch). That gap is deliberate: the
+-- grant happens while "Gotcha!" and the line saying where the monster went
+-- are still queued, and a grid pushed then would have the player naming a
+-- catch nobody had told them about.
+function M:oweNickname(mon, label)
+  if type(mon) ~= "table" then return false end
+  self.owedNickname = { mon = mon, label = label }
+  return true
+end
+
+-- Returns true when it took the frame, which is what holds `finish` off for
+-- as long as the prompt is up. Cleared before the push, not after the answer:
+-- a prompt that could not open is not owed a second try, and the fight has to
+-- end either way.
+function M:askOwedNickname()
+  local owed = self.owedNickname
+  if not owed then return false end
+  self.owedNickname = nil
+  local ui = self.ui
+  if not (ui and type(ui.askNickname) == "function" and self.game) then
+    return false
+  end
+  local ok = pcall(function()
+    ui:askNickname(self.game, owed.mon, owed.label)
+  end)
+  return ok
 end
 
 -- ------- one turn's intent

--- a/src/Gen.lua
+++ b/src/Gen.lua
@@ -148,6 +148,223 @@ function M.startMenuId(game)
   return "Start" .. "Menu"
 end
 
+-- ------- the nickname a catch earns
+--
+-- A wild caught on the engine's own path is named through
+-- BattleState:askNicknameUI: the caught text, then "Do you want to give a
+-- nickname to X?", then the letter grid.  A wild caught in an MMO fight is
+-- granted by this mod instead (MediatedBattle / CoopBattle `grantCatch`), and
+-- until this existed the grant went straight into the party -- the catcher
+-- never got the prompt every other catch in the game gives them.
+--
+-- The two generations differ in three ways that a single call site would
+-- otherwise have to know: the screen id, the opts shape, and -- the one that
+-- actually bites -- who pops the screen.  Gen 1's NamingScreen pops *itself*
+-- before calling onDone (src/ui/NamingScreen.lua); Gold's does not, and its
+-- callers pop for it (src/ui/gen2/BattleState.lua:answerNickname).  So this
+-- pops on Gold and leaves Gen 1 alone: doing either on both generations
+-- either strands the grid on the stack forever or takes the screen underneath
+-- it down with the answer.
+
+function M.nicknameScreenId(game)
+  if M.generation(game) == 2 then return "Gen2NamingScreen" end
+  -- Split for the reason startMenuId's is: gen2check MK409 flags a bare Gen 1
+  -- screen id literal in a helper that also answers with a Gen 2 one.
+  return "Naming" .. "Screen"
+end
+
+-- The sentence the prompt asks, in the player's own copy's words where the
+-- dataset carries them.
+--
+-- Gen 1 has the ROM string (_DoYouWantToNicknameText, whose CONT is a tab and
+-- whose {RAM} token is the species); Gold's engine prints a plain sentence of
+-- its own (Gen2 BattleState:askNickname), so there is nothing to look up and
+-- the fallback *is* the line.  `displayName` is substituted through a function
+-- so a name carrying `%` cannot blow up gsub's replacement parser.
+function M.nicknamePromptText(game, displayName)
+  local name = tostring(displayName or "")
+  if name == "" then name = "POKeMON" end
+  if M.generation(game) == 2 then
+    return "Give a nickname to\n" .. name .. "?"
+  end
+  local text = game and game.data and game.data.text
+    and game.data.text._DoYouWantToNicknameText
+  if type(text) == "string" and text ~= "" then
+    local out = text:gsub("\t", "\n"):gsub("{RAM:?[%w_]*}", function()
+      return name
+    end)
+    return out
+  end
+  return "Do you want to\ngive a nickname\nto " .. name .. "?"
+end
+
+-- Put the letter grid up for `mon`, and write what was typed onto it.
+--
+-- `onDone` is called with the typed name (or nil) *after* the grid has left
+-- the stack, so a caller can carry on sequencing from it.  Returns false when
+-- no screen went up -- a build with no naming screen registered, or a push
+-- that threw -- which is the caller's cue to say so rather than wait for an
+-- answer that is never coming.
+function M.askNickname(game, mon, displayName, onDone)
+  if not (type(game) == "table" and type(mon) == "table") then return false end
+  local gen2 = M.generation(game) == 2
+  local name = tostring(displayName or mon.species or "")
+
+  -- Guarded because the two screens reach it differently (Gold's onCancel and
+  -- onDone are both endings) and a nickname must not be written twice.
+  local answered = false
+  local function done(typed)
+    if answered then return end
+    answered = true
+    if gen2 then
+      pcall(function() game.stack:pop() end)
+    end
+    if type(typed) == "string" and typed ~= "" then mon.nickname = typed end
+    if onDone then onDone(typed) end
+  end
+
+  local opts
+  if gen2 then
+    local data = game.data or {}
+    local icons = data.gen2Icons
+    local iconId = icons and icons.species and icons.species[mon.species]
+    local entry = iconId and icons.icons and icons.icons[iconId]
+    opts = {
+      type = "nickname",
+      monName = name,
+      iconPath = entry and entry.image or nil,
+      menuGfx = data.gen2MenuGfx,
+      onDone = done,
+      onCancel = function() done(nil) end,
+    }
+  else
+    opts = {
+      title = "NICKNAME?",
+      maxLen = Config.NICKNAME_MAX,
+      onDone = done,
+    }
+  end
+
+  local pushed
+  local ok = pcall(function()
+    pushed = mod.ui.push(game, M.nicknameScreenId(game), opts)
+  end)
+  -- A pcall that succeeds but hands back nothing table-shaped is as
+  -- screen-less as a throw (an unregistered id resolves to nil), and both
+  -- leave the catcher waiting on a grid that never came up.
+  if not (ok and type(pushed) == "table") then
+    mod.log:warn("could not open the naming screen for the POKeMON you just "
+      .. "caught; it keeps its species name and can be renamed at the NAME "
+      .. "RATER")
+    return false
+  end
+  return true
+end
+
+-- ------- the rest of what a capture writes into the save
+--
+-- Adding the monster to the party is only the visible half of a catch. The
+-- engine's own capture (`BattleState:storeCaughtMon` on Red,
+-- `Gen2 BattleState:pushCaught` on Gold) also marks the #DEX, stamps the
+-- catcher onto the mon as its original trainer, and -- on Gold -- registers
+-- an UNOWN's form.  An MMO catch is granted by this mod, so none of it
+-- happened: the caught monster was owned by nobody, the dex never moved, and
+-- an UNOWN caught in a co-op fight never unlocked its letter.
+--
+-- All three are the same shape of question -- "which field does this
+-- generation keep it in" -- so they live here together, and the engine's own
+-- helpers do the writing wherever it exports one (`BattleState.stampOT`,
+-- `Mon.stampOT`, `Unown.registerCatch`). The dex is written directly because
+-- neither generation exports a marker: Gen 1's `markOwned` is a `BattleState`
+-- static that reads `game.save.pokedex.owned`, Gold stamps
+-- `pokedex.caught` inline, and the rule for which of the two a save carries
+-- is already stated once in this file (see `dexCounts`).
+
+-- The catcher's name and id on the monster they caught. `mon.traded` is
+-- respected by both engine stamps: a traded mon keeps the id it arrived with.
+local function stampOT(game, save, mon)
+  if type(save.player) ~= "table" then return false end
+  local path = (M.generation(game) == 2)
+    and "src.battle.gen2.Mon" or "src.battle.BattleState"
+  local stamped = false
+  pcall(function()
+    local engine = require(path)
+    if type(engine.stampOT) == "function" then
+      engine.stampOT(save, mon)
+      stamped = true
+    end
+  end)
+  if stamped then return true end
+  -- No engine module to ask (a headless load, a build without it): the OT
+  -- name is the half a player sees on the status screen, so it is written
+  -- rather than dropped. The id is left alone -- inventing one here would be
+  -- inventing the number the traded check turns on.
+  mon.ot = mon.ot or save.player.name
+  return mon.ot ~= nil
+end
+
+-- Seen + owned/caught, and whether this species was new.
+--
+-- `caught` when the save carries it or declares generation 2, `owned`
+-- otherwise -- the same rule src/Trade2.lua marks a received trade under, and
+-- the same pair `dexCounts` reads back out.
+local function markDex(save, species)
+  local dex = save.pokedex
+  if not (type(dex) == "table" and type(species) == "string") then return nil end
+  dex.seen = dex.seen or {}
+  dex.seen[species] = true
+  if dex.caught ~= nil or save.generation == 2 then
+    dex.caught = dex.caught or {}
+    local knew = dex.caught[species] and true or false
+    dex.caught[species] = true
+    return not knew
+  end
+  dex.owned = dex.owned or {}
+  local knew = dex.owned[species] and true or false
+  dex.owned[species] = true
+  return not knew
+end
+
+-- Everything the engine's own capture does to the save except choosing the
+-- monster's home, which is the caller's (party, then a box).
+--
+-- Returns whether the species was **new** to the dex, which is the answer the
+-- "new #DEX data" line is asked for -- and nil when this save has no dex at
+-- all, which is not the same as "already known".
+--
+-- Ordered the way the engine orders it: the dex and the OT are written before
+-- the monster is put anywhere, so a catch that ends up with nowhere to go
+-- still counted as seen (`storeCaughtMon` marks owned before `Party.add`).
+function M.recordCatch(game, mon)
+  if not (type(game) == "table" and type(mon) == "table") then return nil end
+  local save = game.save
+  if type(save) ~= "table" then return nil end
+  stampOT(game, save, mon)
+  local isNew = markDex(save, mon.species)
+  if M.generation(game) == 2 then
+    -- AddPartyMon's `.registerunowndex`: the form list UNOWN MODE and
+    -- VAR_UNOWNCOUNT read. A no-op for every species but UNOWN.
+    pcall(function()
+      local Unown = require("src.core.gen2.Unown")
+      if type(Unown.registerCatch) == "function" then
+        Unown.registerCatch(save, mon)
+      end
+    end)
+  end
+  return isNew
+end
+
+-- "This one is new", in each game's own words (_ItemUseBallText06 on Red,
+-- NewDexDataText on Gold).
+function M.dexAddedText(game, displayName)
+  local name = tostring(displayName or "")
+  if name == "" then name = "It" end
+  if M.generation(game) == 2 then
+    return name .. "'s data was newly\nadded to the #DEX."
+  end
+  return "New POKéDEX data\nwill be added for\n" .. name .. "!"
+end
+
 function M.avatarName(playerId)
   return "mmo_" .. tostring(playerId)
 end

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -2110,7 +2110,14 @@ function M:onEvent(msg)
     end
     -- Ball id for AnimPlayer opts on the following toss/shake chain.
     local effect = msg.text and effectsFor(self.game).itemEffect(msg.text)
-    if effect and effect.ball then self.medBall = msg.text end
+    if effect and effect.ball then
+      self.medBall = msg.text
+      -- ...and the same id, kept past the `over` that clears medBall, for the
+      -- `ball` field of the caught announcement. Only our own throws: the
+      -- catcher is the thrower, and in a co-op fight the last ball on the
+      -- wire may have been somebody else's.
+      if msg.slot == self:mySlot() then self.caughtBall = msg.text end
+    end
 
   elseif kind == "turn" then
     -- Held rather than acted on: the lines this turn's events produced are
@@ -3116,17 +3123,117 @@ function M:grantCatch(msg)
   local game = self.game
   local save = game and game.save
   if not save then return end
+  -- The name the prompt will ask about: a fresh catch has no nickname, so
+  -- this is the species record's display name -- the same thing the engine's
+  -- own catch prompt asks about (BattleState:storeCaughtMon passes
+  -- `self.enemy.name`).
+  local label = speciesName(game and game.data, mon)
+  -- The #DEX, the OT stamp and (on Gold) the UNOWN form, before the monster
+  -- is put anywhere -- the order `BattleState:storeCaughtMon` writes them in,
+  -- and the reason a catch with nowhere to go still counts as seen.
+  local isNew = Gen.recordCatch(game, mon)
   local okParty, Party = pcall(require, "src.pokemon.Party")
-  if okParty and Party.add(save.party, mon) then
-    self:say((mon.nickname or mon.species or "It") .. " was\nadded to the party!")
-    return
-  end
   local okBoxes, Boxes = pcall(require, "src.pokemon.Boxes")
-  if okBoxes and Boxes.deposit(save, mon) then
-    self:say((mon.nickname or mon.species or "It") .. " was\nsent to the PC!")
+  local destination
+  if okParty and Party.add(save.party, mon) then
+    destination = "party"
+  elseif okBoxes and Boxes.deposit(save, mon) then
+    destination = "box"
+  else
+    self:say("But every BOX\nis full!")
     return
   end
-  self:say("But every BOX\nis full!")
+  -- The new-entry line goes in front of the line saying where the monster
+  -- went, which is where the engine prints it. The #DEX *page* that follows
+  -- it there is deliberately not opened: this screen has one queue and one
+  -- prompt seam, and a dex entry over a co-op battle three other people are
+  -- still leaving is a screen nobody asked for.
+  if isNew then self:say(Gen.dexAddedText(game, label)) end
+  if destination == "party" then
+    self:say((mon.nickname or mon.species or "It") .. " was\nadded to the party!")
+  else
+    self:say((mon.nickname or mon.species or "It") .. " was\nsent to the PC!")
+  end
+  -- Asked for a boxed catch too: AddPartyMon and SendNewMonToBox both call
+  -- AskName on the cart (item_effects.asm), so a full party costs the player
+  -- the slot, never the naming.
+  self:oweNickname(mon, label)
+  M.announceCaught(self, game, mon, destination, isNew, self.caughtBall)
+end
+
+-- The engine's own `pokemon.caught`, for a catch the engine never saw.
+--
+-- **Emitted through `src.mods.Runtime` rather than `mod.events:emit`**, which
+-- is the one place this mod reaches past the facade on purpose. The facade
+-- namespaces a mod's emits to `mod.<id>.*` so no mod can forge an engine
+-- event, and CoopBattle's own `announce` obeys that rule for battle
+-- start/end. This is the other case, and src/Trade2.lua already draws the
+-- line here: that file *is* the Gen 2 TradeSession the engine has not got, so
+-- it emits `pokemon.received` and `trade.completed` under the engine's names
+-- rather than inventing private ones nothing listens for. A caught monster is
+-- the same -- `grantCatch` stands in for `storeCaughtMon`, which emits this,
+-- and a dex tracker or a shiny logger listening for `pokemon.caught` should
+-- see an MMO catch exactly as it sees a solo one. Announcing it under a
+-- private name instead would mean every such mod needs an rby_mmo special
+-- case to keep working in an MMO game, which is the outcome the rule exists
+-- to prevent, not to cause.
+--
+-- Same payload keys as both engine sites, so one listener covers all three:
+-- `isNew` is the dex answer read before the stamp, `destination` is the home
+-- the monster actually got, and `ball` is the id this client last threw.
+-- `battle` is this screen and not a `BattleState` -- there is no BattleState
+-- in a mediated fight -- so a listener that reaches into it must check what
+-- it got. Wrapped in pcall + `wants` for the same reason every hot path in
+-- this mod is: a listener that throws must not take the catch down with it.
+function M.announceCaught(screen, game, mon, destination, isNew, ball)
+  pcall(function()
+    local Runtime = require("src.mods.Runtime")
+    if type(Runtime.emit) ~= "function" then return end
+    if Runtime.wants and not Runtime.wants("pokemon.caught") then return end
+    Runtime.emit("pokemon.caught", {
+      battle = screen, mon = mon, species = mon.species,
+      isNew = isNew and true or false, ball = ball,
+      destination = destination, game = game,
+    })
+  end)
+end
+
+-- ------- the nickname the catcher is owed
+--
+-- Recorded here and asked *later*, and the gap is the whole point: this runs
+-- inside `finish`, one line after "Gotcha!" is queued and while the rest of
+-- the ending is still to print.  A grid pushed now would land on top of the
+-- lines that say what just happened -- the player would be typing a name for
+-- a catch they have not been told about yet.
+--
+-- So it waits for the message queue to run dry (see `update`'s over branch),
+-- which is exactly where the engine asks it: after the caught text, and
+-- before the player is allowed to leave the battle.
+function M:oweNickname(mon, label)
+  if type(mon) ~= "table" then return false end
+  self.owedNickname = { mon = mon, label = label }
+  return true
+end
+
+-- Put the prompt up, once, when there is nothing left on screen to read.
+--
+-- Returns true when it took the frame -- the screen is no longer the top of
+-- the stack, so the A that would have closed the battle must not also be
+-- read as one.  The record is cleared before the push rather than after the
+-- answer: a prompt that failed to open is not owed a second attempt, and the
+-- fight has to stay leavable either way.
+function M:askOwedNickname()
+  local owed = self.owedNickname
+  if not owed then return false end
+  self.owedNickname = nil
+  local ui = self.ui
+  if not (ui and type(ui.askNickname) == "function" and self.game) then
+    return false
+  end
+  local ok = pcall(function()
+    ui:askNickname(self.game, owed.mon, owed.label)
+  end)
+  return ok
 end
 
 function M:finish(result, reason, msg)
@@ -4994,6 +5101,10 @@ function M:update(dt)
   if self:tickMessages(dt, input) then return end
 
   if self.phase == "over" then
+    -- The catch's naming prompt, owed since `grantCatch` and asked now that
+    -- the ending has finished printing -- the engine's own ordering, and the
+    -- last thing between the player and the way out.
+    if self:askOwedNickname() then return end
     if input and input:wasPressed("a") then self:leave() end
     return
   end

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -993,6 +993,49 @@ function M:confirm(game, text, onChoose, opts)
   })
 end
 
+-- ------- the prompt a catch earns
+--
+-- "Do you want to give a nickname to X?", and the letter grid behind a YES.
+-- The engine asks this of every wild the player catches on its own path
+-- (BattleState:askNicknameUI); an MMO catch is granted by this mod, so this
+-- is where the same two screens are put up for it.
+--
+-- The rhythm is vanilla's rather than two boxes at once: CONFIRM prints the
+-- sentence and opens the yes/no under it once the text has finished, and only
+-- a YES opens the grid.  `onDone` fires on **both** answers and on a failure
+-- to open either screen, because the caller behind it is a battle screen
+-- waiting to be allowed to close -- a path that answers nothing would leave
+-- the player holding a finished fight they cannot leave.
+--
+-- Nothing here writes the nickname: Gen.askNickname owns that, and owns the
+-- generation's screen id, opts shape and pop rule with it.
+function M:askNickname(game, mon, displayName, onDone)
+  game = game or self.ctx.game
+  local function finish(name)
+    if onDone then onDone(name) end
+  end
+  if not (game and type(mon) == "table") then
+    finish(nil)
+    return false
+  end
+  local pushed = self:confirm(game, Gen.nicknamePromptText(game, displayName),
+    function(yes)
+      if not yes then return finish(nil) end
+      if not Gen.askNickname(game, mon, displayName, finish) then
+        finish(nil)
+      end
+    end)
+  if type(pushed) ~= "table" then
+    -- No box went up (a build with no UI at all), so the answer is the one a
+    -- NO would have given rather than a fight that never ends.
+    mod.log:warn("could not ask about a nickname for the POKeMON you just "
+      .. "caught; it keeps its species name")
+    finish(nil)
+    return false
+  end
+  return true
+end
+
 -- A question with named answers, where **B is an answer and not an escape**.
 --
 -- CONFIRM is the yes/no box, and its B is a no that returns the player to

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -517,6 +517,8 @@ return function(game)
     -- link battle, and the coop_npc trainer leg.
     if os.getenv("MMO_PARTY_WILD_E2E") == "1" then
       local WILD_SPECIES = "PIDGEY"
+      -- Six characters so the assertion cannot pass on a species name.
+      local WILD_NICKNAME = "MMOMON"
       local announced = H.listenForModEvents(game, {
         "mod.rby_mmo.coop_battle_started",
         "mod.rby_mmo.coop_battle_ended",
@@ -545,6 +547,9 @@ return function(game)
 
       -- Bag sheet is uploaded when the mediated fight starts; seed before divert.
       check(H.giveItem(game, "MASTER_BALL", 1), "seeded a MASTER_BALL for the catch")
+      -- Subscribed before the throw: the mod's announcement is guarded on
+      -- there being a listener, which is exactly the case worth proving.
+      local caughtEvents, caughtPayloads = H.listenForEvents({ "pokemon.caught" })
       local partyBefore = H.partySpeciesCount(game)
       local speciesBefore = H.partySpeciesCount(game, WILD_SPECIES)
       local ballsBefore = (game.save.inventory and game.save.inventory.MASTER_BALL) or 0
@@ -602,6 +607,16 @@ return function(game)
             "filed MASTER_BALL from the ITEM menu")
       log("threw MASTER_BALL")
 
+      -- The prompt the catch earns, driven before the battle is closed
+      -- because that is where the mod puts it: on the last tick of the
+      -- ending, with the fight still on screen and the player not yet let
+      -- off it. A catcher who is never asked is the bug this drives.
+      local named = H.answerNicknamePrompt(game, WILD_NICKNAME, 90,
+        function()
+          U.shot(game, SHOT_DIR .. "/host-party-wild-nickname.png")
+        end)
+      check(named, "the catcher is asked to name what they caught, and can")
+
       local medGaps = 0
       local over = H.drivePrompts(game, function()
         local top = H.top(game)
@@ -631,6 +646,30 @@ return function(game)
             "catcher party grew after the MASTER_BALL catch")
       check(speciesAfter > speciesBefore,
             ("caught %s was granted to the host party"):format(WILD_SPECIES))
+      local kept = H.partyNickname(game, WILD_SPECIES)
+      check(kept == WILD_NICKNAME,
+            "and the name typed on the grid is the one the save keeps")
+      log("caught nickname:", tostring(kept))
+
+      -- ...and the rest of the paperwork a catch does: the #DEX, the OT
+      -- stamp, and the event every other catch in the game fires.
+      check(H.dexOwned(game, WILD_SPECIES) == true,
+            ("the #DEX marks the caught %s as owned"):format(WILD_SPECIES))
+      local caught = H.partyMon(game, WILD_SPECIES)
+      local myName = game.save.player and game.save.player.name
+      check(caught ~= nil and caught.ot == myName,
+            "the catcher is stamped on it as the original trainer")
+      check(caught ~= nil and caught.otId ~= nil, "...with their trainer id")
+      check(caughtEvents["pokemon.caught"] >= 1,
+            "pokemon.caught fired for a catch the engine never saw")
+      local payload = caughtPayloads["pokemon.caught"]
+      check(payload ~= nil and payload.species == WILD_SPECIES
+            and payload.destination == "party",
+            "...naming the species and where it went")
+      log(("catch paperwork: dex=%s ot=%s otId=%s events=%d ball=%s"):format(
+        tostring(H.dexOwned(game, WILD_SPECIES)),
+        tostring(caught and caught.ot), tostring(caught and caught.otId),
+        caughtEvents["pokemon.caught"], tostring(payload and payload.ball)))
       log(("catch grant: party %d -> %d, %s %d -> %d, balls %d -> %d"):format(
         partyBefore, partyAfter, WILD_SPECIES, speciesBefore, speciesAfter,
         ballsBefore, ballsAfter))

--- a/tests/drivers/mmo_host_gen2.lua
+++ b/tests/drivers/mmo_host_gen2.lua
@@ -340,7 +340,11 @@ return function(game)
       "mod.rby_mmo.coop_battle_ended",
     }) or nil
     check(H.giveItem(game, "MASTER_BALL", 1), "seeded a MASTER_BALL for the catch")
+    -- Subscribed before the throw: the announcement is guarded on a listener.
+    local caughtEvents, caughtPayloads = H.listenForEvents({ "pokemon.caught" })
     local WILD_SPECIES = "SENTRET"
+    -- Six characters, so the assertion cannot pass on a species name.
+    local WILD_NICKNAME = "MMOMON"
     local wildFinished = nil
     local staged = H.stageWild(game, WILD_SPECIES, 5, function(result)
       wildFinished = result
@@ -404,6 +408,14 @@ return function(game)
           "filed MASTER_BALL from the ITEM menu")
     log("threw MASTER_BALL")
 
+    -- The naming prompt the catch earns, on Gold's own grid (the mod picks
+    -- the screen by generation). Driven here because the mod asks it on the
+    -- last tick of the ending, with the fight still on screen.
+    local named = H.answerNicknamePrompt(game, WILD_NICKNAME, 90, function()
+      U.shot(game, SHOT_DIR .. "/host-party-wild-nickname.png")
+    end)
+    check(named, "the catcher is asked to name what they caught, and can")
+
     local medGaps = 0
     local over = H.drivePrompts(game, function()
       local fieldTop = H.top(game)
@@ -427,6 +439,28 @@ return function(game)
             "coop_battle_ended fired after Party vs Wild")
     end
     log("engine wild result:", tostring(wildFinished))
+    local kept = H.partyNickname(game, WILD_SPECIES)
+    check(kept == WILD_NICKNAME,
+          "and the name typed on Gold's grid is the one the save keeps")
+    log("caught nickname:", tostring(kept))
+
+    -- ...and the paperwork: Gold keeps the dex bit under `caught`, and its OT
+    -- stamp is the Gen 2 one (ot + otName).
+    check(H.dexOwned(game, WILD_SPECIES) == true,
+          ("the #DEX marks the caught %s"):format(WILD_SPECIES))
+    local caught = H.partyMon(game, WILD_SPECIES)
+    local myName = game.save.player and game.save.player.name
+    check(caught ~= nil and caught.ot == myName,
+          "the catcher is stamped on it as the original trainer")
+    check(caughtEvents["pokemon.caught"] >= 1,
+          "pokemon.caught fired for a catch the engine never saw")
+    local payload = caughtPayloads["pokemon.caught"]
+    check(payload ~= nil and payload.species == WILD_SPECIES,
+          "...naming the species that was caught")
+    log(("catch paperwork: dex=%s ot=%s otId=%s events=%d"):format(
+      tostring(H.dexOwned(game, WILD_SPECIES)),
+      tostring(caught and caught.ot), tostring(caught and caught.otId),
+      caughtEvents["pokemon.caught"]))
 
     -- No exp check on this leg by design: it ends with a MASTER_BALL, and a
     -- caught foe never faints -- there is nothing for the referee's

--- a/tests/drivers/mmo_join.lua
+++ b/tests/drivers/mmo_join.lua
@@ -518,6 +518,11 @@ return function(game)
           "non-catcher party size unchanged after the host's catch")
     check(speciesAfter == speciesBefore,
           ("non-catcher did not receive the caught %s"):format(WILD_SPECIES))
+    -- ...and none of the catch's paperwork either: the #DEX entry belongs to
+    -- whoever threw the ball, exactly as it does on the cart.
+    check(H.dexOwned(game, WILD_SPECIES) ~= true,
+          ("the non-catcher's #DEX does not mark %s as caught"):format(
+            WILD_SPECIES))
     log(("no catch grant on guest: party %d, %s %d"):format(
       partyAfter, WILD_SPECIES, speciesAfter))
     U.shot(game, SHOT_DIR .. "/join-party-wild-after.png")

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -560,6 +560,197 @@ function M.enterJoinCode(game, code)
   return true
 end
 
+-- ------- the nickname prompt a catch earns
+--
+-- An MMO catch is granted by the mod (MediatedBattle / CoopBattle
+-- `grantCatch`), and the catcher is asked to name what they caught exactly as
+-- the engine's own catch asks: a yes/no box once the ending has finished
+-- printing, then the letter grid behind a YES.
+--
+-- Driven properly rather than skipped, because "can the catcher actually name
+-- it" is the question this leg exists to answer -- and because a prompt left
+-- standing swallows the taps the rest of the leg makes to close the battle.
+
+-- Which naming grid is on top, if either: the two generations are different
+-- screens with different fields (Gen 1 keeps `glyphs` and a `grid()`; Gold
+-- keeps the typed string on `text` and its board behind `rows()`).
+function M.namingGridKind(top)
+  if type(top) ~= "table" then return nil end
+  if type(top.glyphs) == "table" and type(top.grid) == "function" then
+    return "gen1"
+  end
+  if type(top.text) == "string" and type(top.rows) == "function"
+     and type(top.characterAt) == "function" then
+    return "gen2"
+  end
+  return nil
+end
+
+-- Gold's board, walked the way M.typeOnGrid walks Gen 1's: step the cursor
+-- rather than compute a tap count, because both axes wrap and SELECT swaps in
+-- a page with different rows. Cursor coordinates are 0-based here, and the
+-- row past the last letter row is the fat case/DEL/END one.
+local function gen2Cell(screen, ch)
+  local grid = screen:rows()
+  for r = 1, #grid do
+    for c = 1, #(grid[r] or {}) do
+      if grid[r][c] == ch then return r - 1, c - 1 end
+    end
+  end
+  return nil
+end
+
+local function typeOnGen2Grid(game, screen, text)
+  for i = 1, #text do
+    local ch = text:sub(i, i)
+    local r, c = gen2Cell(screen, ch)
+    if not r then
+      U.tap(game, "select") -- the other case page
+      U.wait(2)
+      r, c = gen2Cell(screen, ch)
+    end
+    if not r then
+      U.log("WARN no cell on Gold's naming grid for", ch)
+      return false
+    end
+    for _ = 1, 12 do
+      if screen.row == r then break end
+      U.tap(game, "down")
+      U.wait(1)
+    end
+    for _ = 1, 12 do
+      if screen.col == c then break end
+      U.tap(game, "right")
+      U.wait(1)
+    end
+    if screen.row ~= r or screen.col ~= c then
+      U.log("WARN could not reach Gold's cell for", ch)
+      return false
+    end
+    U.tap(game, "a")
+    U.wait(2)
+  end
+  return true
+end
+
+-- Wait for the prompt, answer YES, type `name`, confirm.
+--
+-- Returns true only when the grid actually held what was typed -- the point
+-- of the leg is that the catcher can name the monster, and a grid that came
+-- up empty is a failure with a screenshot rather than a pass.
+-- `onGrid` (optional) runs once the grid is up and before anything is typed,
+-- which is the only moment an empty naming screen can be photographed.
+function M.answerNicknamePrompt(game, name, seconds, onGrid)
+  local asked = M.waitSeconds(game, function()
+    local top = M.top(game)
+    if M.namingGridKind(top) then return true end
+    local text = (M.textOf(top) or ""):lower()
+    return text:find("nickname", 1, true) ~= nil
+  end, seconds or 90, "the nickname prompt after a catch")
+  if not asked then
+    U.log("WARN no nickname prompt after the catch")
+    return false
+  end
+
+  -- A finishes the printing, and A again answers the yes/no under it. YES is
+  -- where the box opens (the mod passes no defaultNo here), so this needs no
+  -- cursor walk -- but it does need a bound, because pressing A into a grid
+  -- types letters.
+  local guard = 0
+  while M.namingGridKind(M.top(game)) == nil and guard < 40 do
+    U.tap(game, "a")
+    U.wait(6)
+    guard = guard + 1
+  end
+  local screen = M.top(game)
+  local kind = M.namingGridKind(screen)
+  if not kind then
+    U.log("WARN the nickname question never opened a naming grid")
+    return false
+  end
+
+  if onGrid then pcall(onGrid, screen, kind) end
+
+  if kind == "gen1" then
+    if not M.typeOnGrid(game, name) then return false end
+    local typed = table.concat(screen.glyphs)
+    if typed ~= name then
+      U.log("WARN the grid holds", typed, "not", name)
+      return false
+    end
+    -- START is the confirm on Gen 1 (or the ED cell); the screen pops itself.
+    U.tap(game, "start")
+  else
+    if not typeOnGen2Grid(game, screen, name) then return false end
+    if screen.text ~= name then
+      U.log("WARN Gold's grid holds", tostring(screen.text), "not", name)
+      return false
+    end
+    -- Gold's START only parks the cursor on END; A on END is the confirm.
+    U.tap(game, "start")
+    U.wait(4)
+    U.tap(game, "a")
+  end
+  U.wait(30)
+  return true
+end
+
+-- The party's own copy of the mon of `species` -- what a driver asserts the
+-- catch's paperwork against (nickname, OT, whatever else lands on it).
+function M.partyMon(game, species)
+  local party = game.save and game.save.party or {}
+  for _, mon in ipairs(party) do
+    if mon.species == species then return mon end
+  end
+  return nil
+end
+
+-- What the party is calling the mon of `species` -- its nickname when it has
+-- one, so a driver can assert the name it just typed actually landed.
+function M.partyNickname(game, species)
+  local mon = M.partyMon(game, species)
+  return mon and mon.nickname
+end
+
+-- Is this species marked in the #DEX -- `caught` on Gold, `owned` on Red,
+-- the same pair src/Gen.lua stamps and reads back.
+function M.dexOwned(game, species)
+  local dex = game.save and game.save.pokedex
+  if type(dex) ~= "table" then return nil end
+  local bag = dex.caught or dex.owned or {}
+  return bag[species] and true or false
+end
+
+-- Listen for real ENGINE events, by subscribing rather than by wrapping emit.
+--
+-- M.captureEvents above counts emits by patching Runtime.emit, which is
+-- enough for an event the engine fires unconditionally. It is not enough here:
+-- an emitter that guards on Runtime.wants (this mod's caught announcement
+-- does, and every hot engine site does) emits **nothing** when no listener is
+-- subscribed -- so a counter that never subscribes measures its own absence.
+-- This subscribes for real, which is also the thing worth proving: another
+-- mod listening for `pokemon.caught` hears an MMO catch.
+--
+-- Returns two tables keyed by event name: how many arrived, and the last
+-- payload of each.
+function M.listenForEvents(names)
+  local Runtime = require("src.mods.Runtime")
+  local bus = Runtime.events
+  local counts, last = {}, {}
+  for _, name in ipairs(names) do counts[name] = 0 end
+  if type(bus) ~= "table" or type(bus.on) ~= "function" then
+    U.log("WARN no live mod event bus; engine events cannot be heard")
+    return counts, last
+  end
+  for _, name in ipairs(names) do
+    bus:on(name, function(payload)
+      counts[name] = counts[name] + 1
+      last[name] = payload
+    end, 0, "mmo_e2e")
+  end
+  return counts, last
+end
+
 -- ------- phase barriers
 --
 -- The two drivers are separate processes with no channel between them but

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -24888,4 +24888,385 @@ _G.love = ambientLove
 
 end)()
 
+-- ------- the nickname a catch earns, in an MMO fight
+--
+-- The engine asks every catcher whether they want to name what they just
+-- caught (BattleState:storeCaughtMon -> askNicknameUI).  An MMO catch is
+-- granted by this mod instead -- `grantCatch` on either battle screen -- and
+-- until this block existed the grant went straight into the party: the
+-- catcher in a co-op or mediated wild fight was the one player in the game
+-- who never got the prompt.
+--
+-- Four things are pinned here, and the timing is the one worth stating.  The
+-- grant happens *inside* the ending, one line after "Gotcha!" is queued, so
+-- the prompt cannot be put up there -- it is recorded as owed, and asked at
+-- the moment the message queue runs dry, which is the last tick before the
+-- player is allowed off the screen.
+
+;(function()
+
+local Gen = need("Gen")
+local Config = need("Config")
+local MediatedBattle = need("MediatedBattle")
+local CoopBattle = need("CoopBattle")
+
+local gen1 = { data = { pokemon = { PIDGEY = { name = "PIDGEY" } } } }
+local gen2 = { data = { gen2Constants = {}, pokemon = { PIDGEY = { name = "PIDGEY" } } } }
+
+-- ------- Gen: which screen, and what the question says
+
+eq(Gen.nicknameScreenId(gen1), "NamingScreen", "Gen 1 catches open the Gen 1 grid")
+eq(Gen.nicknameScreenId(gen2), "Gen2NamingScreen", "and Gold's opens Gold's")
+eq(Config.NICKNAME_MAX, 10,
+   "the grid takes the same ten characters every other nickname in the save gets")
+
+check(Gen.nicknamePromptText(gen1, "PIDGEY"):find("PIDGEY", 1, true) ~= nil,
+      "the question names the POKeMON that was caught")
+check(Gen.nicknamePromptText(gen1, "PIDGEY"):lower():find("nickname", 1, true) ~= nil,
+      "...and asks about a nickname")
+
+-- The ROM sentence when the dataset carries one: CONT is a tab, and the
+-- {RAM} token is where the species goes.
+local romGame = {
+  data = {
+    pokemon = { PIDGEY = { name = "PIDGEY" } },
+    text = { _DoYouWantToNicknameText = "Do you want to\tgive a nickname\tto {RAM:StringBuffer1}?" },
+  },
+}
+local romLine = Gen.nicknamePromptText(romGame, "PIDGEY")
+check(romLine:find("PIDGEY", 1, true) ~= nil,
+      "the player's own copy's wording is used when the dataset carries it")
+check(romLine:find("\t", 1, true) == nil,
+      "...with the extractor's CONT turned into the newline a box scrolls on")
+check(romLine:find("{RAM", 1, true) == nil, "...and no token left unfilled")
+
+-- A name carrying a gsub escape is data, not a replacement pattern.
+check(Gen.nicknamePromptText(romGame, "100%"):find("100%", 1, true) ~= nil,
+      "a name carrying a gsub escape is substituted as data, not as a pattern")
+
+-- ------- MediatedBattle: recorded on the grant, asked when the box is empty
+
+local asked
+local uiStub = {
+  askNickname = function(_, _, mon, label)
+    asked = { mon = mon, label = label }
+    return true
+  end,
+}
+
+local function wildFight()
+  local mon = { species = "PIDGEY", level = 5, hp = 4, stats = { hp = 20 } }
+  local game = {
+    data = gen1.data,
+    save = { party = {}, inventory = {} },
+    input = { wasPressed = function() return false end },
+  }
+  local f = MediatedBattle.new({
+    game = game, battle = "b-nickname", role = "host", mode = "wild",
+    ui = uiStub, wildCatchMon = mon,
+  })
+  f.uploaded = true
+  return f, game, mon
+end
+
+do
+  asked = nil
+  local f, game, mon = wildFight()
+  f:finish("win", "catch", { reason = "catch" })
+  eq(#game.save.party, 1, "the catch is still granted")
+  eq(asked, nil, "but nothing is asked while the ending is still printing")
+  check(f.owedNickname ~= nil and f.owedNickname.mon == mon,
+        "the prompt is recorded as owed instead")
+
+  -- Drain the ending. `leave` is stubbed so the run cannot pop a stack this
+  -- game does not have, and so "was the fight leavable yet" is answerable.
+  local left = false
+  f.leave = function() left = true end
+  local guard = 0
+  while asked == nil and guard < 600 do
+    f:update(1 / 60)
+    guard = guard + 1
+  end
+  check(guard < 600, "the prompt goes up once the queue runs dry")
+  eq(asked.mon, mon, "and it asks about the monster that was just caught")
+  eq(asked.label, "PIDGEY", "under the species record's display name")
+  eq(left, false, "the fight is not left out from under the question")
+  eq(f.owedNickname, nil, "and the debt is cleared, so it is asked once")
+
+  -- Asked once even if the screen keeps running: a second grid over the first
+  -- would be a second name for one catch.
+  asked = nil
+  f:update(1 / 60)
+  eq(asked, nil, "a prompt already put up is not put up again")
+end
+
+-- The naming itself is the engine's screen writing onto the mon; what this
+-- mod owes is that the answer lands on the party's copy and not on a
+-- throwaway. The grant adds the very table `grantCatch` was holding, so the
+-- name typed into the grid is the one the save keeps.
+do
+  asked = nil
+  local f, game, mon = wildFight()
+  f:finish("win", "catch", { reason = "catch" })
+  eq(game.save.party[1], mon, "the party holds the caught monster itself")
+  f.owedNickname.mon.nickname = "BIRB"
+  eq(game.save.party[1].nickname, "BIRB",
+     "so a name written by the grid is the name the save has")
+end
+
+-- A grant that could not add the monster anywhere owes nothing: there is no
+-- monster to name.
+do
+  asked = nil
+  local f = wildFight()
+  f.wildCatchMon = nil
+  f:grantCatch({ caught = { species = "PIDGEY" } })
+  eq(f.owedNickname, nil, "a catch that could not be added asks nothing")
+end
+
+-- A screen built without the mod's pusher (the headless suite, a build whose
+-- UI failed to come up) still ends: the debt is dropped, not waited on.
+do
+  local f, game = wildFight()
+  f.ui = nil
+  f:finish("win", "catch", { reason = "catch" })
+  check(f.owedNickname ~= nil, "the debt is recorded either way")
+  eq(f:askOwedNickname(), false, "but with nothing to ask with it is dropped")
+  eq(f.owedNickname, nil, "...and cleared, so the fight is leavable")
+  eq(#game.save.party, 1, "the catch itself is unaffected")
+end
+
+-- ------- CoopBattle: the same rule on the coop_wild path
+
+do
+  local mon = { species = "PIDGEY", level = 5 }
+  local said = {}
+  local coopAsked = nil
+  local screen = setmetatable({
+    game = {
+      data = gen1.data,
+      save = { party = {}, inventory = {} },
+    },
+    messages = {},
+    ui = {
+      askNickname = function(_, _, m, label)
+        coopAsked = { mon = m, label = label }
+        return true
+      end,
+    },
+    wildCatchMon = mon,
+    say = function(_, text) said[#said + 1] = text end,
+  }, CoopBattle)
+
+  screen:grantCatch({})
+  eq(#screen.game.save.party, 1, "the co-op catcher gets the monster")
+  check(screen.owedNickname ~= nil, "and is owed the naming prompt for it")
+  eq(screen.owedNickname.label, "PIDGEY", "under the species display name")
+
+  eq(screen:askOwedNickname(), true, "which the screen asks for itself")
+  eq(coopAsked.mon, mon, "about the monster it just granted")
+  eq(screen:askOwedNickname(), false, "and asks exactly once")
+end
+
+end)()
+
+-- ------- the rest of what a catch writes into the save
+--
+-- Adding the monster is only the visible half. The engine's own capture also
+-- marks the #DEX, stamps the catcher as the OT, registers an UNOWN's form on
+-- Gold, and emits `pokemon.caught` -- and an MMO grant did none of it, so a
+-- co-op catch left a monster owned by nobody, a dex that never moved, and
+-- every listener (a dex tracker, a shiny logger) silent.
+
+;(function()
+
+local Gen = need("Gen")
+local MediatedBattle = need("MediatedBattle")
+local CoopBattle = need("CoopBattle")
+
+local POKEDEX = { pokemon = { PIDGEY = { name = "PIDGEY" } } }
+
+local function gen1Save()
+  return {
+    party = {}, inventory = {},
+    player = { name = "RED", id = 4242 },
+    pokedex = { seen = {}, owned = {} },
+  }
+end
+
+-- ------- Gen.recordCatch
+
+do
+  local game = { data = POKEDEX, save = gen1Save() }
+  local mon = { species = "PIDGEY", level = 5 }
+  local isNew = Gen.recordCatch(game, mon)
+  eq(isNew, true, "a species the dex has never held is new")
+  eq(game.save.pokedex.seen.PIDGEY, true, "a catch is seen")
+  eq(game.save.pokedex.owned.PIDGEY, true, "...and owned, which Gen 1 keeps in `owned`")
+  eq(mon.ot, "RED", "the catcher is stamped on as the original trainer")
+  eq(mon.otId, 4242, "...with their id, which is what the traded check reads")
+
+  -- Asked again for a species already in the dex: still stamped, no longer new.
+  local second = { species = "PIDGEY", level = 9 }
+  eq(Gen.recordCatch(game, second), false,
+     "a second one of the same species is not a new entry")
+  eq(second.ot, "RED", "but it is still the catcher's monster")
+end
+
+-- A traded monster keeps the id it arrived with (engine/battle/experience.asm),
+-- which is the rule both engine stamps carry and this must not undo.
+do
+  local game = { data = POKEDEX, save = gen1Save() }
+  local traded = { species = "PIDGEY", level = 5, traded = true, otId = 7 }
+  Gen.recordCatch(game, traded)
+  eq(traded.otId, 7, "a traded monster keeps its own OT id")
+end
+
+-- Gold keeps the same bit under `caught`, which is the pair Gen.dexCounts and
+-- src/Trade2.lua already read.
+do
+  local game = {
+    data = { gen2Constants = {}, pokemon = POKEDEX.pokemon },
+    save = {
+      generation = 2, party = {}, player = { name = "GOLD", id = 11 },
+      pokedex = { seen = {}, caught = {} },
+    },
+  }
+  local mon = { species = "PIDGEY", level = 5 }
+  eq(Gen.recordCatch(game, mon), true, "new on Gold too")
+  eq(game.save.pokedex.caught.PIDGEY, true, "...and Gold stamps `caught`")
+  eq(game.save.pokedex.owned, nil, "leaving Gen 1's table alone")
+  eq(mon.ot, "GOLD", "the OT stamp is the Gen 2 one")
+end
+
+-- A save with no dex at all is not "already known": nil says there was
+-- nothing to answer with, so no new-entry line is printed for it.
+do
+  local game = { data = POKEDEX, save = { party = {}, player = { name = "RED" } } }
+  eq(Gen.recordCatch(game, { species = "PIDGEY" }), nil,
+     "a save with no #DEX answers nil rather than false")
+end
+
+check(Gen.dexAddedText({ data = POKEDEX }, "PIDGEY"):find("PIDGEY", 1, true) ~= nil,
+      "the new-entry line names the species")
+
+-- ------- the grant, end to end on the screen
+
+do
+  local game = {
+    data = POKEDEX, save = gen1Save(),
+    input = { wasPressed = function() return false end },
+  }
+  local mon = { species = "PIDGEY", level = 5, hp = 4, stats = { hp = 20 } }
+  local f = MediatedBattle.new({
+    game = game, battle = "b-record", role = "host", mode = "wild",
+    wildCatchMon = mon,
+  })
+  f.uploaded = true
+  f.caughtBall = "ULTRA_BALL"
+  f:finish("win", "catch", { reason = "catch" })
+
+  eq(game.save.party[1], mon, "the monster is in the party")
+  eq(game.save.pokedex.owned.PIDGEY, true, "the #DEX moved with the catch")
+  eq(mon.ot, "RED", "and the catcher owns what they caught")
+
+  -- The new-entry line is queued in front of the line saying where it went,
+  -- which is the order the engine prints them in.
+  local dexLine, homeLine
+  for i, text in ipairs(f.lines) do
+    if type(text) == "string" then
+      if text:find("POK", 1, true) and text:find("data", 1, true) then
+        dexLine = dexLine or i
+      end
+      if text:find("added to the party", 1, true) then homeLine = homeLine or i end
+    end
+  end
+  check(dexLine ~= nil, "a new species says so")
+  check(homeLine ~= nil, "and the monster's new home is announced")
+  check(dexLine and homeLine and dexLine < homeLine,
+        "...in that order -- the #DEX line first")
+end
+
+-- A full party sends the catch to a box, and the paperwork is the same:
+-- AddPartyMon and SendNewMonToBox both stamp and both call AskName, so the
+-- only thing a full party costs is the slot.
+do
+  local Party = require("src.pokemon.Party")
+  local game = { data = POKEDEX, save = gen1Save() }
+  for _ = 1, Party.MAX do
+    game.save.party[#game.save.party + 1] = { species = "RATTATA", level = 2 }
+  end
+  local mon = { species = "PIDGEY", level = 5 }
+  local f = MediatedBattle.new({
+    game = game, battle = "b-box", role = "host", mode = "wild",
+    wildCatchMon = mon,
+  })
+  f.uploaded = true
+  f:grantCatch({})
+  eq(#game.save.party, Party.MAX, "a full party stays full")
+  eq(game.save.pokedex.owned.PIDGEY, true, "the #DEX still moves")
+  eq(mon.ot, "RED", "the boxed monster is still the catcher's")
+  check(f.owedNickname ~= nil and f.owedNickname.mon == mon,
+        "and a boxed catch is still owed its naming prompt")
+end
+
+-- ------- the announcement
+--
+-- `pokemon.caught` under the engine's own name, so a listener that already
+-- watches for a catch hears an MMO one too (see the announcer's header for
+-- why this one event is not under `mod.rby_mmo.`).
+do
+  local Runtime = require("src.mods.Runtime")
+  local bus = Runtime.events
+  local heard = {}
+  local unsubscribe
+  if type(bus) == "table" and type(bus.on) == "function" then
+    unsubscribe = bus:on("pokemon.caught", function(payload)
+      heard[#heard + 1] = payload
+    end, 0, "rby_mmo_suite")
+  end
+  if unsubscribe == nil then
+    check(true, "(no live event bus in this run -- the emit is asserted in game)")
+  else
+    local game = {
+      data = POKEDEX, save = gen1Save(),
+      input = { wasPressed = function() return false end },
+    }
+    local mon = { species = "PIDGEY", level = 5 }
+    local f = MediatedBattle.new({
+      game = game, battle = "b-emit", role = "host", mode = "wild",
+      wildCatchMon = mon,
+    })
+    f.uploaded = true
+    f.caughtBall = "ULTRA_BALL"
+    f:grantCatch({})
+    eq(#heard, 1, "one catch, one pokemon.caught")
+    local payload = heard[1] or {}
+    eq(payload.mon, mon, "carrying the monster")
+    eq(payload.species, "PIDGEY", "its species")
+    eq(payload.isNew, true, "whether the entry was new")
+    eq(payload.destination, "party", "where it went")
+    eq(payload.ball, "ULTRA_BALL", "and what caught it")
+    unsubscribe()
+  end
+end
+
+-- CoopBattle's grant records the same things: it is a twin of the mediated
+-- one, and a co-op catcher's save must not end up different from a 1v1's.
+do
+  local game = { data = POKEDEX, save = gen1Save() }
+  local mon = { species = "PIDGEY", level = 5 }
+  local screen = setmetatable({
+    game = game, messages = {},
+    wildCatchMon = mon,
+    say = function() end,
+  }, CoopBattle)
+  screen:grantCatch({})
+  eq(game.save.party[1], mon, "the co-op catcher gets the monster")
+  eq(game.save.pokedex.owned.PIDGEY, true, "the #DEX moved for a co-op catch too")
+  eq(mon.ot, "RED", "and the co-op catcher owns it")
+end
+
+end)()
+
 T.finish("rby_mmo")


### PR DESCRIPTION
## The bug

A wild caught in a co-op divert (`coop_wild`) or a mediated wild fight is granted by this mod rather than by the engine — `grantCatch` on `MediatedBattle` and on `CoopBattle` — and all either of them did was put the monster in the party. Everything else the engine's own capture does was missing, so **the catcher was the one player in the game who could not name what they caught**, and what they caught was owned by nobody and absent from the #DEX.

## The naming prompt

Recorded as *owed* on the grant, and asked when the message queue runs dry: after "Gotcha!" and the line saying where the monster went, and before the player is allowed off the battle — which is where the engine asks it (`storeCaughtMon` → `askNicknameUI`). Asked at grant time instead, the letter grid would land on top of the lines that say what just happened, and the player would be naming a catch nobody had told them about.

`Ui:askNickname` puts up the question and the grid behind a YES, and answers on **both** arms and on a failure to open either screen, so a fight can never be stranded waiting on a screen that never came up.

`Gen.askNickname` owns the generation split, and one part of it is load-bearing: **Gen 1's `NamingScreen` pops itself before calling back and Gold's does not**, so this pops for Gold and leaves Gen 1 alone. Doing either on both would strand the grid on the stack forever or take the screen underneath it down with the answer.

## The rest of the paperwork

`Gen.recordCatch` writes it before the monster is given a home — the order the engine writes it in, and the reason a catch with nowhere to go still counts as seen:

- **#DEX** — seen plus owned, under `caught` on a Gold save and `owned` on a Red one (the pair `Gen.dexCounts` and `src/Trade2.lua` already agree on). A new species says so on screen in each game's own words. The #DEX entry *page* is deliberately not pushed: one queue, one prompt seam, and a co-op battle three other people are still leaving.
- **OT stamp** — through the engine's own `BattleState.stampOT` / `Mon.stampOT`, so the fields and the "a traded mon keeps the id it arrived with" rule stay the engine's.
- **UNOWN** — `Unown.registerCatch` on Gold, which is what UNOWN MODE and `VAR_UNOWNCOUNT` read.
- **`pokemon.caught`** — under the engine's own name, with the payload keys both engine sites use (`mon`, `species`, `isNew`, `ball`, `destination`, `game`), so a dex tracker or a shiny logger hears an MMO catch exactly as it hears a solo one.

Only the catcher's client records or announces anything.

### One deliberate reach past the facade

`mod.events:emit` namespaces a mod's events to `mod.<id>.*`, so `pokemon.caught` cannot be fired through it. This emits through `src.mods.Runtime`, which is the line `src/Trade2.lua` already draws for `pokemon.received` / `trade.completed`: a feature the engine never had (co-op battle start/end) gets a private name, but **a path that stands in for an engine one says what that path says**. A private name here would mean every catch-listening mod needs an `rby_mmo` special case. Guarded by `Runtime.wants` and wrapped in `pcall`, so a listener that throws cannot take the catch down with it.

## Verification

- Mod suite **4663/4663**, T4 **34/34**, `modkit validate --base imported` / `lint` / `pack` / `gen2check` all clean.
- New headless coverage: the timing (owed on the grant, asked once, the fight not leavable underneath the question), the dex/OT/UNOWN writes on both generations, the boxed-catch branch, and a **real subscriber** receiving `pokemon.caught` — subscribing rather than wrapping `emit`, because the announcement is guarded on `Runtime.wants` and a counter that never subscribes measures its own absence.
- Both live LOVE legs type a nickname on the real grid and assert what the save kept:
  - `run-party-wild-e2e.sh` (Red) — `caught nickname: MMOMON`, `catch paperwork: dex=true ot=HOSTY otId=45799 events=1 ball=MASTER_BALL`
  - `run-mmo-e2e-gen2.sh` (Gold) — same leg on Gold's own naming screen, `dex=true ot=HOSTY events=1`, 0 failures both sides
- The guest driver asserts a **non-catcher's** #DEX does not move: the entry belongs to whoever threw the ball.

New driver helpers in `tests/drivers/mmo_util.lua`: `answerNicknamePrompt` (drives both generations' grids), `partyMon`, `dexOwned`, `listenForEvents`.