### PR TITLE
fix: draw the trainer, and our own POKéMON's front pic, in a solo battle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,49 @@ here must match `manifest.version`.
 
 ### Fixed
 
+- **A solo fight drew the player's POKéMON from behind, and its trainer not
+  at all.** With `SOLO BATTLES` on, the arena stood a dark placeholder
+  rectangle where the opposing trainer should be, and drew this client's own
+  monster as its *back* pic, mirrored — the view the classic 160×144 stage
+  wants — where a co-op fight of the same shape draws the front pic. Two
+  separate causes under one screen.
+
+  **The trainer.** `MediatedBattle:battlefieldCtx` folds every non-wild shape
+  into `"1v1"` for the arena's geometry, and the foe-figure arm was reading
+  that folded value — so a `coop_npc` fight was described as a *peer* battle
+  and asked the roster for the sprite of a player a solo fight does not have.
+  `Battlefield.drawHuman` falls back to a silhouette for a figure that names
+  no walk sheet, and that silhouette was the whole trainer. The arm now tests
+  the fight's real mode first and resolves the NPC's overworld sheet the way
+  co-op always has; `src/SoloBattle.lua` hands the screen the engine's own
+  `data.trainers` record for it to read.
+
+  **The monster.** `MediatedBattle:seatFront` hands the arena a front pic for
+  *both* sides, and on Gen 1 it gets one by building a throwaway battler. It
+  was passing the wire sheet straight to `BattleState.makeBattler`, which is
+  written against the engine's own mon: it measures the HP bar with
+  `mon.stats.hp`, and a `Wire.battleMon` sheet keeps its maximum beside the
+  stats as `maxHp` and has no `stats.hp` at all. So the call threw, the pcall
+  swallowed it, and this returned nil for **every** seat — which looked like
+  it worked, because the caller falls back to the pic the slot already holds
+  and a foe's slot pic is already a front. Only this client's own seat, whose
+  slot pic is the back, showed it. It builds a save-mon-shaped stub now, the
+  same one `refreshSlotSprite` has always built.
+
+  `Gen.trainerWalkSpriteId` is the co-op resolver moved to `src/Gen.lua` so
+  both screens share one copy (`MediatedBattle` cannot require `CoopBattle`
+  without closing a cycle). Moving it fixed a second bug it had been hiding:
+  the class→walk-sheet vote over `data.maps` read a bare `data`, a name no
+  scope there binds, so the lookup found the global nil and every class the
+  name transform could not resolve fell straight past the overworld's own
+  answer into the generic list — a LASS fought as `SPRITE_COOLTRAINER_M`
+  rather than as the `SPRITE_COOLTRAINER_F` she walks around as.
+
+  Covered where it draws: the solo end-to-end driver now probes the live arena
+  in both the wild and the trainer leg, asserting that our own seat's pic is
+  not the back pic the slot holds and that the trainer on the foe edge names a
+  real walk sheet.
+
 - **A nicknamed POKéMON was a blank box at Lv 1 on the other player's
   screen.** In an MMO battle the opponent's monster drew as the arena's
   placeholder square with `Lv 1` under it, and knocking it out paid no

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -5146,112 +5146,14 @@ end
 
 -- ------- trainer class → overworld walk sheet
 --
