### PR TITLE
fix: land the attack on the POKéMON that just switched in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,47 @@ here must match `manifest.version`.
 
 ### Fixed
 
+- **An attack on a POKéMON that had just switched in did nothing at all.**
+  Switch a monster out and the attack that answers it landed on nothing you
+  could see: no white flash, no nudge of the field, no impact burst, and a HP
+  bar that never moved. The newcomer simply walked onto the arena with a bar
+  already short, and the sentence naming the move that shortened it printed
+  over a still screen. It happened on every turn somebody switched into a
+  move — in MMO 1v1 and in the solo fights the same screen serves.
+
+  The two events are one batch. The referee fields every switch before it runs
+  a single fight (`_resolveTurn`), so the `send` and the `damage` that answers
+  it are parsed in the same breath — and on the arena a send into an occupied
+  seat is *parked* rather than applied, so the departing monster can finish
+  draining and sinking on numbers that are still its own. The referee's damage
+  was routed to that parked record correctly. The **display row** was not:
+  `queueDrain` measured the fall against the seat, found the departing
+  monster's bar already where its HP said it was, and queued nothing. The
+  arrival was then installed at its post-hit number with nothing left to
+  animate.
+
+  Display rows are now filed against whoever the seat will be showing when
+  they come up — the parked arrival when one is waiting — and the arrival
+  carries the HP it walked out with for its bar to start from. So the monster
+  arrives whole, the hit reads on it, and the bar falls. The same routing
+  fixes the knockout inside that window: a monster switched in and KO'd on the
+  same turn now drains, sinks and releases its pic as itself, instead of
+  spending the departing monster's sink on the wrong sprite.
+
+  Client-side only — no wire field moves, `PROTOCOL` is unchanged, and both
+  twin-parity suites are untouched. Co-op battles never had it: `CoopBattle`
+  already asks its queue who a row belongs to (`showing`), which is the
+  precedent this follows.
+
+  The end-to-end run now presses SWITCH on a **mediated** screen and watches
+  the blow answer it — the co-op leg beside it drives `CoopBattle`, a
+  different screen with a different display model, so this path had no live
+  cover at all. The new leg asserts the newcomer is parked behind the monster
+  walking off, that the fall is queued against the *newcomer*, that its bar
+  starts where it walked out, and that it is then seen to move; on the
+  unfixed code all of them fail. `host-battle-switch.png` is the mediated
+  bench list, which nothing had photographed before.
+
 - **Psychic moves were being fought as Physical in every refereed battle.**
   MMO 1v1, co-op 2-on-2 and the solo battles that run on this mod's referee
   all resolved Psychic damage on Attack/Defense instead of Special/Special,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.1.0](https://img.shields.io/badge/version-1.1.0-3aa757?style=for-the-badge)
+![v1.1.1](https://img.shields.io/badge/version-1.1.1-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -1480,7 +1480,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.1.0` (`experimental: false` — on by default when installed). The full
+It's `1.1.1` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -2260,7 +2260,14 @@ function M:onEvent(msg)
 
   elseif kind == "faint" then
     local slot = self:noteSlot(msg)
-    if slot then slot.hp = 0 end
+    -- Whoever the referee just knocked down, which is the parked arrival when
+    -- one is waiting: a monster switched in and KO'd inside the same batch is
+    -- down before its own `spawnfx` row has played, and zeroing the seat there
+    -- would put its knockout on the monster still walking off. `noteSlot` has
+    -- already routed the number; this is the belt-and-braces beside it, routed
+    -- the same way.
+    local down = slot and (slot.pending or slot) or nil
+    if down then down.hp = 0 end
     if msg.slot == self:mySlot() then
       local mon = self.mine and self.mine[self.active]
       if mon then mon.hp = 0 end
@@ -2290,7 +2297,7 @@ function M:onEvent(msg)
     -- on screen through the flash + "X fainted!". Stamped with its occupant
     -- for the same reason the drain row is: an auto-replacement batched behind
     -- the KO would otherwise have this row take the newcomer's pic down.
-    self.lines[#self.lines + 1] = { clearPic = msg.slot, species = slot and slot.species }
+    self.lines[#self.lines + 1] = { clearPic = msg.slot, species = down and down.species }
     -- A knockout on the *other* side is the only thing that can owe this
     -- client experience, so this is where the credit for one is banked. See
     -- the `exp` branch below for what spends it.
@@ -3101,9 +3108,13 @@ function M:noteSlot(msg)
   -- exit. So a `damage` / `faint` / `status` that lands in the window is
   -- written to the parked record and never to the seat -- the departing
   -- monster's numbers are what its own queued rows are still animating
-  -- against. (Only a forced-choice turn resolving while this queue is busy can
-  -- produce one; the bar simply arrives already low, rather than the wrong
-  -- monster's bar falling.)
+  -- against.
+  --
+  -- That window is not the rarity it was once taken for: **a voluntary switch
+  -- and the attack that answers it resolve in the same batch**, so every hit
+  -- landing on a monster the turn it walked out arrives here. `hp` moves and
+  -- `shownHp` does not, which is what leaves the fall for `queueDrain` to file
+  -- and `applySwap` to hand over -- see the pair of them.
   local parked = slot.pending
   if parked and not (msg.text and (msg.t == "send" or msg.t == "switch")) then
     if msg.maxHp ~= nil then parked.maxHp = msg.maxHp end
@@ -3134,6 +3145,15 @@ function M:noteSlot(msg)
         species = msg.text,
         speciesId = msg.speciesId,
         hp = msg.hp,
+        -- Where this monster's bar *starts*, frozen at the HP it walked out
+        -- with. `hp` above follows the referee for the whole of the park
+        -- window; this does not, and the gap between the two is the fall the
+        -- queue still owes. Without it an arrival that was struck before its
+        -- own `spawnfx` row played was installed at its post-hit number with
+        -- nothing left to animate -- which is why an attack on a monster that
+        -- had just switched in read as no attack at all: no flash, no nudge,
+        -- no impact burst and a bar that never moved.
+        shownHp = msg.hp,
         -- What that HP is out of, when the referee stated it (PROTOCOL 24).
         -- Installed by `applySwap`, not written to the seat here: the bar
         -- underneath still belongs to the monster finishing its exit, and its
@@ -5150,12 +5170,20 @@ function M:applySwap(row)
   -- what its bar is out of, and the older guess -- the biggest HP the seat has
   -- ever been told about -- is only what is left when it stated none.
   slot.hp = arrival.hp or 0
+  -- The bar starts where this monster *walked out*, which is where it already
+  -- stands on every ordinary arrival and is higher than it on the one that
+  -- matters: a hit landing inside the park window moved `arrival.hp` and left
+  -- `arrival.shownHp` where the send put it, and the gap between the two is
+  -- the drain row waiting behind this one. Taking the current number here
+  -- swallowed that fall -- the newcomer simply appeared already low and the
+  -- attack that hurt it showed nothing at all.
+  --
+  -- The predecessor's descent, which ended on this same seat record, is
+  -- overwritten either way: it is never inherited.
+  slot.shownHp = arrival.shownHp or slot.hp
   if arrival.maxHp ~= nil then slot.maxHp = max(1, arrival.maxHp) end
   if slot.hp > (slot.maxHp or 1) then slot.maxHp = slot.hp end
-  -- A monster that just walked on has nothing to animate down from, so its bar
-  -- starts where the referee says it is -- and the predecessor's descent, which
-  -- ended on this same record, must not be inherited.
-  slot.shownHp = slot.hp
+  if slot.shownHp > (slot.maxHp or 1) then slot.maxHp = slot.shownHp end
   slot.status = arrival.status
   self:arriveOnSeat(index, index == self:mySlot())
   return true
@@ -5176,19 +5204,32 @@ end
 -- because beat 3's impact burst borrows the *attacking move's* palette, and a
 -- residual has no attacking move -- taking the last one's colours would paint
 -- a poison tick in the last Fire attack's orange.
+--
+-- **Filed against whoever this seat will be showing when the row comes up**,
+-- which is not always who is standing on it now. An arrival parked behind a
+-- monster still finishing its exit (`noteSlot`) is already the one the referee
+-- is talking about, and its own `spawnfx` row is ahead of this one in the
+-- queue -- so a hit that lands inside that window is filed against the
+-- *newcomer* and falls after the swap that puts it on the seat. Read off the
+-- seat instead, the fall was measured between the departing monster's HP and
+-- its own display clock, found them equal, and queued nothing: the switch and
+-- the attack that answers it resolve in one batch, so that was every attack on
+-- a monster the turn it came in. CoopBattle asks the queue the same question
+-- for the same reason (`showing`, src/CoopBattle.lua:3158).
 function M:queueDrain(index, residual)
   if index == nil then return false end
   if not self:usesBattlefield() then return false end
   local slot = self.slots[index]
   if not slot then return false end
-  local to = tonumber(slot.hp) or 0
-  if slot.shownHp == nil then
-    slot.shownHp = to
+  local occupant = slot.pending or slot
+  local to = tonumber(occupant.hp) or 0
+  if occupant.shownHp == nil then
+    occupant.shownHp = to
     return false
   end
-  if slot.shownHp == to then return false end
+  if occupant.shownHp == to then return false end
   self.lines[#self.lines + 1] = {
-    drain = index, to = to, species = slot.species,
+    drain = index, to = to, species = occupant.species,
     residual = (residual ~= nil) or nil,
   }
   return true
@@ -5293,11 +5334,17 @@ end
 -- Stamped with its occupant, exactly like the drain row: the referee can batch
 -- an auto-replacement behind the KO, and a sink meant for the monster that left
 -- would otherwise play against the one standing there now.
+--
+-- A parked arrival is stamped in preference to the seat, exactly as the drain
+-- row is: the monster that walked in and fell inside one batch has not been
+-- installed yet, and a sink named after the one still walking off would be
+-- dropped by `startFaintFx` the moment the swap landed.
 function M:queueFaintFx(index)
   if index == nil then return false end
   if not self:usesBattlefield() then return false end
   local slot = self.slots[index]
-  self.lines[#self.lines + 1] = { faintfx = index, species = slot and slot.species }
+  local occupant = slot and (slot.pending or slot) or nil
+  self.lines[#self.lines + 1] = { faintfx = index, species = occupant and occupant.species }
   return true
 end
 

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -865,6 +865,34 @@ return function(game)
     -- not apply -- wait on `mmoBattle` / `isFighting`, and treat stream gaps
     -- as the desync equivalent.
 
+    -- SWITCH needs somewhere to switch to, and a driver save that has just
+    -- traded still holds exactly one monster. Added *before* the battle is
+    -- asked for, because `MediatedBattle:start` snapshots `game.save.party`
+    -- the moment the hub pairs the two seats -- a bench added after that is a
+    -- bench the referee never hears about. Put back after the fight (see the
+    -- teardown below): a leg that changes the save owns undoing it, and the
+    -- co-op leg behind this one is entitled to the party it was written for.
+    --
+    -- Small and low on purpose. This leg is a test of what the arena *draws*
+    -- when a monster is switched into a blow, not of how long it can survive
+    -- one, and a bulky bench would spend the fight's whole budget proving it.
+    local benchSpecies, addedBench = nil, false
+    do
+      local Pokemon = require("src.pokemon.Pokemon")
+      if #(game.save.party or {}) < 2 then
+        local made, extra = pcall(Pokemon.new, game.data, "PIDGEY", 12)
+        if made and extra then
+          game.save.party[#game.save.party + 1] = extra
+          benchSpecies, addedBench = extra.species, true
+        end
+      else
+        benchSpecies = game.save.party[2].species
+      end
+      log("mediated switch target:", tostring(benchSpecies))
+    end
+    check(benchSpecies ~= nil,
+          "the host has a bench to switch to in the mediated 1v1")
+
     H.await(game, "guest_battle_requested")
     local started, btrail = H.drivePrompts(game, function()
       return H.inMediatedFight(game, exports)
@@ -971,6 +999,172 @@ return function(game)
       check(chips ~= nil and chips.foe == (rosters and rosters.foe),
         "...and the peer's roster chip is drawn from exactly that",
         tostring(chips and chips.foe))
+
+      -- ------- SWITCH, and the blow that answers it in the same turn
+      --
+      -- The only leg anywhere that presses SWITCH on a **mediated** screen.
+      -- The co-op leg next door presses the same command on `CoopBattle`,
+      -- which is a different screen with a different display model, so until
+      -- this existed `MediatedBattle`'s switch had no end-to-end cover at all.
+      --
+      -- The referee fields every switch before it runs a single fight
+      -- (`Battle:_resolveTurn`), so **a switch and the attack answering it are
+      -- one batch**. On the arena a `send` into a seat somebody is still
+      -- standing on is *parked* (`noteSlot`), and everything the referee then
+      -- says about that seat belongs to the monster in the park rather than the
+      -- one walking off. What this watches is the display rows that fall out of
+      -- that -- and the whole claim is one sentence: the newcomer arrives on
+      -- the bar it **walked out** with and is then seen to lose it.
+      --
+      -- Read off the seat instead of the park, the fall was measured against
+      -- the departing monster, came out as no fall at all, and nothing was
+      -- queued: the newcomer was installed already low and the attack that hurt
+      -- it played no flash, no nudge and no bar. That is invisible to a
+      -- headless assertion on truth HP -- `slot.hp` was right the whole time --
+      -- which is exactly why it belongs out here, against a real hub, a real
+      -- peer and the real paced queue.
+      local mySlot = (top.mySlot and top:mySlot()) or 0
+      -- Who this seat opened with, so an attempt can name the monster that is
+      -- *not* standing on it without caring which way round the pair is.
+      local leadSpecies = ((H.top(game).slots or {})[mySlot] or {}).species
+      local target, obs = nil, {}
+      local function sample()
+        local live = H.top(game)
+        if not H.isMediatedBattle(live) then return end
+        local slot = live.slots and live.slots[mySlot] or nil
+        if not slot then return end
+        local parked = slot.pending
+        if parked and parked.species == target then
+          -- The window itself. Sampled rather than inferred, so a run where
+          -- the arrival was never parked says so instead of asserting about a
+          -- window it was never in.
+          obs.parked = true
+          obs.walkedOutOn = tonumber(parked.shownHp) or obs.walkedOutOn
+          obs.parkedMax = tonumber(parked.maxHp) or obs.parkedMax
+        end
+        for _, row in ipairs(live.lines or {}) do
+          if row.drain == mySlot and row.species == target then
+            -- The regression, stated exactly: a fall filed against the monster
+            -- that took it rather than the one that left.
+            obs.drainTo = tonumber(row.to) or obs.drainTo
+          end
+        end
+        if slot.species == target then
+          if obs.arrivedOn == nil then obs.arrivedOn = tonumber(slot.shownHp) end
+          local shown = tonumber(slot.shownHp)
+          if shown and (obs.low == nil or shown < obs.low) then obs.low = shown end
+        end
+      end
+
+      -- Up to three of our own choice windows. One is usually enough -- the
+      -- guest mashes FIGHT with a frontloaded move (`H.frontloadDamage`), so
+      -- the blow lands on the turn we switch -- but a miss is a legal roll and
+      -- a leg that a miss can fail is a leg that fails for no reason. Each
+      -- attempt switches to whoever is *not* out, so the bench and the lead
+      -- take turns walking into it.
+      for attempt = 1, 3 do
+        if obs.drainTo ~= nil then break end
+        -- A forced replacement outranks the command grid, and nobody else is
+        -- pressing anything on this side yet -- so answer it here, or the
+        -- window this attempt is waiting for never opens and the leg spends
+        -- its budget watching a picker.
+        local held = H.top(game)
+        if H.isMediatedBattle(held) and held.phase == "switch" then
+          U.tap(game, "a"); U.wait(20)
+        end
+        local mine = H.waitSeconds(game, function()
+          local live = H.top(game)
+          return H.isMediatedBattle(live) and live.phase == "choose"
+            and live.mustReplace ~= true and live.result == nil
+        end, 45, "the host's own choice window")
+        if not mine then
+          log(("mediated switch: no choice window on attempt %d"):format(attempt))
+          break
+        end
+        local live = H.top(game)
+        local standing = (live.slots and live.slots[mySlot] or {}).species
+        target = (standing == benchSpecies) and leadSpecies or benchSpecies
+        obs = {}
+
+        -- FIGHT is index 1 and SWITCH is index 2, so one RIGHT reaches it
+        -- under *both* layouts the grid is drawn in -- the band's one row of
+        -- four and the classic 2x2. Same tap the co-op leg makes, and correct
+        -- rather than lucky for the same reason.
+        U.tap(game, "right"); U.wait(6)
+        U.tap(game, "a");     U.wait(10)
+        local bench = H.top(game)
+        local opened = H.isMediatedBattle(bench) and bench.phase == "switch"
+        -- Asserted on the **first** attempt only. A retry runs on a field the
+        -- first turn has already moved -- the monster we switched to may have
+        -- been knocked down and the bench emptied behind it -- and
+        -- `updateSwitch` answering "There's no one to switch to!" is that
+        -- field, not a defect. Failing on it would invent a failure on a
+        -- perfectly good tree whenever the first blow missed.
+        if attempt == 1 then
+          check(opened, "SWITCH opens the mediated bench list",
+                tostring(bench and bench.phase))
+        elseif not opened then
+          log(("mediated switch: nothing left to send on attempt %d (%s)")
+            :format(attempt, tostring(bench and bench.phase)))
+        end
+        -- Only commit into a list that is actually open: an A pressed at a
+        -- command grid that never moved files a *move* instead, and the leg
+        -- would then assert about a turn nobody switched on.
+        if not opened then break end
+        -- Shot here, while the list is up and before anything is taken off
+        -- it. This is the one frame the *mediated* bench list is on screen in
+        -- the whole run, and it holds until the press below -- so the picture
+        -- means the same thing every run. Photographing the turn afterwards
+        -- would catch whatever the fight had moved on to instead.
+        if attempt == 1 then
+          U.shot(game, SHOT_DIR .. "/host-battle-switch.png")
+        end
+        U.tap(game, "a");     U.wait(6)
+
+        -- Everything from here is display, so it is sampled every frame: the
+        -- park, the queued fall and the seat's own clock all live for a
+        -- handful of frames each and none of them survives to be read after.
+        H.waitFor(game, function()
+          sample()
+          local now = H.top(game)
+          if not H.isMediatedBattle(now) then return true end
+          -- Done when a menu of ours is up (or the fight is over) *and* the
+          -- queue that explains this turn has been read to the end. `switch`
+          -- counts: a newcomer knocked down inside the very window under test
+          -- is answered with the forced picker, not the command grid, and
+          -- waiting only for `choose` would sit through that whole phase.
+          local settled = #(now.lines or {}) == 0 and now.draining == nil
+            and now.shown == nil
+          return settled and (now.phase == "choose" or now.phase == "switch"
+            or now.result ~= nil)
+        end, 60 * 25, "the switched-into turn to play out")
+
+        log(("mediated switch %d: to=%s parked=%s walkedOutOn=%s arrivedOn=%s "
+             .. "low=%s drainTo=%s"):format(
+          attempt, tostring(target), tostring(obs.parked),
+          tostring(obs.walkedOutOn), tostring(obs.arrivedOn),
+          tostring(obs.low), tostring(obs.drainTo)))
+      end
+
+      check(obs.parked == true,
+            "the switched-in POKeMON is parked behind the one walking off")
+      check(obs.arrivedOn ~= nil,
+            "...and then takes the seat", tostring(obs.arrivedOn))
+      -- The three that are the fix. Held together rather than separately: a
+      -- bar that starts full and never moves, and a bar that starts low and
+      -- never moves, are the same still picture to a player and the same
+      -- silence to a single assertion.
+      check(obs.drainTo ~= nil,
+            "the blow that landed in that window queues its fall against the "
+            .. "newcomer, not the monster that left")
+      check(obs.arrivedOn ~= nil and obs.walkedOutOn ~= nil
+              and obs.arrivedOn == obs.walkedOutOn,
+            "...the newcomer's bar starts where it walked out",
+            ("arrived on %s, walked out on %s"):format(
+              tostring(obs.arrivedOn), tostring(obs.walkedOutOn)))
+      check(obs.low ~= nil and obs.arrivedOn ~= nil and obs.low < obs.arrivedOn,
+            "...and is then seen to fall, so the attack reads on the arena",
+            ("%s -> %s"):format(tostring(obs.arrivedOn), tostring(obs.low)))
     end
 
     local gaps = 0
@@ -995,6 +1189,19 @@ return function(game)
     -- settle, broadcast -- is exercised against a real battle rather than a
     -- fabricated result.
     H.closeToOverworld(game)
+
+    -- Put the party back the way this leg found it. The bench monster exists
+    -- only so SWITCH had somewhere to send, and the co-op leg below was
+    -- written against a one-monster host -- so leaving it behind would fail a
+    -- later leg with a defect this one invented. A leg that changes the save
+    -- owns undoing it (the co-op driver's switch test does the same).
+    local tail = game.save.party and game.save.party[#game.save.party]
+    if addedBench and #(game.save.party or {}) > 1
+       and tail and tail.species == benchSpecies then
+      table.remove(game.save.party)
+      log("removed the extra POKeMON the mediated switch needed")
+    end
+
     H.rankAfterBattle(game, exports, check)
 
     -- ------- 6b. a co-op battle, over the *in-game* hub

--- a/tests/mediated_battle_client.lua
+++ b/tests/mediated_battle_client.lua
@@ -1258,6 +1258,55 @@ do
   eq(a.slots[2].pending, nil, "...leaving nothing parked")
   eq(a.slots[2].shownHp, 21, "...and the bar starts where the referee put it")
 
+  -- ------- the hit that lands inside the window belongs to the newcomer
+  --
+  -- The switch and the attack that answers it resolve in **one batch** -- the
+  -- referee fields every switch before it runs a single fight
+  -- (`_resolveTurn`, src/BattleSim/Turn.lua) -- so a monster is struck while
+  -- its own arrival is still parked on every turn somebody switches into a
+  -- move. Read off the seat, that fall was measured against the *departing*
+  -- monster's numbers, came out as no fall at all, and queued nothing: the
+  -- newcomer was installed at its post-hit HP and the attack showed nothing.
+  -- No flash, no nudge, no impact burst, no bar. So the row is filed against
+  -- whoever the seat will be showing when it plays, and the arrival carries
+  -- the HP it walked out with for the bar to start from.
+  local hits = 0
+  for _, e in ipairs(a.fx or {}) do if e.kind == "flash" then hits = hits + 1 end end
+  ev({ t = "switch", slot = 2, text = "NIDORAN", speciesId = 29, level = 6, mon = 2 })
+  ev({ t = "send", slot = 2, text = "NIDORAN", hp = 26, maxHp = 26,
+       speciesId = 29, level = 6, mon = 2 })
+  ev({ t = "anim", slot = 0, side = "a", text = "TACKLE" })
+  ev({ t = "damage", slot = 2, hp = 17, amount = 9 })
+  eq(a.slots[2].species, "RATTATA",
+     "the seat is still the departing monster's while the arrival is parked")
+  eq(a.slots[2].hp, 21, "...and the hit is not written to its numbers")
+  eq(a.slots[2].pending.hp, 17, "the referee's number lands on the newcomer")
+  eq(a.slots[2].pending.shownHp, 26,
+     "...whose bar still starts where it walked out")
+  local filed = nil
+  for _, row in ipairs(a.lines) do
+    if row.drain then filed = row end
+  end
+  check(filed ~= nil, "a fall is queued for it -- this is the regression")
+  eq(filed and filed.species, "NIDORAN",
+     "...named for the monster that took it, so it survives the swap")
+  eq(filed and filed.to, 17, "...and falls to the referee's number")
+
+  local sawHit, walkedOutAt = false, nil
+  guard = 0
+  while (#a.lines > 0 or a.draining) and guard < 1500 do
+    a:update(1 / 60); guard = guard + 1
+    if a.slots[2].species == "NIDORAN" and walkedOutAt == nil then
+      walkedOutAt = a.slots[2].shownHp
+    end
+    for _, e in ipairs(a.fx or {}) do if e.kind == "flash" then sawHit = true end end
+  end
+  check(guard < 1500, "the batch drains in bounded frames")
+  eq(walkedOutAt, 26, "the newcomer is drawn whole, before the blow reads")
+  check(sawHit, "...the hit reads on it (beat 3: the flash and the nudge)")
+  eq(a.slots[2].shownHp, 17, "...and the bar finishes where the referee put it")
+  eq(a.slots[2].hp, 17, "...with the seat's truth agreeing")
+
   -- Teardown: a battle ending mid-window strands neither a hold nor a park.
   ev({ t = "send", slot = 2, text = "PIDGEY", hp = 24 })
   check(a.slots[2].pending ~= nil, "a fresh arrival is parked")


### PR DESCRIPTION
Switch a monster out and the attack answering it did nothing you could see: no white flash, no nudge of the field, no impact burst, and a HP bar that never moved. The newcomer walked onto the arena with a bar already short, and the sentence naming the move that shortened it printed over a still screen. It happened on **every turn somebody switched into a move** — in MMO 1v1 and in the solo fights the same screen serves.

## The referee was never wrong

Driving `BattleSim` directly gives the correct stream — the damage lands on the monster that just came in:

```
switch   slot=2   text=Delta
send     slot=2   hp=100   text=Delta
anim     slot=0   text=thump
msg      Alpha used thump
damage   slot=2   hp=75    amount=25
```

The two events are **one batch**: `Battle:_resolveTurn` fields every switch before it runs a single fight. On the arena a `send` into a seat somebody is still standing on is *parked* as `slot.pending` rather than applied, so the departing monster can finish draining and sinking on numbers that are still its own.

`noteSlot` routed the referee's damage to that parked record correctly. The **display row** did not. `queueDrain` read `self.slots[i]` — the departing monster — found its bar already where its HP said it was, and queued **nothing**. `applySwap` then installed the arrival at its post-hit number with `shownHp = hp`, leaving nothing to animate.

## The fix

Display rows are now filed against whoever the seat will be showing when they play — `slot.pending or slot` — and the parked arrival carries a `shownHp` frozen at the HP it walked out with, so `applySwap` has something to fall from.

The same routing covers the companion case: `queueFaintFx`, the `faint` branch's `hp = 0` and the `clearPic` stamp all addressed the departing monster, so a monster switched in and KO'd on the same turn spent the wrong sprite's sink.

`CoopBattle` never had any of this — its `showing()` already scans the queue forward for the newest pending `swap` before answering who a row belongs to. That is the precedent this follows.

**Client-side only.** No wire field moves, `PROTOCOL` is unchanged, and both twin-parity suites are untouched.

## Covered twice, and both checked against the unfixed source

- `tests/mediated_battle_client.lua` drives the referee's real event shape through the client and pins the queued fall, the bar's starting point and the hit beat. Reverting `src/MediatedBattle.lua` to the previous commit fails **6 of them**, including `the newcomer is drawn whole, before the blow reads (got 17, want 26)`.
- `tests/drivers/mmo_host.lua` adds the first end-to-end leg anywhere that presses SWITCH on a **mediated** screen — the co-op leg beside it drives `CoopBattle`, a different screen with a different display model, so this path had no live cover. It samples the park, the queued `drain` row and the seat's `shownHp` every frame, because none of them survives the turn. The same six checks fail end-to-end on the unfixed source (`arrivedOn=0 drainTo=nil` — the newcomer installed already dead, with no baseline and no fall ever filed).

Retry attempts in the new leg log rather than assert, so a legal miss on the first turn cannot invent a failure. `host-battle-switch.png` now photographs the mediated bench list while it is up, which nothing had photographed before.

## Verification

| | |
|---|---|
| T4 `run_modkit.lua` | 36/36 suites |
| `run-mmo-e2e.sh` | 0 failures (both hubs' drivers run) |
| `run-hub-e2e.sh` | 0 failures |
| `hub.test.js` / `config.test.js` | 160/160, 262/262 |
| `twin_parity` / `hub_protocol_parity` | 14/14, 28/28 |

Version bumped 1.1.0 → 1.1.1 across `manifest.json`, `server/package.json` and `README.md` (×2).

The four `MK302` NIRE findings from `modkit lint` are pre-existing and unrelated — no assets are touched by this branch. They are the known false positive from the aspect-aware `ahash` patch that never landed upstream.