### PR TITLE
fix: a wild POKéMON cannot use items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+## [1.0.9] - 2026-08-18
+
+### Fixed
+
+- **A wild POKéMON cannot use items any more.** Wild fights were drinking
+  POTIONs, curing their own status and reading X ATTACK mid-battle, which is
+  something no wild encounter has ever done in any of these games. The bag was
+  not the wild monster's: `wild` and `coop_wild` seat their wildlife on the
+  *same synthetic NPC seat machinery* a `coop_npc` trainer sits on, and
+  `Hub:tryStartSim` seeded every one of those seats with `DEFAULT_NPC_BAG` --
+  the gym-style kit that exists so a trainer can potion. The auto-pick then
+  found a bag and used it. Fixed at both ends rather than one: the hub
+  (`src/Hub.lua`, `server/lib/relay.js`) now asks `isWildSeat` and seeds only
+  the trainer seats, and all four turn-machine twins (`src/BattleSim/Turn.lua`,
+  `src/BattleSim2/Turn.lua`, `server/lib/battle/Turn.js`,
+  `server/lib/battle2/Turn.js`) refuse an item choice from the wild seat
+  outright -- both the one they pick for it and one submitted on its behalf --
+  so a bag that arrives from anywhere else is still never spent. A trainer
+  battle is untouched: a gym leader still potions.
+
 ## [1.0.8] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.0.8](https://img.shields.io/badge/version-1.0.8-3aa757?style=for-the-badge)
+![v1.0.9](https://img.shields.io/badge/version-1.0.9-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -1333,7 +1333,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.0.8` (`experimental: false` — on by default when installed). The full
+It's `1.0.9` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/battle2_turn.test.js
+++ b/server/battle2_turn.test.js
@@ -541,3 +541,60 @@ test('the Gen2 event vocabulary knows exp, the party index and the ask slot', ()
   assert.strictEqual(built.participants, 2);
   assert.strictEqual(built.mon, 1);
 });
+
+// ------------------------------------------------------------------
+// wildlife never uses an item, from either end
+// ------------------------------------------------------------------
+//
+// Twin of tests/battle_sim2_turn.lua's section 4, and byte-shared with the Gen 1
+// pair. A wild monster has no bag and no hands, and its seat is driven from two
+// ends -- the hub auto-picks for it, and a submitted choice can arrive addressed
+// to it -- so both are pinned. The wild seat is handed a bag on purpose: even a
+// seat that HAS one must never spend it, so a hub seeding the wrong kit cannot
+// put a Potion in a wild monster's mouth.
+
+const wildBattle2 = (mode, id, bBag) => build({
+  id, mode, seed: 88010, choiceTimeout: 10, reconnectGrace: 60,
+  sides: {
+    a: [{
+      playerId: 'p1', name: 'Ann', bag: { POTION: 1 },
+      mons: [mn({ species: 'Alpha', maxHp: 200, spe: 90, moves: [mv('thump', 40, 255, 0)] })],
+    }],
+    b: [{
+      playerId: 'wild', name: 'Wild', bag: bBag,
+      // Hurt below half and poisoned: a trainer seat heals or cures here.
+      mons: [mn({
+        species: 'Beta', maxHp: 200, hp: 40, spe: 10, status: 'PSN',
+        moves: [mv('thump', 40, 255, 0)],
+      })],
+    }],
+  },
+});
+
+for (const mode of ['wild', 'coop_wild']) {
+  test(`${mode}: auto-pick never reaches the wild seat's bag`, () => {
+    const battle = wildBattle2(mode, 'wa', { POTION: 2, FULL_HEAL: 1, X_ATTACK: 1 });
+    battle.drainEvents();
+    battle.submitChoice('p1', { action: 'fight', move: 0 });
+    assert.strictEqual(battle.tick(11), true, "the wild seat's turn resolves");
+    const items = battle.drainEvents().filter((event) => event.t === 'item');
+    assert.deepStrictEqual(items, [], 'no item event came off the wild seat');
+    assert.strictEqual(battle.byId.get('wild').bag.POTION, 2, 'and it spent none of it');
+    assert.strictEqual(battle.byId.get('wild').bag.FULL_HEAL, 1, 'cure untouched too');
+    assert.strictEqual(battle.byId.get('wild').mons[0].status, 'poison', 'still poisoned');
+  });
+
+  test(`${mode}: a submitted item from the wild seat is refused`, () => {
+    const battle = wildBattle2(mode, 'wb', { POTION: 1 });
+    battle.drainEvents();
+    assert.strictEqual(
+      battle.submitChoice('wild', { action: 'item', item: 'POTION', slot: 0 }), false,
+      'wildlife cannot be talked into using an item',
+    );
+    assert.strictEqual(battle.byId.get('wild').choice, null, 'and files nothing');
+    assert.strictEqual(
+      battle.submitChoice('p1', { action: 'item', item: 'POTION', slot: 0 }), true,
+      'the player on side a still may',
+    );
+  });
+}