--- There is no class→sprite field anywhere in engine data. A trainer record
--- (`data.trainers`) carries the battle front pic, the parties and the prize
--- money, and says nothing about the overworld; the walk sheet is chosen per
--- **map object**, where `data.maps[*].objects[*]` pairs a `sprite` with the
--- `trainerClass` that object fights as. That is still a real mapping, just an
--- indirect one -- so it is read out of the data rather than hand-written here:
--- every object naming a class votes for the sheet it is drawn with, and the
--- class takes the sheet with the most votes.
---
--- Which is what the name transform below cannot do on its own. Red has no
--- SPRITE_LASS and no SPRITE_BUG_CATCHER -- those classes walk around as
--- SPRITE_COOLTRAINER_F and SPRITE_YOUNGSTER -- so `OPP_BUG_CATCHER` resolved to
--- nothing, `battlefieldFoeHumans` returned an empty list, and a coop_npc fight
--- announced "BUG CATCHER wants to fight!" over an empty right-hand edge.
---
--- Ties break on id order so two clients never disagree about a class, and the
--- whole walk is memoised against the maps table it was built from: one pass
--- over ~250 maps per boot, and none at all once a battle is running.
-local trainerSpriteVotes = nil
-local trainerSpriteVotesFrom = nil
-
-local function trainerSpritesByClass(data)
-  local maps = type(data) == "table" and data.maps or nil
-  if type(maps) ~= "table" then return nil end
-  if trainerSpriteVotesFrom == maps then return trainerSpriteVotes end
-
-  local votes = {}
-  local ok = pcall(function()
-    for _, map in pairs(maps) do
-      if type(map) == "table" and type(map.objects) == "table" then
-        for _, obj in pairs(map.objects) do
-          if type(obj) == "table" then
-            local class, sprite = obj.trainerClass, obj.sprite
-            if type(class) == "string" and class ~= ""
-               and type(sprite) == "string" and sprite ~= "" then
-              local bucket = votes[class]
-              if not bucket then
-                bucket = {}
-                votes[class] = bucket
-              end
-              bucket[sprite] = (bucket[sprite] or 0) + 1
-            end
-          end
-        end
-      end
-    end
-  end)
-  if not ok then return nil end
-
-  local out = {}
-  for class, bucket in pairs(votes) do
-    local best, bestN = nil, -1
-    for sprite, n in pairs(bucket) do
-      if n > bestN or (n == bestN and (best == nil or sprite < best)) then
-        best, bestN = sprite, n
-      end
-    end
-    out[class] = best
-  end
-  trainerSpriteVotes = out
-  trainerSpriteVotesFrom = maps
-  return out
-end
-
--- Last resort, best first: a class nobody walks around as on any map (the
--- unused ones, and anything a mod adds without an overworld object) still gets
--- a body on the field rather than an empty foe edge. Probed against the
--- catalog, so a build without one of these falls to the next.
-local GENERIC_TRAINER_SPRITES = {
-  "SPRITE_COOLTRAINER_M", "SPRITE_YOUNGSTER", "SPRITE_GENTLEMAN",
-}
-
--- OPP_YOUNGSTER → SPRITE_YOUNGSTER when the catalog has a walk sheet; the
--- overworld's own answer for the classes it does not (OPP_LASS,
--- OPP_BUG_CATCHER, …); a generic trainer after that.
+-- Moved to `Gen.trainerWalkSpriteId` (src/Gen.lua), because the solo screen
+-- asks the same question: `MediatedBattle:battlefieldCtx` needs the NPC
+-- trainer's walk sheet for a `coop_npc` fight, and it cannot require this
+-- module without closing a cycle. The vote-over-map-objects walk and the
+-- generic fallbacks live there unchanged; see that header for why the mapping
+-- has to be read out of `data.maps` rather than written down.
 local function trainerWalkSpriteId(trainer, game)
