### PR TITLE
feature: remember the last-used move, and state each move's type on its own row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+## [1.0.17] - 2026-08-19
+
 ### Added
 
 - **This mod's battle system, with nobody else in the room.** A new
@@ -90,6 +92,31 @@ here must match `manifest.version`.
   end-to-end host driver now mounts through `save.onBike` — what the bag's
   BICYCLE row writes — and asserts on the sheet the frame actually posed
   from (`tests/drivers/mmo_util.lua`, `M.shotBike`).
+
+### Changed
+
+- **The MOVES list opens on the move you last used, and every row states its
+  own type.** Two things the battle menu was making the player pay for.
+
+  The list used to open on row one every single turn, so a Gen 1 fight — which
+  is mostly one attack repeated — charged a walk back down the list for a
+  decision already made. It now opens on the move this monster was last sent
+  into a turn with (`rememberedMove`, on both the mediated screen and the
+  co-op one). Nothing is pre-committed: it is only where the cursor starts, B
+  still backs out to the command grid, and the choice on the wire is byte-for
+  -byte the one it always was. The memory is per monster rather than per
+  battle — row 2 of the mon you switched to is a different move — and it is
+  clamped against the sheet that monster has *now*, so a Transform or a Mimic
+  cannot leave the cursor on a row nothing draws.
+
+  Type used to ride the panel title (`MOVES   TYPE/ELECTRIC`), which meant it
+  only ever described whichever row the cursor was on: comparing four moves
+  took four presses. It is now a column on each row, just left of PP, so the
+  whole sheet reads at once — and the title is back to plain `MOVES` rather
+  than restating the cursor. `Battlefield.drawListPanel` grew an optional
+  per-row `tag` for it, measured as a column across the visible rows so both
+  it and PP line up down the panel; a list with no tag on any row is laid out
+  exactly where it always was.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.0.10](https://img.shields.io/badge/version-1.0.10-3aa757?style=for-the-badge)
+![v1.0.17](https://img.shields.io/badge/version-1.0.17-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -1409,7 +1409,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.0.10` (`experimental: false` — on by default when installed). The full
+It's `1.0.17` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.0.10",
+  "version": "1.0.17",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Battlefield.lua
+++ b/src/Battlefield.lua
@@ -2589,6 +2589,9 @@ local LIST_ROW_MAX = 15
 local LIST_TITLE_H = 12
 local LIST_PAD_X = 8
 local LIST_PAD_Y = 4
+-- The gutter between a row's `tag` column and its `right` column. Wide enough
+-- that ELECTRIC and 25/25 read as two figures rather than one run-on string.
+local LIST_TAG_GAP = 10
 
 -- The rect a band widget draws into, clamped to MENU_BAND so an opts override
 -- can never paint over the field.
@@ -2716,9 +2719,12 @@ function M.drawCommandGrid(items, cursor, opts)
   return ok
 end
 
--- Moves / items / party: a scrolling list of { label, right?, dim? }. `right`
--- is right-aligned in the secondary colour (PP "12/15", a type name);
--- opts.title prints a small header, opts.visible overrides the row count.
+-- Moves / items / party: a scrolling list of { label, tag?, right?, dim? }.
+-- `right` is right-aligned against the panel edge in the secondary colour (PP
+-- "12/15", HP, a count); `tag` is a second right-aligned column just left of
+-- it, drawn a size smaller (a move's type). Both are laid out as columns
+-- across the visible rows, so they line up down the list. opts.title prints a
+-- small header, opts.visible overrides the row count.
 function M.drawListPanel(rows, cursor, opts)
   local gfx = g()
   if not gfx then return false end
@@ -2753,6 +2759,32 @@ function M.drawListPanel(rows, cursor, opts)
     end
     withFont(gfx, M.FONT_SECONDARY, function(font)
       local th = heightWith(font)
+      -- Two right-hand columns, both measured before anything paints.
+      -- `right` (PP, HP, a count) keeps the panel edge it always had; `tag` --
+      -- a move's type -- takes a column of its own to the left of it. Measured
+      -- once across the visible rows rather than per row, so each reads as a
+      -- column down the panel instead of stepping in and out with whatever
+      -- that row's own text happens to measure.
+      local micro = uiFont(M.FONT_MICRO)
+      local rightCol, tagCol = 0, 0
+      for slot = 0, visible - 1 do
+        local row = rows[first + slot]
+        if type(row) == "table" then
+          if row.right ~= nil and tostring(row.right) ~= "" then
+            rightCol = math.max(rightCol, widthWith(font, tostring(row.right)))
+          end
+          if row.tag ~= nil and tostring(row.tag) ~= "" then
+            tagCol = math.max(tagCol, widthWith(micro, tostring(row.tag)))
+          end
+        end
+      end
+      local rightEdge = x + w - pad
+      local tagRight = rightEdge - rightCol - (rightCol > 0 and LIST_TAG_GAP or 0)
+      -- What a label may not paint into. A list with no tag on any row
+      -- reserves exactly what the right column always reserved, so every
+      -- untagged panel is laid out where it always was.
+      local reserve = (rightCol > 0) and (rightCol + 8) or 0
+      if tagCol > 0 then reserve = reserve + tagCol + LIST_TAG_GAP end
       for slot = 0, visible - 1 do
         local row = rows[first + slot]
         if row then
@@ -2773,17 +2805,33 @@ function M.drawListPanel(rows, cursor, opts)
             gfx.rectangle("fill", x + pad - 2, ry, 2, rowH - 2)
           end
           local ty = ry + math.floor((rowH - th) / 2)
-          local rightW = 0
           if right ~= nil and tostring(right) ~= "" then
             right = tostring(right)
-            rightW = widthWith(font, right) + 8
             setColor(gfx, dim and TEXT_DIM or TEXT_MUTED)
-            gfx.print(right, x + w - pad - rightW + 8, ty)
+            gfx.print(right, rightEdge - widthWith(font, right), ty)
           end
           setColor(gfx, dim and TEXT_DIM or (hot and TEXT_ON or TEXT_MUTED))
           gfx.print(fitLine(font, tostring(label or ""),
-            w - pad * 2 - rightW - 6), x + pad + 4, ty)
+            w - pad * 2 - reserve - 6), x + pad + 4, ty)
         end
+      end
+      -- The tag column, in the micro face the title already uses: smaller than
+      -- the row so a move's type reads as a note about the row rather than a
+      -- second name for it. One pass, so the face changes once per panel.
+      if tagCol > 0 then
+        withFont(gfx, M.FONT_MICRO, function(mfont)
+          local mh = heightWith(mfont)
+          for slot = 0, visible - 1 do
+            local row = rows[first + slot]
+            local tag = (type(row) == "table") and row.tag or nil
+            if tag ~= nil and tostring(tag) ~= "" then
+              tag = tostring(tag)
+              setColor(gfx, row.dim and TEXT_DIM or TEXT_MUTED)
+              gfx.print(tag, tagRight - widthWith(mfont, tag),
+                top + slot * rowH + math.floor((rowH - mh) / 2))
+            end
+          end
+        end)
       end
       -- Scroll thumb, only when there is something off-panel.
       if count > visible then

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -617,6 +617,13 @@ function M.new(game, opts)
     gen2Mediated = gen2Mediated or nil,
     phase = "intro",
     moveIndex = 1,
+    -- The move each of our party was last sent into a turn with, keyed by its
+    -- party index. Where the move list *opens* and nothing else (see
+    -- `rememberedMove`): a Gen 1 fight is mostly one attack repeated, and
+    -- re-walking the list to it every turn is the tax this removes. Per
+    -- monster, because the fourth row of the mon you switched to is a
+    -- different move.
+    moveMemory = {},
     targetIndex = 1,
     frame = 0,
     messages = {},
@@ -2019,6 +2026,21 @@ function M:liveMoves()
   return (battler and battler.curMoves) or {}
 end
 
+-- Where the move list opens: the move this monster last actually used, or its
+-- first move if it has not attacked yet.
+--
+-- Clamped against the list it has *now* rather than the one it had then --
+-- Transform and Mimic rewrite a sheet mid-fight, and a cursor left past the
+-- end would open on a row that is not drawn.
+function M:rememberedMove()
+  local slot = self:mySlot()
+  local moves = self:liveMoves()
+  local key = (slot and slot.active) or 1
+  local want = math.floor(tonumber((self.moveMemory or {})[key]) or 1)
+  if want < 1 or want > #moves then return 1 end
+  return want
+end
+
 function M:hasLivePP()
   if self.medMoveList then
     for _, move in ipairs(self.medMoveList) do
@@ -2062,7 +2084,7 @@ function M:updateCommand(input)
   elseif input:wasPressed("a") then
     local command = M.COMMANDS[self.commandIndex]
     if command == "FIGHT" then
-      self.moveIndex = 1
+      self.moveIndex = self:rememberedMove()
       self.phase = "move"
     elseif command == "SWITCH" then
       self.switchIndex = 1
@@ -2915,6 +2937,15 @@ end
 
 function M:commit(action)
   self.phase = "wait"
+  -- A fight, and only a fight: `kind` is set on run / switch / item, and an
+  -- item's `move` names the move being restored rather than one being used.
+  -- Taken here rather than at the three call sites in `updateMove` /
+  -- `updateTarget` so a fourth can never forget to.
+  if action and action.kind == nil and tonumber(action.move) then
+    local slot = self:mySlot()
+    self.moveMemory = self.moveMemory or {}
+    self.moveMemory[(slot and slot.active) or 1] = math.floor(action.move)
+  end
   -- Your own answer is in, whoever else's is not -- which is what keeps the
   -- wait line from naming the person reading it.
   self:markActed(action.slot)
@@ -6397,9 +6428,29 @@ function M:bandCommandItems()
   return items
 end
 
+-- A move's type under the name the classic TYPE/ strip prints.
+--
+-- `displayName` is what turns PSYCHIC_TYPE into PSYCHIC and a modded type into
+-- its registered name; it answers from the module's own vanilla records when
+-- nothing called `load`, so this is safe wherever it is asked. Without the
+-- module at all the raw type id is still true, just less pretty.
+function M:moveTypeName(id)
+  local moves = self.game and self.game.data and self.game.data.moves
+  local def = type(moves) == "table" and moves[id] or nil
+  local typeId = def and def.type
+  if type(typeId) ~= "string" or typeId == "" then return nil end
+  local TypeChart = engine and engine.TypeChart
+  if TypeChart and type(TypeChart.displayName) == "function" then
+    local ok, name = pcall(TypeChart.displayName, typeId)
+    if ok and type(name) == "string" and name ~= "" then return name end
+  end
+  return typeId
+end
+
 -- The move list, and the strip that used to sit beside it. PP is the row's own
--- right column now; TYPE rides the title, where it belongs to the highlighted
--- move rather than to the list.
+-- right column and TYPE the column left of it -- on every row, because what
+-- the player is comparing four ways is on the four rows, not on a strip that
+-- can only ever describe the highlighted one.
 function M:bandMoveRows()
   local moves = self:liveMoves()
   local data = self.game and self.game.data
@@ -6407,6 +6458,7 @@ function M:bandMoveRows()
   for _, moveInst in ipairs(moves) do
     local def = (data and data.moves or {})[moveInst.id]
     local row = { label = (def and def.name) or moveInst.id or "-" }
+    row.tag = self:moveTypeName(moveInst.id)
     local pp = tonumber(moveInst.pp)
     if def and tonumber(def.pp) then
       -- The classic strip's own arithmetic: PP Ups add a fifth of the base
@@ -6423,18 +6475,11 @@ function M:bandMoveRows()
   return rows
 end
 
+-- Just "MOVES" since the type moved onto the rows: the title used to carry
+-- `TYPE/x` for the highlighted move, and repeating on the header what every
+-- row already says is a header that only ever restates the cursor.
 function M:bandMoveTitle()
-  local moves = self:liveMoves()
-  local pick = moves[self.moveIndex or 1]
-  local def = pick and (self.game and self.game.data and self.game.data.moves
-    or {})[pick.id]
-  if not (def and def.type) then return "MOVES" end
-  local TypeChart = engine and engine.TypeChart
-  local typeName = def.type
-  if TypeChart and TypeChart.displayName then
-    typeName = TypeChart.displayName(def.type) or def.type
-  end
-  return ("MOVES   TYPE/%s"):format(tostring(typeName))
+  return "MOVES"
 end
 
 -- The bench, as `benchOf` filters it -- alive, and not the one already out.

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -105,6 +105,11 @@ local function loadEngine()
     AnimPlayer = grab("AnimPlayer", "src.battle.AnimPlayer"),
     BattleState = grab("BattleState", "src.battle.BattleState"),
     Sprites = grab("Sprites", "src.pokemon.Sprites"),
+    -- Display only, and soft for that reason: it names a move's type for the
+    -- move list's own column (`moveTypeName`). `displayName` needs no `load`
+    -- -- it falls back to the module's vanilla records -- so a build without
+    -- the chart shows the raw type id rather than losing the column.
+    TypeChart = grab("TypeChart", "src.battle.TypeChart"),
     -- Exp is the *client's* arithmetic and can only ever be. The referee holds
     -- no species table (the legal floor -- no ROM bytes on a hub), so it can
     -- never price a faint: it states what fell and how many shared it, and
@@ -1199,6 +1204,12 @@ function M.new(opts)
     shown     = nil,
     dwell     = 0,
     cursor    = 1,
+    -- The move each of ours was last sent into a turn with, keyed by its index
+    -- into `mine`. Purely where the cursor opens (see `rememberedMove`): a
+    -- Gen 1 fight is mostly one attack repeated, and re-walking the list to it
+    -- every turn is the tax this removes. Per monster, not per battle -- the
+    -- fourth row of the mon you switched to is a different move.
+    moveMemory = {},
     commandIndex = 1,
     itemIndex = 1,
     switchIndex = 1,
@@ -1652,6 +1663,26 @@ end
 
 -- A move's display name, CoopBattle's lookup: the registry name when the build
 -- has one, the wire id otherwise.
+-- A move's type under the name the player reads on the classic TYPE/ strip.
+--
+-- `TypeChart.displayName` is the mapping that turns PSYCHIC_TYPE into PSYCHIC
+-- and a modded type into its registered name, and it answers from the module's
+-- own vanilla records when nothing called `load` -- so this is safe on a
+-- screen that never touched the chart. A build without the module at all falls
+-- through to the raw id, which still says something true.
+function M:moveTypeName(id)
+  local moves = self.game and self.game.data and self.game.data.moves
+  local def = type(moves) == "table" and moves[id] or nil
+  local typeId = def and def.type
+  if type(typeId) ~= "string" or typeId == "" then return nil end
+  local TypeChart = (loadEngine() or {}).TypeChart
+  if TypeChart and type(TypeChart.displayName) == "function" then
+    local ok, name = pcall(TypeChart.displayName, typeId)
+    if ok and type(name) == "string" and name ~= "" then return name end
+  end
+  return typeId
+end
+
 function M:moveLabel(id)
   if type(id) ~= "string" or id == "" then return nil end
   local moves = self.game and self.game.data and self.game.data.moves
@@ -3380,7 +3411,29 @@ function M:pickMove(index)
   local mon = self:activeMon()
   local moves = mon and mon.moves
   if not (moves and moves[index]) then return false end
-  return self:sendChoice({ action = "fight", move = index - 1 })
+  local sent = self:sendChoice({ action = "fight", move = index - 1 })
+  -- Remembered only once the choice is really on the wire: a refused send
+  -- leaves the turn unspent, and moving the cursor for it would be the menu
+  -- reporting a decision that was not taken.
+  if sent then
+    self.moveMemory = self.moveMemory or {}
+    self.moveMemory[self.active or 1] = index
+  end
+  return sent
+end
+
+-- Where the move list opens: the move this monster last actually used, or its
+-- first move if it has not attacked yet.
+--
+-- Clamped against the list it has *now* rather than the one it had then --
+-- Transform and Mimic rewrite a sheet mid-fight, and a cursor left past the
+-- end would open on a row that is not drawn.
+function M:rememberedMove()
+  local mon = self:activeMon()
+  local moves = (mon and mon.moves) or {}
+  local want = math.floor(tonumber((self.moveMemory or {})[self.active or 1]) or 1)
+  if want < 1 or want > #moves then return 1 end
+  return want
 end
 
 -- Classic Gen 1 order (row-major): FIGHT SWITCH / ITEM RUN.
@@ -3573,7 +3626,7 @@ function M:updateCommand(input)
   elseif input:wasPressed("a") then
     local command = M.COMMANDS[self.commandIndex]
     if command == "FIGHT" then
-      self.cursor = 1
+      self.cursor = self:rememberedMove()
       self.phase = "move"
     elseif command == "SWITCH" then
       self.switchIndex = 1
@@ -5507,6 +5560,10 @@ function M:bandMoveRows()
     -- list after Transform/Mimic carries `pp` and may carry no maximum, so the
     -- right column is dropped rather than invented.
     local row = { label = self:moveLabel(move.id) or tostring(move.id) }
+    -- The type, in the column left of PP. Same reason PP is on the row rather
+    -- than under it: what the player is comparing four ways is on the four
+    -- rows, not on a strip that only ever describes the highlighted one.
+    row.tag = self:moveTypeName(move.id)
     local pp = tonumber(move.pp)
     local maxPp = tonumber(move.maxPp)
     if pp and maxPp then

--- a/tests/drivers/battlefield_shot.lua
+++ b/tests/drivers/battlefield_shot.lua
@@ -261,12 +261,23 @@ return function(game)
   screen.mine = {
     { species = MINE_SPECIES, level = 25, nickname = "SPARKY",
       hp = 40, stats = { hp = 55 },
-      -- `maxPp`, not `ppMax`: M:bandMoveRows() (src/MediatedBattle.lua:3565)
-      -- reads `move.maxPp` for the PP column the new moves-list frame
+      -- `maxPp`, not `ppMax`: M:bandMoveRows() (src/MediatedBattle.lua)
+      -- reads `move.maxPp` for the PP column the moves-list frame
       -- exercises -- get this wrong and drawModernBand's pcall just
       -- swallows the mismatch and the frame silently falls back to the
       -- classic GB list instead of the widget under test.
-      moves = { { id = "THUNDERBOLT", pp = 15, maxPp = 15 } } },
+      --
+      -- Four moves, not one: the list draws its type and PP as *columns*
+      -- measured across the visible rows, so a single-row sheet cannot show
+      -- whether they line up. Two ELECTRIC and two NORMAL, with the widest
+      -- name (THUNDERSHOCK) beside the widest type, is the row that runs out
+      -- of width first.
+      moves = {
+        { id = "THUNDERSHOCK", pp = 25, maxPp = 30 },
+        { id = "GROWL",        pp = 39, maxPp = 40 },
+        { id = "THUNDER_WAVE", pp = 20, maxPp = 20 },
+        { id = "QUICK_ATTACK", pp = 30, maxPp = 30 },
+      } },
   }
   screen.active = 1
   screen.slots[screen:foeSlot()] = {
@@ -577,8 +588,46 @@ return function(game)
   end
 
   -- ---- (b) moves-list frame: phase == "move", drawListPanel's MOVES list ----
+  --
+  -- The rows are asserted here rather than only photographed: the type column
+  -- is resolved through the *real* TypeChart against this boot's own dataset,
+  -- which is the half a fixture-stubbed unit test cannot reach. A move whose
+  -- record this boot does not carry would silently drop its type and the
+  -- screenshot would still look like a perfectly good moves list.
   screen.phase = "move"
   screen.cursor = 1
+  do
+    local moveRows = screen:bandMoveRows()
+    check(#moveRows == 4, "move: one row per move on the sheet",
+          "rows=" .. tostring(#moveRows))
+    local tagged, tags = 0, {}
+    for _, row in ipairs(moveRows) do
+      if type(row.tag) == "string" and row.tag ~= "" then
+        tagged = tagged + 1
+        tags[#tags + 1] = row.tag
+      end
+    end
+    check(tagged == #moveRows,
+          "move: every row states its own type, resolved through the real "
+          .. "TypeChart", table.concat(tags, "/"))
+    check(moveRows[1].tag == "ELECTRIC" and moveRows[2].tag == "NORMAL",
+          "move: the type on the row is the move's own, not the cursor's",
+          tostring(moveRows[1].tag) .. " / " .. tostring(moveRows[2].tag))
+    check(moveRows[1].right == "25/30",
+          "move: PP still keeps its own column beside the type",
+          tostring(moveRows[1].right))
+
+    -- The cursor's memory, on the same live screen. Nothing is committed --
+    -- `pickMove` is what writes it, and it opens the list where the player
+    -- left it rather than back on row one.
+    check(screen:rememberedMove() == 1,
+          "move: a monster that has not attacked yet opens on its first move")
+    screen.moveMemory = screen.moveMemory or {}
+    screen.moveMemory[screen.active] = 3
+    check(screen:rememberedMove() == 3,
+          "move: and afterwards on the move it was last sent into a turn with")
+    screen.moveMemory[screen.active] = nil
+  end
   U.wait(6)
   local path3 = SHOT_DIR .. "/battlefield-move.png"
   if U.shot(game, path3) then

--- a/tests/mediated_battle_client.lua
+++ b/tests/mediated_battle_client.lua
@@ -1474,4 +1474,96 @@ do
   end
 end
 
+-- ------------------------------------------------------------------
+-- 14. the move list: a type column, and a cursor that remembers
+-- ------------------------------------------------------------------
+--
+-- Two things the player asked the menu for, and both are *presentation only*:
+-- the wire, the choice and the sim are untouched by either.
+--
+--   * every row states its own type, so four moves can be compared at once
+--     rather than one at a time under the cursor;
+--   * the list opens on the move this monster last actually used, because a
+--     Gen 1 fight is mostly one attack repeated and walking back down to it
+--     every turn is a tax on a decision already made.
+do
+  local function client()
+    return setmetatable({
+      game = { data = DATA },
+      phase = "move",
+      active = 1,
+      cursor = 1,
+      moveMemory = {},
+      commandIndex = 1,
+      mine = {
+        { species = "CHARMANDER", moves = {
+            { id = "EMBER", pp = 25, maxPp = 25 },
+            { id = "GROWL", pp = 40, maxPp = 40 },
+            { id = "HYDRO", pp = 5, maxPp = 5 },
+        } },
+        { species = "SQUIRTLE", moves = { { id = "HYDRO", pp = 5, maxPp = 5 } } },
+      },
+    }, { __index = Mediated })
+  end
+
+  -- ------- the type column
+  local f = client()
+  local rows = f:bandMoveRows()
+  eq(#rows, 3, "one row per move")
+  eq(rows[1].tag, "FIRE", "the type is the row's own column...")
+  eq(rows[1].right, "25/25", "...and does not displace the PP beside it")
+  eq(rows[2].tag, "NORMAL", "a status move states its type too")
+  eq(rows[3].tag, "WATER", "...as does every other row, not just the hot one")
+
+  -- A referee-published sheet after Transform/Mimic can name a move this copy
+  -- has no record of. No record, no type: a blank column says nothing, and
+  -- inventing one would say something false.
+  f.mine[1].moves[3] = { id = "MYSTERY", pp = 5 }
+  rows = f:bandMoveRows()
+  eq(rows[3].tag, nil, "a move the dataset does not carry gets no type column")
+  eq(rows[3].label, "MYSTERY", "...and still shows under its id")
+
+  -- ------- the cursor
+  local g = client()
+  eq(g:rememberedMove(), 1,
+     "a monster that has not attacked yet opens on its first move")
+
+  local sent = {}
+  g.sendChoice = function(_, choice) sent[#sent + 1] = choice; return true end
+  check(g:pickMove(2), "the second move is sendable")
+  eq(sent[1].move, 1, "the wire is still 0-based, unchanged by any of this")
+  eq(g.moveMemory[1], 2, "and the move actually sent is what gets remembered")
+
+  local input = fakeInput()
+  g.phase = "choose"
+  g.commandIndex = 1
+  input.press("a")
+  g:updateCommand(input)
+  eq(g.phase, "move", "FIGHT opens the move list")
+  eq(g.cursor, 2, "...on the move this monster last used, not back on row one")
+
+  -- Per monster: the one that comes in after a switch opens on its own first
+  -- move, because row 2 of its sheet is a different move entirely.
+  g.active = 2
+  g.phase = "choose"
+  input.press("a")
+  g:updateCommand(input)
+  eq(g.cursor, 1, "a monster that has not attacked yet opens on row one, "
+     .. "whatever the one it replaced was using")
+
+  -- Sent is what counts. A refused send leaves the turn unspent, so moving
+  -- the cursor for it would be the menu reporting a decision never taken.
+  g.active = 1
+  g.sendChoice = function() return false end
+  check(not g:pickMove(3), "a refused send reports the refusal")
+  eq(g.moveMemory[1], 2, "...and leaves the remembered move where it was")
+
+  -- The sheet it has *now* is what the memory is clamped against: Transform
+  -- and Mimic rewrite one mid-fight, and a cursor past the end opens on a row
+  -- that is not drawn.
+  g.moveMemory[1] = 9
+  eq(g:rememberedMove(), 1,
+     "a remembered row past the end of the current sheet falls back to one")
+end
+
 T.finish("mediated_battle_client")

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -13584,6 +13584,13 @@ end)()
   local okList = pcall(Battlefield.drawListPanel,
     { { label = "TACKLE", right = "20/20" } }, 1, { title = "MOVES" })
   check(okList, "drawListPanel does not throw headless")
+  -- The type column: with a tag, and with a tag on only some of the rows --
+  -- an item's move list carries none, and the two must share one panel.
+  local okTagged = pcall(Battlefield.drawListPanel, {
+    { label = "THUNDERSHOCK", tag = "ELECTRIC", right = "25/25" },
+    { label = "GROWL", right = "39/39" },
+  }, 1, { title = "MOVES" })
+  check(okTagged, "drawListPanel does not throw on a row carrying a tag")
 
   -- Edge-shaped inputs: empty rows, an oversized list (overflow), and no
   -- title -- all still headless-safe.
@@ -22036,10 +22043,66 @@ end)()
     eq(#rows, 2, "one row per live move")
     eq(rows[1].label, "FIX BOOST", "the label is the move's display name")
     eq(rows[1].right, "0/20", "PP is its own right column, current/max")
+    eq(rows[1].tag, "NORMAL",
+       "the move's type is the row's own column, left of PP -- so all four "
+       .. "types are readable at once instead of only the highlighted one")
+    eq(moveClient:bandMoveTitle(), "MOVES",
+       "...and the title no longer restates the cursor's type")
     check(rows[1].dim == true, "a move at 0 PP is dimmed")
     eq(rows[2].right, "18/24",
        "PP Ups add a fifth of base pp each -- floor(20/5)*1 == 4 -> 24")
     check(not rows[2].dim, "a move with PP left is not dimmed")
+
+    -- ------- the move cursor remembers what this monster last used
+    --
+    -- A Gen 1 fight is mostly one attack repeated, so opening the list on row
+    -- one every turn charges the player a walk down it for a choice they
+    -- already made. The memory is *only* where the cursor opens -- nothing is
+    -- pre-committed, and B still backs out to the command grid.
+    local cursorClient = setmetatable({
+      medMoveList = {
+        { id = "FIX_BOOST", pp = 20, ppUps = 0 },
+        { id = "FIX_BOOST", pp = 20, ppUps = 0 },
+        { id = "FIX_BOOST", pp = 20, ppUps = 0 },
+      },
+      moveMemory = {},
+      game = { data = data },
+      mySlot = function() return { active = 2 } end,
+    }, { __index = CoopBattle })
+
+    eq(cursorClient:rememberedMove(), 1,
+       "a monster that has not attacked yet opens on its first move")
+    cursorClient.moveMemory[2] = 3
+    eq(cursorClient:rememberedMove(), 3,
+       "...and afterwards on the move it was last sent into a turn with")
+    cursorClient.moveMemory[1] = 2
+    eq(cursorClient:rememberedMove(), 3,
+       "the memory is keyed by party slot, so the mon on the bench keeps its "
+       .. "own row rather than moving this one's cursor")
+    cursorClient.moveMemory[2] = 9
+    eq(cursorClient:rememberedMove(), 1,
+       "a remembered row past the end of the sheet it has *now* (Transform, "
+       .. "Mimic) opens on the first rather than on a row nothing draws")
+
+    -- What writes it: `commit`, so none of the three fight call sites can
+    -- forget to, and none of the item / switch / run ones can write to it.
+    local commitClient = setmetatable({
+      medMoveList = cursorClient.medMoveList,
+      moveMemory = {},
+      mediated = true,
+      game = { data = data },
+      mine = 1,
+      mySlot = function() return { active = 2 } end,
+      sendMediatedChoice = function() return true end,
+    }, { __index = CoopBattle })
+    commitClient:commit({ slot = 1, move = 2, target = 3 })
+    eq(commitClient.moveMemory[2], 2, "a fight remembers the move it sent")
+    commitClient:commit({ slot = 1, kind = "item", item = "ETHER", move = 1 })
+    eq(commitClient.moveMemory[2], 2,
+       "an item's `move` names the move being restored, not one being used, "
+       .. "so it leaves the memory alone")
+    commitClient:commit({ slot = 1, kind = "run" })
+    eq(commitClient.moveMemory[2], 2, "...and so does a run")
 
     local items = CoopBattle.bandCommandItems({})
     eq(items[1].label, "FIGHT", "the grid keeps the classic FIGHT/SWITCH/ITEM/RUN order")


### PR DESCRIPTION
Two things the battle MOVES menu was making the player pay for.

<img width="600" alt="MOVES list with a type column" src="https://github.com/user-attachments/assets/REPLACE-ME" />

## The cursor remembers what this monster last used

The list opened on row one **every single turn**, so a Gen 1 fight — which is mostly one attack repeated — charged a walk back down the list for a decision already made. It now opens on the move this monster was last sent into a turn with.

- `moveMemory` maps a party index → move index; `rememberedMove()` reads it back, **clamped against the sheet that monster has _now_**, so a Transform or a Mimic cannot leave the cursor on a row nothing draws.
- **Per monster, not per battle** — row 2 of the mon you switched to is a different move.
- Written by `MediatedBattle:pickMove` only once the choice is really on the wire, and inside `CoopBattle:commit` only when the action carries no `kind` — so an item's `move` (which names the move being *restored*) and switch/run leave it alone, and none of the three fight call sites can forget to record it.
- **Nothing is pre-committed.** It is only where the cursor starts, `B` still backs out to the command grid, and the choice on the wire is byte-for-byte the one it always was.

## Type is a column on the row, not a label on the title

Type used to ride the panel title (`MOVES   TYPE/ELECTRIC`), which meant it only ever described whichever row the cursor was on — comparing four moves took four presses. It is a column on each row now, just left of PP, so the whole sheet reads at once:

```
MOVES
▌THUNDERSHOCK                          ELECTRIC   25/30
 GROWL                                   NORMAL   39/40
 THUNDER WAVE                          ELECTRIC   20/20
 QUICK ATTACK                            NORMAL   30/30
```

- `Battlefield.drawListPanel` grew an optional per-row `tag`, drawn a size smaller in the micro face the title already uses.
- Both `tag` and the existing `right` column are **measured across the visible rows** rather than per row, so they line up down the panel instead of stepping in and out with each row's own text.
- A list with **no tag on any row reserves exactly what the right column always reserved** — party, items and target panels are laid out where they always were.
- The name behind the type is `TypeChart.displayName`, so `PSYCHIC_TYPE` reads `PSYCHIC` and a modded type shows under its registered name. It answers from the module's vanilla records when nothing called `load`, and a move this copy has no record of gets **no** type rather than a blank column.
- The title is back to plain `MOVES` rather than restating the cursor.

## Tests

- Band row builders and the cursor memory pinned on **both** screens (`tests/rby_mmo_test.lua`, `tests/mediated_battle_client.lua`) — including that an item commit does not move the memory, and that a refused send does not either.
- `drawListPanel` gains a headless case with a tag on **only some** rows, since an item's move list carries none and the two share one panel.
- The battlefield screenshot driver's fixture goes from one move to four — the columns are measured across rows, so a single-row sheet could not show whether they align — and asserts the type resolves through the **real** `TypeChart` against the boot's own dataset, which is the half a fixture-stubbed unit test cannot reach.

| Suite | Result |
|---|---|
| `rby_mmo_test.lua` | 4760/4760 |
| T4 (`run_modkit.lua`) | 36/36 |
| `server/config.test.js` | 262/262 |
| battlefield e2e | 41/41 |
| solo-battle e2e | 76/76 |

## Version

Bumped to **1.0.17** (`manifest.json`, `server/package.json`, README badge + Known-jank line). That also repairs `server/config.test.js`'s version parity, which was **already failing on `main`**: `manifest.json` read `1.0.15` while `server/package.json` was still on `1.0.10`. `server/README.md`'s VPS clone pin is deliberately left alone — hand-stamping it names a tag that does not exist yet.

## Pre-existing issues found while verifying (not addressed here)

1. **MMO e2e**: `the ranking list portrait is palette-correct` fails on the host's RANK screen (the guest leg passes the same probe). Reproduced identically on a pristine export of `40252ab` with zero working changes.
2. **`modkit lint` / `validate` / `pack` now fail**: an e2e ROM import populated `{data,assets}/generated` in the engine checkout for the first time. The ROM-bytes gate compares mod art against `assets/generated/sprites/*`, so it had been passing *vacuously*; it now reports 4 `MK302` errors on `assets/chars/nire{,_hood}/{walk,bike}.png`. Also pre-existing — same result on the pristine export.

## Merge note

`mossy-bridge-1732` is editing the same `drawListPanel` row block on `feature/improve-pokemon-options` (a **left** front-pic gutter; rows read `lx/lw` instead of `x/w`). The two are semantically compatible — their gutter is a left column, this is a right one — but the textual conflict is certain. Whoever merges second should swap `x`→`lx` and `w`→`lw` in three expressions (`rightEdge`, `tagRight`, and the label's `fitLine` width); the column widths themselves are pure text measurements and do not move.