--- a/server/battle_turn.test.js
+++ b/server/battle_turn.test.js
@@ -1366,3 +1366,60 @@ test('a wedged resolve aborts on the wall-clock ceiling', () => {
   assert.strictEqual(battle.snapshot().phase, 'over');
   assert.strictEqual(battle.snapshot().resolveDeadline, null);
 });
+
+// ------------------------------------------------------------------
+// wildlife never uses an item, from either end
+// ------------------------------------------------------------------
+//
+// Twin of tests/battle_sim_turn.lua's 12f3. A wild monster has no bag and no
+// hands, and its seat is driven from two ends -- the hub auto-picks for it, and
+// a submitted choice can arrive addressed to it -- so both are pinned. The wild
+// seat is handed a bag on purpose: even a seat that HAS one must never spend
+// it, so a hub seeding the wrong kit (which is what `wild` did with
+// DEFAULT_NPC_BAG) cannot put a Potion in a wild monster's mouth.
+
+const wildBattle = (mode, id, bBag) => build({
+  id, mode, seed: 88010, choiceTimeout: 10, reconnectGrace: 60,
+  sides: {
+    a: [{
+      playerId: 'p1', name: 'Ann', bag: { POTION: 1 },
+      mons: [mn({ species: 'Alpha', maxHp: 200, spd: 90, moves: [mv('thump', 40, 255, 0)] })],
+    }],
+    b: [{
+      playerId: 'wild', name: 'Wild', bag: bBag,
+      // Hurt below half and poisoned: a trainer seat heals or cures here.
+      mons: [mn({
+        species: 'Beta', maxHp: 200, hp: 40, spd: 10, status: 'PSN',
+        moves: [mv('thump', 40, 255, 0)],
+      })],
+    }],
+  },
+});
+
+for (const mode of ['wild', 'coop_wild']) {
+  test(`${mode}: auto-pick never reaches the wild seat's bag`, () => {
+    const battle = wildBattle(mode, 'wa', { POTION: 2, FULL_HEAL: 1, X_ATTACK: 1 });
+    battle.drainEvents();
+    battle.submitChoice('p1', { action: 'fight', move: 0 });
+    assert.strictEqual(battle.tick(11), true, "the wild seat's turn resolves");
+    const items = battle.drainEvents().filter((event) => event.t === 'item');
+    assert.deepStrictEqual(items, [], 'no item event came off the wild seat');
+    assert.strictEqual(battle.byId.get('wild').bag.POTION, 2, 'and it spent none of it');
+    assert.strictEqual(battle.byId.get('wild').bag.FULL_HEAL, 1, 'cure untouched too');
+    assert.strictEqual(battle.byId.get('wild').mons[0].status, 'poison', 'still poisoned');
+  });
+
+  test(`${mode}: a submitted item from the wild seat is refused`, () => {
+    const battle = wildBattle(mode, 'wb', { POTION: 1 });
+    battle.drainEvents();
+    assert.strictEqual(
+      battle.submitChoice('wild', { action: 'item', item: 'POTION', slot: 0 }), false,
+      'wildlife cannot be talked into using an item',
+    );
+    assert.strictEqual(battle.byId.get('wild').choice, null, 'and files nothing');
+    assert.strictEqual(
+      battle.submitChoice('p1', { action: 'item', item: 'POTION', slot: 0 }), true,
+      'the player on side a still may',
+    );
+  });
+}

--- a/server/hub_battle.test.js
+++ b/server/hub_battle.test.js
@@ -308,6 +308,15 @@ function testCoopNpcMediated() {
     && record.parties.get('nc1b').mons.length === 1,
     "and the trainer's team is dealt one to each seat");
 