-  if type(trainer) ~= "table" then return nil end
-  local id = trainer.id or trainer.sprite or trainer.spriteId
-  if type(id) ~= "string" or id == "" then return nil end
-  local spriteId = id
-  if spriteId:match("^OPP_") then
-    spriteId = "SPRITE_" .. spriteId:sub(5)
-  elseif not spriteId:match("^SPRITE_") then
-    spriteId = "SPRITE_" .. spriteId
-  end
-  -- `Gen.spriteCatalog`, not `data.sprites`: Gold keeps its walk sheets on
-  -- `data.gen2Sprites`, and reading Gen 1's table on a Gold boot proves nothing
-  -- about a sheet that is really there.
-  local sprites = Gen.spriteCatalog(game)
-  if type(sprites) == "table" and type(sprites[spriteId]) == "table" then
-    return spriteId
-  end
-  -- Soft: accept the id even if we cannot prove the sheet exists here;
-  -- Battlefield.resolveHumanSheet will silhouette if load fails.
-  if sprites == nil then return spriteId end
-  if type(sprites) ~= "table" then return nil end
-
-  local byClass = trainerSpritesByClass(data)
-  local mapped = byClass and byClass[id] or nil
-  if type(mapped) == "string" and type(sprites[mapped]) == "table" then
-    return mapped
-  end
-  for _, generic in ipairs(GENERIC_TRAINER_SPRITES) do
-    if type(sprites[generic]) == "table" then return generic end
-  end
-  return nil
+  return Gen.trainerWalkSpriteId(trainer, game)
 end
 
 -- Resolve a battle FRONT pic for the field (not the bag-icon sheet — those

--- a/src/Gen.lua
+++ b/src/Gen.lua
@@ -599,6 +599,128 @@ function M.spriteCatalog(game)
   return nil
 end
 
+-- ------- trainer class -> overworld walk sheet
+--
+-- There is no class->sprite field anywhere in engine data. A trainer record
+-- (`data.trainers`) carries the battle front pic, the parties and the prize
+-- money, and says nothing about the overworld; the walk sheet is chosen per
+-- **map object**, where `data.maps[*].objects[*]` pairs a `sprite` with the
+-- `trainerClass` that object fights as. That is still a real mapping, just an
+-- indirect one -- so it is read out of the data rather than hand-written here:
+-- every object naming a class votes for the sheet it is drawn with, and the
+-- class takes the sheet with the most votes.
+--
+-- Which is what the name transform below cannot do on its own. Red has no
+-- SPRITE_LASS and no SPRITE_BUG_CATCHER -- those classes walk around as
+-- SPRITE_COOLTRAINER_F and SPRITE_YOUNGSTER -- so `OPP_BUG_CATCHER` resolved to
+-- nothing and the foe edge of the arena was left empty.
+--
+-- Ties break on id order so two clients never disagree about a class, and the
+-- whole walk is memoised against the maps table it was built from: one pass
+-- over ~250 maps per boot, and none at all once a battle is running.
+--
+-- **Lives here, and not in a battle screen**, because both of them ask it --
+-- `CoopBattle:battlefieldFoeHumans` for a co-op NPC fight and
+-- `MediatedBattle:battlefieldCtx` for the solo one -- and MediatedBattle cannot
+-- require CoopBattle without closing a cycle. It sits next to `spriteCatalog`
+-- for the reason that function exists: this is a walk-sheet question, and the
+-- catalog it has to be answered against is generation-shaped.
+local trainerSpriteVotes = nil
+local trainerSpriteVotesFrom = nil
+
+local function trainerSpritesByClass(data)
+  local maps = type(data) == "table" and data.maps or nil
+  if type(maps) ~= "table" then return nil end
+  if trainerSpriteVotesFrom == maps then return trainerSpriteVotes end
+
+  local votes = {}
+  local ok = pcall(function()
+    for _, map in pairs(maps) do
+      if type(map) == "table" and type(map.objects) == "table" then
+        for _, obj in pairs(map.objects) do
+          if type(obj) == "table" then
+            local class, sprite = obj.trainerClass, obj.sprite
+            if type(class) == "string" and class ~= ""
+               and type(sprite) == "string" and sprite ~= "" then
+              local bucket = votes[class]
+              if not bucket then
+                bucket = {}
+                votes[class] = bucket
+              end
+              bucket[sprite] = (bucket[sprite] or 0) + 1
+            end
+          end
+        end
+      end
+    end
+  end)
+  if not ok then return nil end
+
+  local out = {}
+  for class, bucket in pairs(votes) do
+    local best, bestN = nil, -1
+    for sprite, n in pairs(bucket) do
+      if n > bestN or (n == bestN and (best == nil or sprite < best)) then
+        best, bestN = sprite, n
+      end
+    end
+    out[class] = best
+  end
+  trainerSpriteVotes = out
+  trainerSpriteVotesFrom = maps
+  return out
+end
+
+-- Last resort, best first: a class nobody walks around as on any map (the
+-- unused ones, and anything a mod adds without an overworld object) still gets
+-- a body on the field rather than an empty foe edge. Probed against the
+-- catalog, so a build without one of these falls to the next.
+local GENERIC_TRAINER_SPRITES = {
+  "SPRITE_COOLTRAINER_M", "SPRITE_YOUNGSTER", "SPRITE_GENTLEMAN",
+}
+
+-- OPP_YOUNGSTER -> SPRITE_YOUNGSTER when the catalog has a walk sheet; the
+-- overworld's own answer for the classes it does not (OPP_LASS,
+-- OPP_BUG_CATCHER, ...); a generic trainer after that.
+function M.trainerWalkSpriteId(trainer, game)
+  if type(trainer) ~= "table" then return nil end
+  local id = trainer.id or trainer.sprite or trainer.spriteId
+  if type(id) ~= "string" or id == "" then return nil end
+  local spriteId = id
+  if spriteId:match("^OPP_") then
+    spriteId = "SPRITE_" .. spriteId:sub(5)
+  elseif not spriteId:match("^SPRITE_") then
+    spriteId = "SPRITE_" .. spriteId
+  end
+  -- `M.spriteCatalog`, not `data.sprites`: Gold keeps its walk sheets on
+  -- `data.gen2Sprites`, and reading Gen 1's table on a Gold boot proves nothing
+  -- about a sheet that is really there.
+  local sprites = M.spriteCatalog(game)
+  if type(sprites) == "table" and type(sprites[spriteId]) == "table" then
+    return spriteId
+  end
+  -- Soft: accept the id even if we cannot prove the sheet exists here;
+  -- Battlefield.resolveHumanSheet will silhouette if load fails.
+  if sprites == nil then return spriteId end
+  if type(sprites) ~= "table" then return nil end
+
+  -- **`game.data`, and it used to be a bare `data`** -- a name no scope here
+  -- binds, so the lookup found the global nil, the vote table was never built
+  -- and every class the name transform could not resolve fell straight past
+  -- the overworld's own answer into the generic list. A LASS fought as a
+  -- COOLTRAINER_M rather than as the SPRITE_COOLTRAINER_F she walks around
+  -- as, which reads as a lazy fallback rather than as the dead branch it was.
+  local byClass = trainerSpritesByClass(game and game.data)
+  local mapped = byClass and byClass[id] or nil
+  if type(mapped) == "string" and type(sprites[mapped]) == "table" then
+    return mapped
+  end
+  for _, generic in ipairs(GENERIC_TRAINER_SPRITES) do
+    if type(sprites[generic]) == "table" then return generic end
+  end
+  return nil
+end
+
 function M.restoreMapMusic(game, opts)
   opts = opts or {}
   local Music = opts.Music

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -1160,6 +1160,14 @@ function M.new(opts)
     peerName  = opts.peerName or "FRIEND",
     onDone    = opts.onDone,
 
+    -- The NPC the other seat is fighting as, on a `coop_npc` fight -- the
+    -- engine's own `data.trainers` record, handed straight through by
+    -- src/SoloBattle.lua. Read for exactly one thing: the overworld walk sheet
+    -- the arena stands on the foe edge (`battlefieldCtx`). Nil on every other
+    -- shape, including a peer fight, where the figure on that edge is a
+    -- player and comes from the roster instead.
+    trainer   = opts.trainer,
+
     -- A test hook, and named as one.  With it set, a turn is answered the
     -- instant it opens with the first move at the default target, which is
     -- what lets the headless suite drive a whole fight with no input device.
@@ -1276,6 +1284,21 @@ function M.new(opts)
     targetIndex = 1,          -- field cursor when a target list exists
   }, M)
 end
+
+-- The exp-awarding modes that have a *trainer* on the other side.
+--
+-- The referee's own gate is `EXP_MODES` = wild / coop_wild / coop_npc
+-- (server/lib/battle/Turn.js, src/BattleSim/Turn.lua). Two of those three are
+-- wildlife; only `coop_npc` fields a trainer, so the x1.5 belongs to it alone
+-- and every other token -- including a mode this screen never learned -- pays
+-- the plain wild rate.
+--
+-- Declared here, with the file's constants, rather than beside the exp award
+-- that was its first reader: `battlefieldCtx` now asks the same question to
+-- decide whether the foe edge of the arena holds a trainer or a peer, and a
+-- `local` is only in scope *below* its declaration -- left where it was, that
+-- read would have found the global nil and indexed it.
+local TRAINER_MODES = { coop_npc = true }
 
 -- ------- Gen1 Battlefield theatre gate
 --
@@ -1413,9 +1436,46 @@ function M:seatFront(speciesKey, monHint, slot, isOwn)
   local eng = loadEngine()
   local data = self.game and self.game.data
   local save = self.game and self.game.save
-  local mon = monHint
-  if (not mon or not mon.species) and data then
-    mon = { species = speciesKey, level = (monHint and monHint.level) or 5 }
+  -- **A save-mon-shaped stub, and never the wire sheet itself.**
+  --
+  -- `BattleState.makeBattler` is written against the engine's own mon: it
+  -- indexes `data.pokemon[mon.species]` for the definition it names the
+  -- battler from, and it measures the HP bar with
+  -- `Timing.hpBarPixels(mon.hp, math.max(1, mon.stats.hp))`. A `Wire.battleMon`
+  -- sheet answers neither. Its `species` is the *display* token (the nickname
+  -- wherever the player set one), and its `stats` is the wire dialect --
+  -- `atk`/`def`/`spd`/`spc`, with **no `hp` at all**, because the maximum
+  -- travels beside it as `maxHp`. So `mon.stats.hp` was nil, `math.max` threw,
+  -- the pcall swallowed it and this function returned nil for *every* seat on
+  -- Gen 1.
+  --
+  -- Which looked like it worked, because the caller falls back to
+  -- `slot.sprite`: a foe's slot pic is already the front (`refreshSlotSprite`
+  -- passes isPlayer=false), so the opponent drew correctly by accident, while
+  -- this client's own monster drew the *back* pic the classic 1v1 stage wants
+  -- -- the arena showing PIKACHU from behind, mirrored, where co-op shows the
+  -- front pic. The two screens agree again now, which is the whole point of
+  -- `seatFrontFor` in src/CoopBattle.lua being this function's twin: it never
+  -- hit this because it is handed a real `battler.mon`.
+  --
+  -- Same shape as `refreshSlotSprite`'s stub, deliberately -- the id in
+  -- `species` and the narrated token kept as `nickname` -- so the two pics a
+  -- seat can hold are resolved off the same description.
+  local mon = nil
+  if data then
+    local maxHp = (slot and slot.maxHp) or (monHint and monHint.maxHp) or 1
+    mon = {
+      species = speciesKey,
+      nickname = (slot and slot.species) or (monHint and monHint.species),
+      level = (monHint and monHint.level) or (slot and slot.level) or 5,
+      hp = (slot and slot.hp) or (monHint and monHint.hp) or maxHp,
+      stats = {
+        hp = maxHp,
+        attack = 1, defense = 1, speed = 1, special = 1,
+      },
+      moves = (monHint and monHint.moves) or { { id = "TACKLE", pp = 1 } },
+      status = slot and slot.status or nil,
+    }
   end
   if Gen.generation(self.game) == 2 then
     local def = data and type(data.pokemon) == "table" and data.pokemon[speciesKey]