+  // A trainer seat the host uploaded no bag for is seeded with the gym kit, so
+  // a gym leader can potion. testCoopWildCatchCatcher is the other half of this
+  // claim: wildlife is never seeded, because a wild monster has no bag.
+  ok(!relay.isWildSeat(record, 'nc1a'),
+    'a coop_npc npc seat is a trainer, not wildlife');
+  ok(record.bags.get('nc1a'), 'so it was seeded with a gym kit');
+  ok(record.sim.byId.get('nc1a').bag.POTION === relay.Turn.DEFAULT_NPC_BAG.POTION,
+    'the kit the sim actually fights with');
+
   const ready = take(a, 'mmo.battle_ready');
   ok(ready && ready.sides.b.length === 2,
     'both trainer seats are advertised on side b');
@@ -441,6 +450,16 @@ function testCoopWildCatchCatcher() {
     }],
   });
   ok(record && record.sim, 'coop_wild sim starts with two humans and a wild party');
+
+  // Wildlife carries no bag. The seat is synthetic exactly as a coop_npc
+  // trainer seat is, and it used to be seeded with the same gym kit -- which is
+  // how a wild monster ended up drinking a Potion mid-fight. The turn machine
+  // refuses an item from the seat as well; this is the bag never existing.
+  const wildSeat = record.npcIds[0];
+  ok(relay.isNpcSeat(record, wildSeat), 'the wild seat is a synthetic seat');
+  ok(relay.isWildSeat(record, wildSeat), 'and it is wildlife, not a trainer');
+  ok(!record.bags.get(wildSeat), 'so no gym kit was seeded onto it');
+  ok(!record.sim.byId.get(wildSeat).bag, 'and it fights with no bag at all');
   take(a, 'mmo.battle_ready');
   take(b, 'mmo.battle_ready');
   a.peer.outbox = [];

--- a/server/lib/battle/Turn.js
+++ b/server/lib/battle/Turn.js
@@ -157,6 +157,18 @@ function maxFighters(mode, side) {
   return FIGHTERS_PER_SIDE;
 }
 