@@ -1677,7 +1737,27 @@ function M:battlefieldCtx()
     spriteId = selfSpriteId(),
   }}
   local foeHumans = {}
-  if mode == "1v1" then
+  -- Who is standing on the foe edge: an NPC trainer, a peer, or nobody.
+  --
+  -- **The trainer arm has to come first**, because `mode` above folds every
+  -- non-wild shape into "1v1" for the arena's geometry -- so a `coop_npc`
+  -- fight fell into the peer arm and was drawn from `self.peerId`, which a
+  -- solo battle never has. `peerSpriteId(nil)` is nil, and a human with no
+  -- sheet is `Battlefield.drawHuman`'s placeholder silhouette: the dark box
+  -- that stood where the trainer should have been for the whole of every solo
+  -- trainer fight.
+  --
+  -- One entry and never a player's, exactly as
+  -- `CoopBattle:battlefieldFoeHumans` builds it: the entry is unconditional
+  -- even when the walk sheet cannot be named, because the trainer *is* on the
+  -- field either way and the silhouette is still a trainer standing there.
+  if TRAINER_MODES[self.mode] then
+    foeHumans[1] = {
+      id = (self.trainer and self.trainer.id) or self.peerId,
+      name = (self.trainer and self.trainer.name) or self.peerName or "FRIEND",
+      spriteId = Gen.trainerWalkSpriteId(self.trainer, self.game),
+    }
+  elseif mode == "1v1" then
     foeHumans[1] = {
       id = self.peerId,
       name = self.peerName or "FRIEND",
@@ -2319,15 +2399,6 @@ function M:paidSheetIndex(msg)
   if index < 1 then return self.active or 1 end
   return index
 end
-
--- The exp-awarding modes that have a *trainer* on the other side.
---
--- The referee's own gate is `EXP_MODES` = wild / coop_wild / coop_npc
--- (server/lib/battle/Turn.js, src/BattleSim/Turn.lua). Two of those three are
--- wildlife; only `coop_npc` fields a trainer, so the x1.5 belongs to it alone
--- and every other token -- including a mode this screen never learned -- pays
--- the plain wild rate.
-local TRAINER_MODES = { coop_npc = true }
 
 -- Warn once per screen rather than once per faint: a build with no Experience
 -- module loses exp on every knockout, and forty identical lines in the log

--- a/src/SoloBattle.lua
+++ b/src/SoloBattle.lua
@@ -552,6 +552,15 @@ function M:_begin(game, state, mapId, kind)
     -- call later -- but see the bag below, where the same shape was not.
     peerId = (kind ~= "wild") and FOE_SEAT or nil,
     peerName = (kind == "wild") and "WILD" or foeName(state),
+    -- The NPC record, so the arena can stand them on the foe edge.
+    --
+    -- The screen reads it for one thing -- `Gen.trainerWalkSpriteId`, the same
+    -- class-to-walk-sheet resolution `CoopBattle:battlefieldFoeHumans` does --
+    -- and without it a solo trainer fight drew the placeholder silhouette
+    -- there, because the only other figure a `coop_npc` seat could name is a
+    -- peer and a solo fight has none. Nil on a wild fight, where the foe edge
+    -- is correctly empty.
+    trainer = (kind ~= "wild") and SoloBrain.trainerOf(state) or nil,
     mode = mode,
     wildParty = (kind == "wild") and enemySheets or nil,
     wildCatchMon = wildMon,

--- a/tests/drivers/solo_battle_e2e.lua
+++ b/tests/drivers/solo_battle_e2e.lua
@@ -350,6 +350,44 @@ return function(game)
     end, 60, what or "the solo command grid")
   end
 
+  -- ------- what the arena is actually holding
+  --
+  -- The two halves of the picture a solo fight draws, read off the live screen
+  -- rather than off a fixture, because both were wrong in a way only a real
+  -- boot could show:
+  --
+  --   * **the player's own front pic.** `MediatedBattle:seatFront` hands the
+  --     arena a *front* for both sides -- that is the whole difference between
+  --     this theatre and the classic 160x144 stage, where the player's side is
+  --     a back pic. When it fails it falls back to `slot.sprite`, which on our
+  --     own seat *is* that back pic, so the failure draws a monster seen from
+  --     behind and mirrored rather than an empty seat. Nothing but comparing
+  --     the two images catches that: a nil check passes on the wrong pic.
+  --   * **the figure on the foe edge.** `Battlefield.drawHuman` falls back to a
+  --     dark placeholder rectangle when a human names no walk sheet, which is
+  --     what a solo trainer fight drew for the whole battle.
+  --
+  -- Soft throughout: a probe that throws must not take the leg with it.
+  local function arenaProbe(mine)
+    local top = medTop()
+    if not top then return nil end
+    local out = {}
+    pcall(function()
+      if not (top.usesBattlefield and top:usesBattlefield()) then
+        out.classic = true
+        return
+      end
+      local index = mine and top:mySlot() or top:foeSlot()
+      local slot = top.slots and top.slots[index]
+      local seat = top.battlefieldSeat and top:battlefieldSeat(index, mine)
+      out.front = seat and seat.front or nil
+      out.slotSprite = slot and slot.sprite or nil
+      local ctx = top.battlefieldCtx and top:battlefieldCtx() or nil
+      out.foeHumans = ctx and ctx.foeHumans or nil
+    end)
+    return out
+  end
+
   -- FIGHT / SWITCH / ITEM / RUN, then the bag row for `itemId`.
   --
   -- The grid's shape is asked for rather than assumed -- the battlefield band
@@ -665,6 +703,28 @@ return function(game)
             "the command grid opens on the mod's screen")
       shot("solo-wild-battle")
 