+// The wild monster's seat. Wildlife is always the synthetic side-b seat of a
+// mode whose name says "wild" (the seat `maxFighters` caps at one above and
+// `_awardExp` pays the other side for), and wildlife carries no bag: a wild
+// monster never uses an item, no matter who asks on its behalf. Both askers are
+// gated -- `_normaliseChoice` refuses a submitted one, `_autoItemChoice` never
+// picks one -- because the seat can be driven from either end.
+const WILD_SIDE = 'b';
+
+function isWildSeat(mode, fighter) {
+  return !!fighter && fighter.side === WILD_SIDE && Effects.isWildMode(mode);
+}
+
 // Auto-pick priorities (twin of Turn.lua AUTO_* tables).
 const AUTO_STATUS_PRI = {
   32: 4, // SLEEP_EFFECT
@@ -883,6 +895,9 @@ class Battle {
     if (action === 'item') {
       const item = str(choice.item);
       if (!item) return null;
+      // Wildlife has no bag and no hands. Refused rather than ignored so a wild
+      // seat that is somehow handed one never spends the turn on it either.
+      if (isWildSeat(this.mode, fighter)) return null;
       // A fighter with a bag sheet must actually hold the stack (hub/NPC auto).
       // Seats with no bag stay permissive so headless fixtures can still item.
       if (fighter.bag && !this._bagHas(fighter, item)) return null;
@@ -1074,6 +1089,9 @@ class Battle {
   // Bag item for the active mon: cure → heal ≤50% → X-item while stages flat.
   _autoItemChoice(fighter, mon) {
     if (!fighter.bag) return null;
+    // A wild monster is not a trainer: it never reaches into a bag, even when
+    // the hub seeded its seat with one.
+    if (isWildSeat(this.mode, fighter)) return null;
 
     if (mon.status) {
       const list = AUTO_STATUS_CURE[mon.status];

--- a/server/lib/battle2/Turn.js
+++ b/server/lib/battle2/Turn.js
@@ -140,6 +140,18 @@ function maxFighters(mode, side) {
   return FIGHTERS_PER_SIDE;
 }
 
+// The wild monster's seat. Wildlife is always the synthetic side-b seat of a
+// mode whose name says "wild" (the seat `maxFighters` caps at one above and
+// `_awardExp` pays the other side for), and wildlife carries no bag: a wild
+// monster never uses an item, no matter who asks on its behalf. Both askers are
+// gated -- `_normaliseChoice` refuses a submitted one, `_autoItemChoice` never
+// picks one -- because the seat can be driven from either end.
+const WILD_SIDE = 'b';
+
+function isWildSeat(mode, fighter) {
+  return !!fighter && fighter.side === WILD_SIDE && Effects.isWildMode(mode);
+}
+
 // Auto-pick priorities (twin of Turn.lua AUTO_* tables).
 const AUTO_STATUS_PRI = {
   32: 4, // SLEEP_EFFECT
@@ -896,6 +908,9 @@ class Battle {
     if (action === 'item') {
       const item = str(choice.item);
       if (!item) return null;
+      // Wildlife has no bag and no hands. Refused rather than ignored so a wild
+      // seat that is somehow handed one never spends the turn on it either.
+      if (isWildSeat(this.mode, fighter)) return null;
       // A fighter with a bag sheet must actually hold the stack (hub/NPC auto).
       // Seats with no bag stay permissive so headless fixtures can still item.
       if (fighter.bag && !this._bagHas(fighter, item)) return null;
@@ -1087,6 +1102,9 @@ class Battle {
   // Bag item for the active mon: cure → heal ≤50% → X-item while stages flat.
   _autoItemChoice(fighter, mon) {
     if (!fighter.bag) return null;
+    // A wild monster is not a trainer: it never reaches into a bag, even when
+    // the hub seeded its seat with one.
+    if (isWildSeat(this.mode, fighter)) return null;
 
     if (mon.status) {
       const list = AUTO_STATUS_CURE[mon.status];

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -2554,6 +2554,20 @@ class Relay {
   }
 
   /*
+   * Is this seat wildlife rather than a trainer? Wild / coop_wild seat their one
+   * synthetic fighter with a wild monster, and a wild monster carries no bag --
+   * so it is never handed the gym kit tryStartSim seeds a trainer seat with.
+   * The turn machine refuses an item from that seat as well (isWildSeat in
+   * lib/battle/Turn.js): this only keeps the bag from existing in the first
+   * place.
+   */
+  isWildSeat(record, seat) {
+    if (!record) return false;
+    if (record.mode !== 'wild' && record.mode !== 'coop_wild') return false;
+    return this.isNpcSeat(record, seat);
+  }
+
+  /*
    * Which seat a party fills. Normally the sender's own id. For coop_npc the
    * host may also upload the trainer party under side "b", which is dealt across
    * the synthetic npc seats rather than displacing their own team -- so this
@@ -2720,9 +2734,11 @@ class Relay {
       const party = record.parties.get(seat);
       if (!party) return null;
       const client = this.clients.get(seat);
-      // Seed NPC seats with a gym-style kit when the host uploaded no bag.
+      // Seed trainer NPC seats with a gym-style kit when the host uploaded no
+      // bag. A wild seat is skipped: wildlife does not carry items.
       if (!record.bags) record.bags = new Map();
-      if (!record.bags.has(seat) && this.isNpcSeat(record, seat)) {
+      if (!record.bags.has(seat) && this.isNpcSeat(record, seat)
+          && !this.isWildSeat(record, seat)) {
         record.bags.set(seat, this.cloneBagMap(this.Turn.DEFAULT_NPC_BAG));
       }
       const bag = record.bags.get(seat);

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/BattleSim/Turn.lua
+++ b/src/BattleSim/Turn.lua
@@ -134,6 +134,19 @@ local function maxFighters(mode, side)
   return M.FIGHTERS_PER_SIDE
 end
 
+-- The wild monster's seat.  Wildlife is always the synthetic side-b seat of a
+-- mode whose name says "wild" (the seat `maxFighters` caps at one above and
+-- `_awardExp` pays the other side for), and wildlife carries no bag: a wild
+-- monster never uses an item, no matter who asks on its behalf.  Both askers
+-- are gated -- `_normaliseChoice` refuses a submitted one, `_autoItemChoice`
+-- never picks one -- because the seat can be driven from either end.
+local WILD_SIDE = "b"
+
+local function isWildSeat(mode, fighter)
+  return fighter ~= nil and fighter.side == WILD_SIDE
+    and Effects.isWildMode(mode)
+end
+
 -- Wire spells a condition as a three-letter token and Status.lua spells it as
 -- a word.  Both are accepted on the way in and the token is what goes back out
 -- on an event, so neither vocabulary leaks into the other's file.
@@ -879,6 +892,9 @@ function Battle:_normaliseChoice(fighter, choice)
   if action == "item" then
     local item = str(choice.item)
     if not item then return nil end
+    -- Wildlife has no bag and no hands.  Refused rather than ignored so a wild
+    -- seat that is somehow handed one never spends the turn on it either.
+    if isWildSeat(self.mode, fighter) then return nil end
     -- A fighter with a bag sheet must actually hold the stack (hub/NPC auto).
     -- Seats with no bag stay permissive so headless fixtures can still item.
     if fighter.bag and not self:_bagHas(fighter, item) then return nil end
@@ -1113,6 +1129,9 @@ end
 -- Bag item for the active mon: cure → heal ≤50% → X-item while stages flat.
 function Battle:_autoItemChoice(fighter, mon)
   if not fighter.bag then return nil end
+  -- A wild monster is not a trainer: it never reaches into a bag, even when the
+  -- hub seeded its seat with one.
+  if isWildSeat(self.mode, fighter) then return nil end
 
   if mon.status then
     local list = AUTO_STATUS_CURE[mon.status]

--- a/src/BattleSim2/Turn.lua
+++ b/src/BattleSim2/Turn.lua
@@ -132,6 +132,19 @@ local function maxFighters(mode, side)
   return M.FIGHTERS_PER_SIDE
 end
 
+-- The wild monster's seat.  Wildlife is always the synthetic side-b seat of a
+-- mode whose name says "wild" (the seat `maxFighters` caps at one above and
+-- `_awardExp` pays the other side for), and wildlife carries no bag: a wild
+-- monster never uses an item, no matter who asks on its behalf.  Both askers
+-- are gated -- `_normaliseChoice` refuses a submitted one, `_autoItemChoice`
+-- never picks one -- because the seat can be driven from either end.
+local WILD_SIDE = "b"
+
+local function isWildSeat(mode, fighter)
+  return fighter ~= nil and fighter.side == WILD_SIDE
+    and Effects.isWildMode(mode)
+end
+
 -- Wire spells a condition as a three-letter token and Status.lua spells it as
 -- a word.  Both are accepted on the way in and the token is what goes back out
 -- on an event, so neither vocabulary leaks into the other's file.
@@ -905,6 +918,9 @@ function Battle:_normaliseChoice(fighter, choice)
   if action == "item" then
     local item = str(choice.item)
     if not item then return nil end
+    -- Wildlife has no bag and no hands.  Refused rather than ignored so a wild
+    -- seat that is somehow handed one never spends the turn on it either.
+    if isWildSeat(self.mode, fighter) then return nil end
     -- A fighter with a bag sheet must actually hold the stack (hub/NPC auto).
     -- Seats with no bag stay permissive so headless fixtures can still item.
     if fighter.bag and not self:_bagHas(fighter, item) then return nil end
@@ -1139,6 +1155,9 @@ end
 -- Bag item for the active mon: cure → heal ≤50% → X-item while stages flat.
 function Battle:_autoItemChoice(fighter, mon)
   if not fighter.bag then return nil end
+  -- A wild monster is not a trainer: it never reaches into a bag, even when the
+  -- hub seeded its seat with one.
+  if isWildSeat(self.mode, fighter) then return nil end
 
   if mon.status then
     local list = AUTO_STATUS_CURE[mon.status]

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -1357,6 +1357,17 @@ function M:isNpcSeat(record, seat)
   return false
 end
 
+-- Is this seat wildlife rather than a trainer?  Wild / coop_wild seat their one
+-- synthetic fighter with a wild monster, and a wild monster carries no bag --
+-- so it is never handed the gym kit `tryStartSim` seeds a trainer seat with.
+-- BattleSim refuses an item from that seat as well (`isWildSeat` in
+-- BattleSim/Turn.lua): this only keeps the bag from existing in the first place.
+function M:isWildSeat(record, seat)
+  if not record then return false end
+  if record.mode ~= "wild" and record.mode ~= "coop_wild" then return false end
+  return self:isNpcSeat(record, seat)
+end
+
 -- Which seat a party fills.  Normally the sender's own id.  For coop_npc the
 -- host may also upload the trainer's party under side "b", which is dealt across
 -- the synthetic npc seats rather than displacing their own team -- so this
@@ -1536,9 +1547,11 @@ function M:tryStartSim(record)
     local party = record.parties[seat]
     if not party then return nil end
     local client = self.clients[seat]
-    -- Seed NPC seats with a gym-style kit when the host uploaded no bag.
+    -- Seed trainer NPC seats with a gym-style kit when the host uploaded no
+    -- bag.  A wild seat is skipped: wildlife does not carry items.
     record.bags = record.bags or {}
-    if not record.bags[seat] and self:isNpcSeat(record, seat) then
+    if not record.bags[seat] and self:isNpcSeat(record, seat)
+       and not self:isWildSeat(record, seat) then
       record.bags[seat] = self:cloneBagMap(self.Turn.DEFAULT_NPC_BAG)
     end
     local bag = record.bags[seat]

--- a/tests/battle_sim2_turn.lua
+++ b/tests/battle_sim2_turn.lua
@@ -594,6 +594,73 @@ do
 end
 
 -- ------------------------------------------------------------------
+-- 4. wildlife never uses an item, from either end
+-- ------------------------------------------------------------------
+--
+-- Byte-shared with the Gen 1 twin's 12f3 and with server/lib/battle2/Turn.js.
+-- A wild monster has no bag and no hands, and its seat is driven from two ends
+-- -- the hub auto-picks for it, and a submitted choice can arrive addressed to
+-- it -- so both are pinned.  The wild seat is handed a bag on purpose: the
+-- point is that even a seat that HAS one never spends it, so a hub seeding the
+-- wrong kit cannot put a Potion in a wild monster's mouth.
+
+for _, mode in ipairs({ "wild", "coop_wild" }) do
+  do
+    local battle = battleOf({
+      mode = mode,
+      choiceTimeout = 10,
+      seed = 88010,
+      sides = {
+        a = {
+          { playerId = "p1", name = "Ann",
+            mons = { mon({ species = "Alpha", maxHp = 200, spe = 90 }) } },
+        },
+        b = {
+          { playerId = "wild", name = "Wild",
+            -- Hurt below half and poisoned: a trainer seat heals or cures here.
+            mons = { mon({ species = "Beta", maxHp = 200, hp = 40, spe = 10,
+                           status = "PSN" }) },
+            bag = { POTION = 2, FULL_HEAL = 1, X_ATTACK = 1 } },
+        },
+      },
+    })
+    drain(battle)
+    battle:submitChoice("p1", { action = "fight", move = 0 })
+    ok(battle:tick(11) == true, mode .. ": the wild seat's turn resolves")
+    local items = ofKind(drain(battle), "item")
+    eq(#items, 0, mode .. ": auto-pick never reaches the wild seat's bag")
+    eq(battle.byId.wild.bag.POTION, 2, mode .. ": and spends none of it")
+    eq(battle.byId.wild.bag.FULL_HEAL, 1, mode .. ": cure untouched too")
+    eq(battle.byId.wild.mons[1].status, "poison", mode .. ": still poisoned")
+  end
+
+  do
+    local battle = battleOf({
+      mode = mode,
+      seed = 88011,
+      sides = {
+        a = {
+          { playerId = "p1", name = "Ann",
+            mons = { mon({ species = "Alpha", maxHp = 200, spe = 90 }) },
+            bag = { POTION = 1 } },
+        },
+        b = {
+          { playerId = "wild", name = "Wild",
+            mons = { mon({ species = "Beta", maxHp = 200, hp = 40, spe = 10 }) },
+            bag = { POTION = 1 } },
+        },
+      },
+    })
+    drain(battle)
+    ok(battle:submitChoice("wild", { action = "item", item = "POTION", slot = 0 })
+       == false, mode .. ": a submitted item from the wild seat is refused")
+    eq(battle.byId.wild.choice, nil, mode .. ": and files nothing")
+    ok(battle:submitChoice("p1", { action = "item", item = "POTION", slot = 0 })
+       == true, mode .. ": the player on side a still may")
+  end
+end
+
+-- ------------------------------------------------------------------
 
 io.write(string.format("battle_sim2_turn: %d passed, %d failed\n", passed, failed))
 os.exit(failed == 0 and 0 or 1)

--- a/tests/battle_sim_turn.lua
+++ b/tests/battle_sim_turn.lua
@@ -3153,6 +3153,80 @@ do
 end
 
 -- ------------------------------------------------------------------
+-- 12f3. wildlife never uses an item, from either end
+-- ------------------------------------------------------------------
+--
+-- A wild monster has no bag and no hands.  The seat is driven from two ends --
+-- the hub auto-picks for it, and a submitted choice can arrive addressed to it
+-- -- so both are pinned here.  The bag is handed to the wild seat deliberately:
+-- the point is that even a seat that HAS one never spends it, so a hub that
+-- seeds the wrong kit (which is what `wild` did with `DEFAULT_NPC_BAG`) cannot
+-- put a Potion in a Rattata's mouth.  Trainer seats are unaffected -- 12f above
+-- is the same fixture on the default 1v1 mode and still spends its Potion.
+
+for _, mode in ipairs({ "wild", "coop_wild" }) do
+  do
+    local battle = battleOf({
+      mode = mode,
+      choiceTimeout = 10,
+      seed = 88010,
+      sides = {
+        a = {
+          { playerId = "p1", name = "Ann",
+            mons = { mon({ species = "Alpha", maxHp = 200, spd = 90,
+                           moves = { move({ id = "thump", power = 40 }) } }) } },
+        },
+        b = {
+          { playerId = "wild", name = "Wild",
+            -- Hurt below half and poisoned: 12f's fixture files a heal here.
+            mons = { mon({ species = "Beta", maxHp = 200, hp = 40, spd = 10,
+                           status = "PSN",
+                           moves = { move({ id = "thump", power = 40 }) } }) },
+            bag = { POTION = 2, FULL_HEAL = 1, X_ATTACK = 1 } },
+        },
+      },
+    })
+    drain(battle)
+    battle:submitChoice("p1", { action = "fight", move = 0 })
+    ok(battle:tick(11) == true, mode .. ": the wild seat's turn resolves")
+    local events = drain(battle)
+    local itemUsed = nil
+    for _, event in ipairs(events) do
+      if event.t == "item" and event.side == "b" then itemUsed = event.text end
+    end
+    eq(itemUsed, nil, mode .. ": auto-pick never reaches the wild seat's bag")
+    eq(battle.byId.wild.bag.POTION, 2, mode .. ": and spends none of it")
+    eq(battle.byId.wild.bag.FULL_HEAL, 1, mode .. ": cure untouched too")
+    eq(battle.byId.wild.mons[1].status, "poison", mode .. ": still poisoned")
+  end
+
+  do
+    local battle = battleOf({
+      mode = mode,
+      seed = 88011,
+      sides = {
+        a = {
+          { playerId = "p1", name = "Ann",
+            mons = { mon({ species = "Alpha", maxHp = 200, spd = 90 }) },
+            bag = { POTION = 1 } },
+        },
+        b = {
+          { playerId = "wild", name = "Wild",
+            mons = { mon({ species = "Beta", maxHp = 200, hp = 40, spd = 10 }) },
+            bag = { POTION = 1 } },
+        },
+      },
+    })
+    drain(battle)
+    ok(battle:submitChoice("wild", { action = "item", item = "POTION", slot = 0 })
+       == false, mode .. ": a submitted item from the wild seat is refused")
+    eq(battle.byId.wild.choice, nil, mode .. ": and files nothing")
+    ok(battle:submitChoice("p1", { action = "item", item = "POTION", slot = 0 })
+       == true, mode .. ": the player on side a still may")
+  end
+end
+
+-- ------------------------------------------------------------------
 -- 12h. round 5: `exp` event emission gates (`_awardExp`)
 -- ------------------------------------------------------------------
 --

--- a/tests/hub_battle.lua
+++ b/tests/hub_battle.lua
@@ -676,6 +676,16 @@ do
   eq(#record.parties[record.npcIds[1]].mons, 1, "dealt one to each seat")
   eq(#record.parties[record.npcIds[2]].mons, 1, "both of them, not one seat's two")
 
+  -- A trainer seat the host uploaded no bag for is seeded with the gym kit, so
+  -- a gym leader can potion.  The wild-seat block below is the other half of
+  -- this claim: wildlife is never seeded, because a wild monster has no bag.
+  ok(not hub:isWildSeat(record, record.npcIds[1]),
+     "a coop_npc npc seat is a trainer, not wildlife")
+  ok(record.bags[record.npcIds[1]] ~= nil, "so it was seeded with a gym kit")
+  eq(record.sim.byId[record.npcIds[1]].bag.POTION,
+     need("BattleSim/Turn").DEFAULT_NPC_BAG.POTION,
+     "the kit the sim actually fights with")
+
   local ready = take(annPeer, Wire.BATTLE_READY)
   ok(ready ~= nil, "the field is announced")
   ok(Wire.battleReady(ready) ~= nil, "in a shape the client's sanitiser accepts")
@@ -737,6 +747,16 @@ do
   record.ruleset = { chart = CHART, seed = 1 }
   ok(hub:tryStartSim(record), "wild sim starts")
   ok(record.sim ~= nil, "and the intermediator is running")
+
+  -- Wildlife carries no bag.  The seat is synthetic exactly as a coop_npc
+  -- trainer seat is, and it used to be seeded with the same gym kit -- which is
+  -- how a wild monster ended up drinking a Potion mid-fight.  BattleSim refuses
+  -- an item from the seat as well; this is the bag never existing.
+  ok(hub:isNpcSeat(record, record.npcIds[1]), "the wild seat is a synthetic seat")
+  ok(hub:isWildSeat(record, record.npcIds[1]), "and it is wildlife, not a trainer")
+  eq(record.bags[record.npcIds[1]], nil, "so no gym kit was seeded onto it")
+  eq(record.sim.byId[record.npcIds[1]].bag, nil,
+     "and it fights with no bag at all")
 end
 
 -- ------- coop_wild: two humans, one wild seat; 2-human gate; catcher on catch
@@ -801,6 +821,10 @@ do
   hub:receive(ann, { type = Wire.BATTLE_PARTY, battle = "cw-catch", side = "b",
     mons = { mon({ species = "PIDGEY", catchRate = 255 }) } })
   ok(record.sim ~= nil, "coop_wild sim starts with two humans and a wild party")
+  ok(hub:isWildSeat(record, record.npcIds[1]),
+     "coop_wild's synthetic seat is wildlife too")
+  eq(record.sim.byId[record.npcIds[1]].bag, nil,
+     "and it is seated with no bag either")
   take(annPeer, Wire.BATTLE_READY)
   take(bobPeer, Wire.BATTLE_READY)
 


### PR DESCRIPTION
## The bug

Wild fights were drinking POTIONs, curing their own status and reading X ATTACK mid-battle — something no wild encounter has ever done in any of these games.

## Root cause

The bag was never the wild monster's. `wild` and `coop_wild` seat their wildlife on the **same synthetic NPC seat machinery** a `coop_npc` trainer sits on — `Hub:openMediatedBattle` mints an `npcId` for those modes too — and `tryStartSim` seeded *every* one of those seats with `Turn.DEFAULT_NPC_BAG`, the gym-style kit (POTION ×2, SUPER_POTION, FULL_HEAL, X_ATTACK) that exists so a gym leader can potion. `_autoChoice → _autoItemChoice` then found a bag and spent it.

"NPC seat" is not "trainer" in this hub, and that is the whole bug.

## The fix — both ends, because the seat can be driven from either

**The hub stops handing the bag out.** New `isWildSeat(record, seat)` in `src/Hub.lua` and `server/lib/relay.js`; `tryStartSim` seeds the kit only on trainer seats.

**The referee refuses the item regardless of where a bag came from.** All four turn-machine twins — `src/BattleSim/Turn.lua`, `src/BattleSim2/Turn.lua`, `server/lib/battle/Turn.js`, `server/lib/battle2/Turn.js` — get a module-local `isWildSeat(mode, fighter)` (wild-ish mode plus side `b`, the same seat `_awardExp` already assumes) and gate both askers:

- `_normaliseChoice` refuses a submitted `item` choice from the wild seat
- `_autoItemChoice` never picks one for it

A bag that arrives from anywhere else is still never spent.

A trainer battle is untouched, and that is asserted rather than assumed: a `coop_npc` seat is still seeded and still fights with the kit.

Also checked and deliberately left alone: the legacy local `CoopSim` host-sim path. Its `aiItem` route requires `self.trainer`, which `Coop.trainerFor` leaves nil for a wild encounter, so wildlife cannot reach a bag there either.

## Tests

Covered in six suites — the Gen 1 and Gen 2 Lua sims, both Node twins, and both hub twins. **Every new case was checked red with the fix reverted.** The sim fixtures deliberately hand the wild seat a bag, so what they pin is that a seat which *has* one never spends it.

Cross-runtime parity and the committed fixtures are unmoved: no wild vector ever seated a bag.

| | |
|---|---|
| Lua sims | `battle_sim_turn` 485/485, `battle_sim2_turn` 68/68, vectors green |
| Hub twins | `tests/hub_battle.lua` 170/170, `server/hub_battle.test.js` 94/94 |
| Node | all 15 suites green, including cross-runtime parity (luajit driver spawned) and `twin_parity` |
| Mod SDK | `run_modkit.lua` 34/34, `modkit validate` / `lint` / `pack` clean |
| End-to-end | `run-party-wild-e2e.sh` **and** the full `run-mmo-e2e.sh` — 0 failures on both instances; the `coop_wild` fight runs to a MASTER_BALL catch with `gaps=0 desyncs=0`, and the `coop_npc` trainer leg still works |

## Version

Bumped 1.0.8 → 1.0.9 across `manifest.json`, `README.md`, `server/package.json` and `CHANGELOG.md`.