+      do
+        local arena = arenaProbe(true)
+        if arena and arena.classic then
+          skip("the wild arena probe", "this generation draws the classic stage")
+        else
+          log(("solo wild arena: front=%s back=%s same=%s foeHumans=%d"):format(
+            tostring(arena and arena.front ~= nil),
+            tostring(arena and arena.slotSprite ~= nil),
+            tostring(arena and arena.front == arena.slotSprite),
+            arena and arena.foeHumans and #arena.foeHumans or -1))
+          check(arena ~= nil and arena.front ~= nil,
+                "our own seat hands the arena a pic to draw")
+          check(arena ~= nil and arena.slotSprite ~= nil
+                  and arena.front ~= arena.slotSprite,
+                "...and it is the FRONT pic co-op draws, not the classic "
+                .. "stage's back pic")
+          check(arena ~= nil and arena.foeHumans ~= nil
+                  and #arena.foeHumans == 0,
+                "a wild fight stands nobody on the foe edge")
+        end
+      end
+
       local over, seen = fightToEnd(240)
       check(over, "the solo wild fight runs to an end", tostring(seen))
       check(backToOverworld(), "and the overworld is restored")
@@ -749,6 +809,33 @@ return function(game)
         check(awaitCommandMenu("the solo trainer command grid"),
               "the command grid opens on the mod's screen")
         shot("solo-trainer-battle")
+
+        do
+          local arena = arenaProbe(true)
+          if arena and arena.classic then
+            skip("the trainer arena probe",
+                 "this generation draws the classic stage")
+          else
+            local who = arena and arena.foeHumans and arena.foeHumans[1] or nil
+            log(("solo trainer arena: front=%s same=%s foe=%s sheet=%s"):format(
+              tostring(arena and arena.front ~= nil),
+              tostring(arena and arena.front == arena.slotSprite),
+              tostring(who and who.name), tostring(who and who.spriteId)))
+            check(arena ~= nil and arena.front ~= nil
+                    and arena.front ~= arena.slotSprite,
+                  "our own seat draws its front pic here too")
+            check(who ~= nil,
+                  "the trainer is standing on the foe edge")
+            check(who ~= nil and type(who.spriteId) == "string"
+                    and who.spriteId ~= "",
+                  "...with a real walk sheet, not the placeholder silhouette",
+                  tostring(who and who.spriteId))
+            check(who ~= nil and type(who.name) == "string"
+                    and who.name ~= "" and who.name ~= "FRIEND",
+                  "...named as the trainer and not as an absent peer",
+                  tostring(who and who.name))
+          end
+        end
 
         local over, seen = fightToEnd(360)
         check(over, "the solo trainer fight runs to an end", tostring(seen))

--- a/tests/mediated_battle_client.lua
+++ b/tests/mediated_battle_client.lua
@@ -73,6 +73,7 @@ local Config = need("Config")
 local Wire = need("Wire")
 local Sessions = need("Sessions")
 local Mediated = need("MediatedBattle")
+local Gen = need("Gen")
 
 -- ------------------------------------------------------------------
 -- a world small enough to state every expected number about
@@ -1472,6 +1473,106 @@ do
        "our seat ended up filled by the referee's replacement")
     eq(f.slots[2].species, "RATTATA", "...and the foe's too")
   end
+end
+
+-- ------------------------------------------------------------------
+-- 14. who is standing on the foe edge of the arena
+-- ------------------------------------------------------------------
+--
+-- `Battlefield.drawHuman` falls back to a dark placeholder rectangle for a
+-- human that names no walk sheet, and that is what a **solo trainer fight**
+-- drew for its whole length: `battlefieldCtx` folds every non-wild shape into
+-- "1v1" for the arena's geometry, and the foe-human arm was reading that same
+-- folded value -- so a `coop_npc` fight was described as a peer battle and
+-- asked the roster for a sprite belonging to a player who does not exist.
+--
+-- The trainer arm has to be tested *ahead* of the peer arm for exactly that
+-- reason, and the walk-sheet resolution under it is `Gen.trainerWalkSpriteId`,
+-- which co-op has always used and which now has one home rather than two.
+do
+  -- Red has SPRITE_YOUNGSTER and no SPRITE_LASS, which is the shape that makes
+  -- all three rungs of the ladder reachable in one fixture.
+  local SPRITES = {
+    SPRITE_YOUNGSTER     = { frames = 4 },
+    SPRITE_COOLTRAINER_F = { frames = 4 },
+    SPRITE_COOLTRAINER_M = { frames = 4 },
+  }
+  local ARENA = {
+    pokemon = DATA.pokemon,
+    sprites = SPRITES,
+    -- Two objects fight as LASS drawn with the cooltrainer sheet and one with
+    -- the youngster sheet, so the vote has a winner rather than a tie.
+    maps = {
+      ROUTE_3 = { objects = {
+        { trainerClass = "OPP_LASS", sprite = "SPRITE_COOLTRAINER_F" },
+        { trainerClass = "OPP_LASS", sprite = "SPRITE_YOUNGSTER" },
+      } },
+      ROUTE_4 = { objects = {
+        { trainerClass = "OPP_LASS", sprite = "SPRITE_COOLTRAINER_F" },
+      } },
+    },
+  }
+  local game = {
+    data = ARENA,
+    save = { party = {}, player = { name = "ANN" } },
+  }
+
+  -- ------- the resolver itself
+  eq(Gen.trainerWalkSpriteId({ id = "OPP_YOUNGSTER" }, game), "SPRITE_YOUNGSTER",
+     "OPP_YOUNGSTER walks around as SPRITE_YOUNGSTER, by the name transform")
+  eq(Gen.trainerWalkSpriteId({ id = "OPP_LASS" }, game), "SPRITE_COOLTRAINER_F",
+     "a class with no sheet of its own takes the one the overworld votes for")
+  eq(Gen.trainerWalkSpriteId({ id = "OPP_NOBODY" }, game), "SPRITE_COOLTRAINER_M",
+     "...and a class nobody walks around as still gets a body, not an empty edge")
+  eq(Gen.trainerWalkSpriteId(nil, game), nil, "no trainer names no sheet")
+  eq(Gen.trainerWalkSpriteId({}, game), nil, "...nor does a record with no id")
+
+  -- ------- and what the arena is told
+  local function screen(fields)
+    local self = setmetatable({
+      game = game,
+      slots = {}, lines = {}, mine = {},
+      active = 1, mySide = "a", phase = "play",
+      commandIndex = 1, frame = 1,
+    }, { __index = Mediated })
+    for k, v in pairs(fields) do self[k] = v end
+    return self
+  end
+
+  local npc = screen({
+    mode = "coop_npc",
+    peerName = "LASS",
+    trainer = { id = "OPP_LASS", name = "LASS" },
+  }):battlefieldCtx()
+  eq(#npc.foeHumans, 1, "a solo trainer fight stands one figure on the foe edge")
+  eq(npc.foeHumans[1].spriteId, "SPRITE_COOLTRAINER_F",
+     "...with the trainer's own walk sheet, not a placeholder silhouette")
+  eq(npc.foeHumans[1].name, "LASS", "...named as the trainer")
+  eq(npc.foeHumans[1].id, "OPP_LASS", "...and identified by their class")
+
+  -- The entry is unconditional, exactly as CoopBattle builds it: a trainer
+  -- whose sheet cannot be named is still a trainer standing there, and the
+  -- silhouette is a better answer than an empty edge.
+  local nameless = screen({
+    mode = "coop_npc", peerId = "npc", peerName = "BUG CATCHER",
+  }):battlefieldCtx()
+  eq(#nameless.foeHumans, 1,
+     "a trainer record that never arrived still puts somebody on the edge")
+  eq(nameless.foeHumans[1].spriteId, nil, "...with no sheet to name")
+  eq(nameless.foeHumans[1].name, "BUG CATCHER",
+     "...still named from the fight, never as an absent FRIEND")
+
+  local wild = screen({ mode = "wild", peerName = "WILD" }):battlefieldCtx()
+  eq(#wild.foeHumans, 0, "a wild fight leaves the foe edge empty")
+
+  -- The peer arm, unchanged: an ordinary MMO 1v1 is still drawn from the
+  -- roster, and nothing above may have moved it.
+  local peer = screen({
+    mode = "1v1", peerId = "peer1", peerName = "BOB",
+  }):battlefieldCtx()
+  eq(#peer.foeHumans, 1, "an MMO 1v1 still stands the peer on the foe edge")
+  eq(peer.foeHumans[1].id, "peer1", "...identified by their player id")
+  eq(peer.foeHumans[1].name, "BOB", "...and named from the roster")
 end
 
 T.finish("mediated_battle_client")


### PR DESCRIPTION
With `SOLO BATTLES` on, the arena stood a dark placeholder rectangle where the opposing trainer should be, and drew this client's own monster as its **back** pic, mirrored — the view the classic 160×144 stage wants — where a co-op fight of the same shape draws the front pic.

Two separate causes under one screen, both in `MediatedBattle`, which solo shares with MMO battles.

## The trainer

`MediatedBattle:battlefieldCtx` folds every non-wild shape into `"1v1"` for the arena's geometry, and the foe-figure arm was reading that *folded* value — so a `coop_npc` fight was described as a **peer** battle and asked the roster for the sprite of a player a solo fight does not have. `Battlefield.drawHuman` falls back to a silhouette for a figure that names no walk sheet, and that silhouette was the whole trainer.

The arm now tests the fight's real mode first, ahead of the peer arm, and resolves the NPC's overworld sheet the way co-op always has. `src/SoloBattle.lua` hands the screen the engine's own `data.trainers` record for it to read.

`TRAINER_MODES` moved up to the file's constants — a `local` is only in scope *below* its declaration, and its new reader sits above the exp award that was its first one.

## The monster

`MediatedBattle:seatFront` hands the arena a front pic for **both** sides, and on Gen 1 it gets one by building a throwaway battler. It was passing the wire sheet straight to `BattleState.makeBattler`, which is written against the engine's own mon: it measures the HP bar with `math.max(1, mon.stats.hp)`, and a `Wire.battleMon` sheet keeps its maximum beside the stats as `maxHp` and has **no `stats.hp` at all**.

So the call threw, the `pcall` swallowed it, and this returned `nil` for *every* seat — which looked like it worked, because the caller falls back to the pic the slot already holds, and a foe's slot pic is already a front. Only this client's own seat, whose slot pic is the back, showed it.

It builds a save-mon-shaped stub now, the same one `refreshSlotSprite` has always built. CoopBattle's twin `seatFrontFor` never hit this — it is handed a real `battler.mon`.

## A third bug the move uncovered

`Gen.trainerWalkSpriteId` is the co-op resolver moved to `src/Gen.lua` so both screens share one copy (`MediatedBattle` cannot require `CoopBattle` without closing a cycle), sitting beside `spriteCatalog` — the generation-shaped catalog it has to be answered against.

Moving it exposed a dead branch it had been hiding: the class→walk-sheet vote over `data.maps` read a bare `data`, a name no scope there binds, so the lookup found the global `nil` and every class the `OPP_` → `SPRITE_` name transform could not resolve fell straight past the overworld's own answer into the generic list. A LASS fought as `SPRITE_COOLTRAINER_M` rather than as the `SPRITE_COOLTRAINER_F` she walks around as.

## Coverage

The solo end-to-end driver probes the live arena in both the wild and the trainer leg: our own seat's pic is not the back pic the slot holds, a wild fight stands nobody on the foe edge, and the trainer names a real walk sheet under their own name rather than an absent `FRIEND`.

Headless, the mediated-client suite pins all three rungs of the walk-sheet ladder and all four foe-edge shapes — NPC, NPC with no record, wild, peer — so the peer arm cannot be moved by accident.

## Verified

- T4 **37/37 suites**; `modkit validate`, `lint` and `pack` all clean
- mediated-client suite **292 → 308** checks
- **solo e2e, Gen 1: `GAPS:0`** — `front=true same=false foe=BUG CATCHER sheet=SPRITE_YOUNGSTER`, i.e. the map vote answering where the generic list used to
- **MMO e2e: end-to-end passed** — the peer path and the 2v2 co-op NPC fight both still render correctly

Not run: the Gold leg of the solo driver (no cached Gen 2 data in this checkout — the Gen 2 arm of `seatFront` is untouched, though the trainer fix does apply there), and the LAN driver, since nothing here touches transport code.

No wire change, no `PROTOCOL` bump, no `server/` change; `affects_link` and the link fingerprint are untouched.