### PR TITLE
fix: make travelling attacks read as their type, not balls and lasers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,15 +55,24 @@ here must match `manifest.version`.
   Power 1 is exempt: Gen 1 uses it to mark fixed-damage and one-hit-KO moves,
   so Guillotine and Seismic Toss take the middle band rather than being drawn
   as the weakest attacks in the game. On top of that a catalogue of 137 signature moves says where
-  the type is a poor description of what the player sees: Flamethrower and
-  Hyper Beam are beams, Explosion is a field-wide blast, Swords Dance plays
-  on the user, Growl is notes thrown at the target.
+  the type is a poor description of what the player sees: Flamethrower is a
+  fire stream (not a laser), Thunderbolt is jagged lightning, Ice Beam is a
+  crystal stream, Hydro Pump is a water jet, Psybeam is a helix of motes,
+  Explosion is a field-wide blast, Swords Dance plays on the user, Growl is
+  notes thrown at the target. Travelling ember / spark / leaf / shard /
+  splash / rock / psi wear those looks in the air -- a generic projectile
+  core is a ball, which is why Ember, Thunder Shock, Razor Leaf, Ice Punch,
+  Water Gun, Rock Throw and Confusion used to read as coloured orbs. Thunder
+  is a strike at the target rather than a thrown object.
 
   **Five deliveries**, so an effect happens where the move does: `burst` at
-  the target, `projectile` (a bright core on an arc with a trail, bursting on
-  arrival), `beam` (attacker to target, opening and fading), `self`, and
-  `field`. A travelling effect whose thrower has left the field degrades to a
-  burst on the target rather than firing from the corner of the canvas.
+  the target, `projectile` (ember, spark, leaf, shard, splash, rock and psi
+  travel as fire / lightning / foliage / crystals / water / chunks / motes;
+  everything else is a bright core on an arc, bursting on arrival), `beam`
+  (fire stream, jagged bolt, crystal stream, water jet or psychic helix for
+  those styles, otherwise an energy quad from attacker to target), `self`,
+  and `field`. A travelling effect whose thrower has left the field degrades
+  to a burst on the target rather than firing from the corner of the canvas.
 
   **On the beats that were already there.** The move's particles ride the
   attacker's lunge (beat 2) — so a status move and a miss both draw, which an

--- a/src/Battlefield.lua
+++ b/src/Battlefield.lua
@@ -2791,6 +2791,10 @@ local POLY3 = { 0, 0, 0, 0, 0, 0 }
 local POLY4 = { 0, 0, 0, 0, 0, 0, 0, 0 }
 local POLY5 = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 local POLY8 = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+-- A jagged bolt's vertices, refilled in place. 7 points = 14 numbers; extras
+-- are niled so `gfx.line` never traces a stale kink from a longer bolt.
+local LIGHTN = {}
+local unpack = unpack or table.unpack
 
 -- Write vertex `n` of `poly` as the local offset (lx, ly) rotated by `ang` and
 -- placed at (x, y).
@@ -2817,8 +2821,20 @@ local function drawParticleShape(gfx, shape, ax, ay, x, y, r, ang)
     -- The soft body only. Its brighter core is a second circle the caller
     -- draws (`drawVfxBurst`), because the core wants the palette's *first*
     -- colour rather than the tint this particle was given -- which is what
-    -- makes smoke and flame read as lit from the inside.
+    -- makes smoke read as lit from the inside.
     gfx.circle("fill", x, y, r)
+
+  elseif shape == "flame" then
+    -- A teardrop: round base, pointed crown. ang == 0 is up (negative y), so
+    -- a rising ember stands as fire and a lean from the emitter reads as a
+    -- flicker rather than a spin. A circle here is a ball; this is the shape
+    -- that stops Flamethrower looking like a beam of dots.
+    put(POLY5, 1, x, y, 0, -r * 1.75, c, s)
+    put(POLY5, 2, x, y, r * 0.58, -r * 0.15, c, s)
+    put(POLY5, 3, x, y, r * 0.46, r * 0.90, c, s)
+    put(POLY5, 4, x, y, -r * 0.46, r * 0.90, c, s)
+    put(POLY5, 5, x, y, -r * 0.58, -r * 0.15, c, s)
+    gfx.polygon("fill", POLY5)
 
   elseif shape == "streak" then
     -- A taper pointing back at the anchor: wide where the particle is, closed
@@ -2831,16 +2847,19 @@ local function drawParticleShape(gfx, shape, ax, ay, x, y, r, ang)
     gfx.polygon("fill", POLY3)
 
   elseif shape == "bolt" then
-    -- Three segments from the anchor to the particle, each kicked sideways --
-    -- electricity that travels in a straight line is a laser, not a spark.
+    -- Five segments from the anchor to the particle, each kicked sideways --
+    -- electricity that travels in a straight line is a laser, not a spark,
+    -- and three kinks at this scale still read as a short stick.
     local dx, dy = x - ax, y - ay
     local nx, ny = -dy, dx
     local len = (nx * nx + ny * ny) ^ 0.5
     if len > 0.001 then nx, ny = nx / len, ny / len end
-    local k = r * 0.75
+    local k = r * 1.15
     gfx.line(ax, ay,
-      ax + dx * 0.33 + nx * k, ay + dy * 0.33 + ny * k,
-      ax + dx * 0.66 - nx * k, ay + dy * 0.66 - ny * k,
+      ax + dx * 0.20 + nx * k, ay + dy * 0.20 + ny * k,
+      ax + dx * 0.40 - nx * k * 0.9, ay + dy * 0.40 - ny * k * 0.9,
+      ax + dx * 0.62 + nx * k * 0.75, ay + dy * 0.62 + ny * k * 0.75,
+      ax + dx * 0.82 - nx * k * 0.45, ay + dy * 0.82 - ny * k * 0.45,
       x, y)
 
   elseif shape == "shard" then
@@ -2852,12 +2871,15 @@ local function drawParticleShape(gfx, shape, ax, ay, x, y, r, ang)
     gfx.polygon("fill", POLY4)
 
   elseif shape == "leaf" then
-    -- A lens: two points on the long axis, two bulges off it.
-    put(POLY4, 1, x, y, r * 1.35, 0, c, s)
-    put(POLY4, 2, x, y, 0, r * 0.62, c, s)
-    put(POLY4, 3, x, y, -r * 1.35, 0, c, s)
-    put(POLY4, 4, x, y, 0, -r * 0.62, c, s)
-    gfx.polygon("fill", POLY4)
+    -- An ovate leaf, not a diamond: sharp tip, full belly, a pinched stem.
+    -- A four-point lens at this size is a green ball; five points with a
+    -- stem is the smallest shape that still reads as foliage in flight.
+    put(POLY5, 1, x, y, r * 1.75, 0, c, s)
+    put(POLY5, 2, x, y, r * 0.20, r * 0.78, c, s)
+    put(POLY5, 3, x, y, -r * 1.20, r * 0.22, c, s)
+    put(POLY5, 4, x, y, -r * 1.55, 0, c, s)
+    put(POLY5, 5, x, y, r * 0.20, -r * 0.78, c, s)
+    gfx.polygon("fill", POLY5)
 
   elseif shape == "chunk" then
     for i = 1, 5 do
@@ -2964,12 +2986,17 @@ local function drawVfxBurst(gfx, styleName, pal, x, y, R, t, seed, intensity)
       local rad = pr * def.size
       gfx.setColor(c[1], c[2], c[3], pa)
       drawParticleShape(gfx, def.shape, x, y, sx, sy, rad, ang)
-      -- A puff's core: the same mote again at half the radius in the palette's
-      -- brightest colour, which is what makes smoke read as lit from inside.
-      if def.shape == "puff" and rad > 2 then
+      -- A puff's / flame's core: the same mote again at half the radius in
+      -- the palette's brightest colour, which is what makes smoke and fire
+      -- read as lit from inside.
+      if (def.shape == "puff" or def.shape == "flame") and rad > 2 then
         local core = pal[1]
         gfx.setColor(core[1], core[2], core[3], pa * 0.55)
-        gfx.circle("fill", sx, sy, rad * 0.45)
+        if def.shape == "flame" then
+          drawParticleShape(gfx, "flame", x, y, sx, sy, rad * 0.45, ang)
+        else
+          gfx.circle("fill", sx, sy, rad * 0.45)
+        end
       end
     end
   end
@@ -2990,24 +3017,259 @@ local function drawVfxGlow(gfx, def, pal, x, y, R, t)
   gfx.circle("fill", x, y, max(1, R * (0.28 + 0.32 * u)))
 end
 
--- A beam: attacker to defender, widening as it opens, held, then thinning out.
--- Two passes -- an outer body in the palette's mid colour and a thin core in
--- its brightest -- which is the whole trick that makes a flat quad read as
--- energy rather than as a coloured stick.
-local function drawVfxBeam(gfx, x0, y0, x1, y1, t, pal, R)
+-- A long jagged bolt from (x0,y0) to (x1,y1). `amp` is the sideways kick in
+-- px; `salt` picks a distinct fork from the same seed. Drawn twice -- a thick
+-- mid-colour body and a thin hot core -- so it reads as lightning and not as
+-- a single-pixel scribble.
+local function drawLightning(gfx, x0, y0, x1, y1, pal, amp, seed, salt, alpha)
+  local dx, dy = x1 - x0, y1 - y0
+  local len = (dx * dx + dy * dy) ^ 0.5
+  if len < 0.5 then return end
+  local nx, ny = -dy / len, dx / len
+  local segs = 6
+  LIGHTN[1], LIGHTN[2] = x0, y0
+  for i = 1, segs - 1 do
+    local p = i / segs
+    local taper = min(p, 1 - p) * 2
+    local kick = (Vfx.rand01(seed, salt, i) - 0.5) * 2 * amp * taper
+    LIGHTN[i * 2 + 1] = x0 + dx * p + nx * kick
+    LIGHTN[i * 2 + 2] = y0 + dy * p + ny * kick
+  end
+  LIGHTN[segs * 2 + 1] = x1
+  LIGHTN[segs * 2 + 2] = y1
+  for i = segs * 2 + 3, #LIGHTN do LIGHTN[i] = nil end
+  local mid, core = pal[2] or pal[1], pal[1]
+  local lw = gfx.getLineWidth and gfx.getLineWidth() or 1
+  if gfx.setLineWidth then pcall(gfx.setLineWidth, 4.2) end
+  gfx.setColor(mid[1], mid[2], mid[3], alpha * 0.6)
+  gfx.line(unpack(LIGHTN))
+  if gfx.setLineWidth then pcall(gfx.setLineWidth, 1.7) end
+  gfx.setColor(core[1], core[2], core[3], alpha)
+  gfx.line(unpack(LIGHTN))
+  if gfx.setLineWidth then pcall(gfx.setLineWidth, lw) end
+end
+
+-- Flames along a line (or the flown part of one). Not a quad: a geometric
+-- beam in fire colours is what made Flamethrower look like a laser. Each
+-- mote is the same teardrop the ember burst uses, so a stream and an impact
+-- are one vocabulary.
+local function drawFireStream(gfx, x0, y0, x1, y1, pal, R, seed, salt, alpha, n)
+  local dx, dy = x1 - x0, y1 - y0
+  local len = (dx * dx + dy * dy) ^ 0.5
+  if len < 0.5 then return end
+  local nx, ny = -dy / len, dx / len
+  n = n or 14
+  for i = 1, n do
+    local p = (i - 0.5) / n
+    local r1 = Vfx.rand01(seed, salt, i)
+    local r2 = Vfx.rand01(seed, salt + 1, i)
+    local r3 = Vfx.rand01(seed, salt + 2, i)
+    local wobble = (r1 - 0.5) * R * 0.42
+    local rise = -r2 * R * 0.28
+    local x = x0 + dx * p + nx * wobble
+    local y = y0 + dy * p + ny * wobble + rise
+    local rad = (0.16 + r3 * 0.22) * R
+    local tint = (p < 0.3) and 1 or ((p < 0.7) and 2 or 3)
+    local c = pal[tint] or pal[2]
+    local ang = (r1 - 0.5) * 0.7
+    gfx.setColor(c[1], c[2], c[3], alpha * (0.65 + r2 * 0.35))
+    drawParticleShape(gfx, "flame", x0, y0, x, y, rad, ang)
+    local core = pal[1]
+    gfx.setColor(core[1], core[2], core[3], alpha * 0.5)
+    drawParticleShape(gfx, "flame", x0, y0, x, y, rad * 0.45, ang)
+  end
+end
+
+-- Thrown matter along an arc: leaves, ice crystals, rocks. The generic
+-- projectile core is a circle, which is why Razor Leaf was a green ball,
+-- Ice Punch a white one and Rock Throw a grey one. Same primitive the
+-- burst already draws, strung along the path instead.
+local function drawTumbleFlight(gfx, shape, at, u, pal, R, seed)
+  local n = (shape == "chunk") and 7 or 8
+  local spinRate = (shape == "chunk") and 2.4 or ((shape == "shard") and 4.2 or 5.0)
+  local sizeMul = (shape == "chunk") and 0.30 or 0.24
+  for i = n, 1, -1 do
+    local p = u - (i - 1) * 0.075
+    if p > 0.02 then
+      local r1 = Vfx.rand01(seed, i, 4)
+      local r2 = Vfx.rand01(seed, i, 5)
+      local cx, cy = at(p)
+      local sway = (r2 - 0.5) * R * 0.28
+      local ang = r1 * 6.283 + p * pi * spinRate
+      local c = pal[(r1 < 0.45) and 1 or 2] or pal[2]
+      local rad = R * (sizeMul + r2 * 0.14) * (1 - (i - 1) * 0.07)
+      gfx.setColor(c[1], c[2], c[3], 0.9 * (1 - (i - 1) / (n + 1)))
+      drawParticleShape(gfx, shape, cx, cy, cx + sway, cy, max(1.5, rad), ang)
+    end
+  end
+end
+
+-- Droplets along a line (Hydro Pump) or the flown part of one (Water Gun).
+-- A single circle here is a blue ball; many, slightly sagging, is water.
+local function drawWaterStream(gfx, x0, y0, x1, y1, pal, R, seed, salt, alpha, n)
+  local dx, dy = x1 - x0, y1 - y0
+  local len = (dx * dx + dy * dy) ^ 0.5
+  if len < 0.5 then return end
+  local nx, ny = -dy / len, dx / len
+  n = n or 16
+  for i = 1, n do
+    local p = (i - 0.5) / n
+    local r1 = Vfx.rand01(seed, salt, i)
+    local r2 = Vfx.rand01(seed, salt + 1, i)
+    local r3 = Vfx.rand01(seed, salt + 2, i)
+    local wobble = (r1 - 0.5) * R * 0.28
+    local sag = p * p * R * 0.18
+    local x = x0 + dx * p + nx * wobble
+    local y = y0 + dy * p + ny * wobble + sag
+    local rad = (0.10 + r3 * 0.16) * R
+    local c = pal[(r2 < 0.4) and 1 or 2] or pal[2]
+    gfx.setColor(c[1], c[2], c[3], alpha * (0.55 + r2 * 0.4))
+    gfx.circle("fill", x, y, max(1.1, rad))
+  end
+end
+
+-- Ice crystals along a line. Ice Beam wearing a laser is the same bug as
+-- Flamethrower: the delivery was "beam" so the renderer drew a quad.
+local function drawShardStream(gfx, x0, y0, x1, y1, pal, R, seed, salt, alpha, n)
+  local dx, dy = x1 - x0, y1 - y0
+  local len = (dx * dx + dy * dy) ^ 0.5
+  if len < 0.5 then return end
+  local nx, ny = -dy / len, dx / len
+  n = n or 12
+  for i = 1, n do
+    local p = (i - 0.5) / n
+    local r1 = Vfx.rand01(seed, salt, i)
+    local r2 = Vfx.rand01(seed, salt + 1, i)
+    local r3 = Vfx.rand01(seed, salt + 2, i)
+    local wobble = (r1 - 0.5) * R * 0.32
+    local x = x0 + dx * p + nx * wobble
+    local y = y0 + dy * p + ny * wobble
+    local rad = (0.16 + r3 * 0.18) * R
+    local c = pal[(r2 < 0.5) and 1 or 2] or pal[2]
+    local ang = r1 * 6.283 + p * pi * 3
+    gfx.setColor(c[1], c[2], c[3], alpha * (0.7 + r2 * 0.3))
+    drawParticleShape(gfx, "shard", x0, y0, x, y, rad, ang)
+  end
+end
+
+-- Psychic motes along a line, helixed so the column reads as a beam of
+-- thought rather than a pink stick. Psybeam keeps a thin core underneath
+-- so the name still holds.
+local function drawPsiStream(gfx, x0, y0, x1, y1, pal, R, seed, t, alpha)
+  local dx, dy = x1 - x0, y1 - y0
+  local len = (dx * dx + dy * dy) ^ 0.5
+  if len < 0.5 then return end
+  local nx, ny = -dy / len, dx / len
+  local n = 16
+  for i = 1, n do
+    local p = (i - 0.5) / n
+    local r1 = Vfx.rand01(seed, 7, i)
+    local ang = p * pi * 6 + t * pi * 4 + r1
+    local rad = R * (0.14 + r1 * 0.12)
+    local x = x0 + dx * p + nx * cos(ang) * rad
+    local y = y0 + dy * p + ny * sin(ang) * rad * 0.75
+    local c = pal[(r1 < 0.4) and 1 or 2] or pal[2]
+    gfx.setColor(c[1], c[2], c[3], alpha * (0.55 + r1 * 0.4))
+    gfx.circle("fill", x, y, max(1.1, R * 0.09))
+  end
+end
+
+-- Psychic projectile: motes orbit the path, pulled slightly inward as they
+-- go. A single core here is a pink ball; the burst is already a spiral.
+local function drawPsiFlight(gfx, at, u, pal, R, seed)
+  local n = 14
+  for i = 1, n do
+    local p = u * ((i - 0.5) / n)
+    if p > 0.02 then
+      local r1 = Vfx.rand01(seed, i, 6)
+      local r2 = Vfx.rand01(seed, i, 7)
+      local cx, cy = at(p)
+      local ang = r1 * 6.283 + u * pi * 4
+      local rad = R * (0.16 + r2 * 0.22) * (1 - p * 0.45)
+      local c = pal[(r1 < 0.4) and 1 or 2] or pal[2]
+      gfx.setColor(c[1], c[2], c[3], 0.8 * (0.4 + p * 0.6))
+      gfx.circle("fill", cx + cos(ang) * rad, cy + sin(ang) * rad * 0.7,
+        max(1.1, R * 0.09))
+    end
+  end
+end
+
+-- A beam: attacker to defender. Hyper Beam stays a widening energy quad.
+-- Ember, spark, shard, splash and psi do not -- those styles wearing a laser
+-- is what made fire look like a beam, Thunderbolt a yellow stick, Ice Beam
+-- a cyan laser and Hydro Pump a blue one.
+local function drawVfxBeam(gfx, styleName, x0, y0, x1, y1, t, pal, R, seed)
   local dx, dy = x1 - x0, y1 - y0
   local len = (dx * dx + dy * dy) ^ 0.5
   if len < 0.001 then return end
   local nx, ny = -dy / len, dx / len
-  -- Opens in the first fifth, holds, and is gone by the end.
   local open = min(1, t / 0.2)
   local fade = (t > 0.55) and (1 - (t - 0.55) / 0.45) or 1
-  local w = M.FX_BEAM_W * (R / M.FX_VFX_R) * open * max(0, fade)
+  fade = max(0, fade)
+  if fade <= 0.01 then return end
+  seed = seed or 0
+
+  if styleName == "ember" then
+    local xHead = x0 + dx * open
+    local yHead = y0 + dy * open
+    drawFireStream(gfx, x0, y0, xHead, yHead, pal, R, seed, 1, 0.85 * fade, 14)
+    return
+  end
+  if styleName == "spark" then
+    local xHead = x0 + dx * open
+    local yHead = y0 + dy * open
+    local flick = 0.45 + 0.55 * Vfx.rand01(seed, math.floor(t * 22), 9)
+    drawLightning(gfx, x0, y0, xHead, yHead, pal, R * 0.32, seed, 1, fade * flick)
+    if flick > 0.55 then
+      local mid = 0.45 + Vfx.rand01(seed, 3, 8) * 0.2
+      local mx = x0 + dx * mid * open
+      local my = y0 + dy * mid * open
+      local fork = 0.35
+      drawLightning(gfx, mx, my,
+        mx + dx * fork * open + nx * R * 0.45,
+        my + dy * fork * open + ny * R * 0.45,
+        pal, R * 0.22, seed, 2, fade * flick * 0.7)
+    end
+    return
+  end
+  if styleName == "shard" then
+    local xHead = x0 + dx * open
+    local yHead = y0 + dy * open
+    drawShardStream(gfx, x0, y0, xHead, yHead, pal, R, seed, 1, 0.85 * fade, 12)
+    return
+  end
+  if styleName == "splash" then
+    local xHead = x0 + dx * open
+    local yHead = y0 + dy * open
+    drawWaterStream(gfx, x0, y0, xHead, yHead, pal, R, seed, 1, 0.85 * fade, 18)
+    return
+  end
+  if styleName == "psi" then
+    local xHead = x0 + dx * open
+    local yHead = y0 + dy * open
+    -- A thin core so Psybeam still reads as a beam, then the helix on top
+    -- so it is thought rather than a coloured stick.
+    local w = M.FX_BEAM_W * (R / M.FX_VFX_R) * open * fade * 0.28
+    if w > 0.2 then
+      local c = pal[2]
+      POLY4[1] = x0 + nx * w; POLY4[2] = y0 + ny * w
+      POLY4[3] = xHead + nx * w; POLY4[4] = yHead + ny * w
+      POLY4[5] = xHead - nx * w; POLY4[6] = yHead - ny * w
+      POLY4[7] = x0 - nx * w; POLY4[8] = y0 - ny * w
+      gfx.setColor(c[1], c[2], c[3], 0.28 * fade)
+      gfx.polygon("fill", POLY4)
+    end
+    drawPsiStream(gfx, x0, y0, xHead, yHead, pal, R, seed, t, 0.9 * fade)
+    return
+  end
+
+  -- Opens in the first fifth, holds, and is gone by the end.
+  local w = M.FX_BEAM_W * (R / M.FX_VFX_R) * open * fade
   if w <= 0.2 then return end
   for pass = 1, 2 do
     local half = (pass == 1) and w or w * 0.34
     local c = (pass == 1) and pal[2] or pal[1]
-    local a = ((pass == 1) and 0.55 or 0.9) * max(0, fade)
+    local a = ((pass == 1) and 0.55 or 0.9) * fade
     POLY4[1] = x0 + nx * half; POLY4[2] = y0 + ny * half
     POLY4[3] = x1 + nx * half; POLY4[4] = y1 + ny * half
     POLY4[5] = x1 - nx * half; POLY4[6] = y1 - ny * half
@@ -3017,15 +3279,56 @@ local function drawVfxBeam(gfx, x0, y0, x1, y1, t, pal, R)
   end
 end
 
--- A projectile in flight: a bright core on a shallow arc, with a short tail of
--- motes strung out behind it along the path it has already covered.
-local function drawVfxFlight(gfx, x0, y0, x1, y1, u, pal, R, seed)
-  -- One arc, evaluated at several points: the core is at `u` and each trail
-  -- mote at a fraction of the flight behind it, so the tail lies *on* the path
-  -- the core actually took rather than on a straight line under it.
+-- A projectile in flight. The default is still a bright core on a shallow
+-- arc (Shadow Ball, Egg Bomb). Named styles wear their own look while they
+-- travel -- a generic circle here is why Ember was a fireball, Thunder Shock
+-- a yellow ball, Razor Leaf a green one, Ice Punch a white one, Water Gun
+-- a blue one, Rock Throw a grey one and Confusion a pink one.
+local function drawVfxFlight(gfx, styleName, x0, y0, x1, y1, u, pal, R, seed)
   local function at(p)
     return x0 + (x1 - x0) * p, y0 + (y1 - y0) * p - 4 * p * (1 - p) * R * 0.55
   end
+  seed = seed or 0
+  local cx, cy = at(u)
+
+  if styleName == "ember" then
+    drawFireStream(gfx, x0, y0, cx, cy, pal, R * 0.85, seed, 3, 0.9, 10)
+    return
+  end
+  if styleName == "spark" then
+    local flick = 0.5 + 0.5 * Vfx.rand01(seed, math.floor(u * 20), 9)
+    drawLightning(gfx, x0, y0, cx, cy, pal, R * 0.28, seed, 1, flick)
+    if flick > 0.5 then
+      drawLightning(gfx, x0, y0,
+        cx + (cy - y0) * 0.12, cy - (cx - x0) * 0.12,
+        pal, R * 0.18, seed, 2, flick * 0.65)
+    end
+    return
+  end
+  if styleName == "leaf" then
+    drawTumbleFlight(gfx, "leaf", at, u, pal, R, seed)
+    return
+  end
+  if styleName == "shard" then
+    drawTumbleFlight(gfx, "shard", at, u, pal, R, seed)
+    return
+  end
+  if styleName == "rock" or styleName == "quake" then
+    drawTumbleFlight(gfx, "chunk", at, u, pal, R, seed)
+    return
+  end
+  if styleName == "splash" then
+    drawWaterStream(gfx, x0, y0, cx, cy, pal, R * 0.9, seed, 3, 0.9, 14)
+    return
+  end
+  if styleName == "psi" then
+    drawPsiFlight(gfx, at, u, pal, R, seed)
+    return
+  end
+
+  -- One arc, evaluated at several points: the core is at `u` and each trail
+  -- mote at a fraction of the flight behind it, so the tail lies *on* the path
+  -- the core actually took rather than on a straight line under it.
   for i = M.FX_VFX_TRAIL, 1, -1 do
     local p = u - i * 0.055
     if p > 0 then
@@ -3035,7 +3338,6 @@ local function drawVfxFlight(gfx, x0, y0, x1, y1, u, pal, R, seed)
       gfx.circle("fill", tx, ty, max(1, R * 0.20 * (1 - i * 0.13)))
     end
   end
-  local cx, cy = at(u)
   local mid, core = pal[2], pal[1]
   gfx.setColor(mid[1], mid[2], mid[3], 0.75)
   gfx.circle("fill", cx, cy, max(1, R * 0.38))
@@ -3063,12 +3365,16 @@ end
 --   self        the same, at the seat it came from.
 --   field       the same, at mid-field and much wider -- Earthquake, Explosion,
 --               a Poke Flute, weather.
---   projectile  the first M.FX_VFX_TRAVEL of the life is the flight and draws
---               *only* the core and its tail; the remainder is the burst on
---               arrival, replayed from t == 0 so the impact is a whole effect
---               rather than the tail end of one.
---   beam        the beam is drawn for the whole life and the burst rides under
---               its far end, opening a beat late so the beam is seen to arrive
+--   projectile  the first M.FX_VFX_TRAVEL of the life is the flight; ember,
+--               spark, leaf, shard, splash, rock, quake and psi wear their
+--               own look in the air, everything else is a core and a tail,
+--               then the remainder is the burst on arrival, replayed from
+--               t == 0 so the impact is a whole effect rather than the tail
+--               end of one.
+--   beam        ember / spark / shard / splash / psi wear their own look
+--               (fire, lightning, crystals, water, a helix of motes); other
+--               styles keep the energy quad. The burst rides under the far
+--               end, opening a beat late so the stream is seen to arrive
 --               before anything answers it.
 --
 -- A travelling delivery whose origin is missing (an effect published with no
@@ -3104,14 +3410,29 @@ local function drawVfx(layout, e)
     local ox, oy = vfxAnchor(layout, fromSide, e.fromSeat)
     local travel = M.FX_VFX_TRAVEL
     if t < travel then
-      pcall(drawVfxFlight, gfx, ox, oy, x, y, t / travel, pal, R, seed)
+      -- Additive for the styles that are light: a spark in flight is
+      -- lightning, an ember in flight is fire, and both want overlapping
+      -- strokes to brighten rather than to stack opaque. Restored before
+      -- return so a throw cannot leak "add" onto the rest of the frame.
+      local add = Vfx.additive(styleName) and gfx.setBlendMode ~= nil
+      local restoredFlight = false
+      if add then restoredFlight = pcall(gfx.setBlendMode, "add", "alphamultiply") end
+      pcall(drawVfxFlight, gfx, styleName, ox, oy, x, y, t / travel, pal, R, seed)
+      if restoredFlight then pcall(gfx.setBlendMode, "alpha", "alphamultiply") end
       pcall(gfx.setColor, 1, 1, 1, 1)
       return
     end
     burstT = (t - travel) / (1 - travel)
   elseif delivery == "beam" and fromSide then
     local ox, oy = vfxAnchor(layout, fromSide, e.fromSeat)
-    pcall(drawVfxBeam, gfx, ox, oy, x, y, t, pal, R)
+    -- Ember / spark / psi beams are light; they want additive the same way
+    -- the burst does. Ice and water streams are matter and do not.
+    local stream = (styleName == "ember" or styleName == "spark"
+      or styleName == "psi") and gfx.setBlendMode ~= nil
+    local restoredBeam = false
+    if stream then restoredBeam = pcall(gfx.setBlendMode, "add", "alphamultiply") end
+    pcall(drawVfxBeam, gfx, styleName, ox, oy, x, y, t, pal, R, seed)
+    if restoredBeam then pcall(gfx.setBlendMode, "alpha", "alphamultiply") end
     burstT = clamp((t - 0.15) / 0.85, 0, 1)
   end
 

--- a/src/Vfx.lua
+++ b/src/Vfx.lua
@@ -147,11 +147,12 @@ end
 -- `shape` is the primitive src/Battlefield.lua draws for one particle:
 --
 --   dot     a filled circle
---   puff    a soft circle with a lighter core (smoke, flame, wisp)
+--   puff    a soft circle with a lighter core (smoke, wisp)
+--   flame   a teardrop, pointed up (fire)
 --   streak  a line pointing away from the anchor (impact spray)
---   bolt    a jagged three-segment line from the anchor (electricity)
+--   bolt    a jagged five-segment line from the anchor (electricity)
 --   shard   a narrow diamond, rotated (ice, crystal)
---   leaf    a lens shape, rotated (foliage)
+--   leaf    an ovate leaf, pointed tip and a stem, rotated (foliage)
 --   chunk   a rough pentagon, rotated (rock, dirt)
 --   arc     a crescent stroke (wind)
 --   ring    a circle outline (bubbles)
@@ -169,10 +170,10 @@ end
 
 M.STYLES = {
   impact  = { count = 12, shape = "streak", size = 4.0, ring = "shock", glow = 0.55 },
-  ember   = { count = 16, shape = "puff",   size = 4.2, glow = 0.50 },
+  ember   = { count = 16, shape = "flame",  size = 5.4, glow = 0.50 },
   splash  = { count = 14, shape = "dot",    size = 3.4, ring = "wave",  glow = 0.35 },
-  leaf    = { count = 12, shape = "leaf",   size = 4.6, glow = 0.25 },
-  spark   = { count = 15, shape = "bolt",   size = 4.0, ring = "shock", glow = 0.60 },
+  leaf    = { count = 14, shape = "leaf",   size = 6.4, glow = 0.25 },
+  spark   = { count = 15, shape = "bolt",   size = 5.4, ring = "shock", glow = 0.60 },
   shard   = { count = 12, shape = "shard",  size = 4.6, glow = 0.40 },
   psi     = { count = 14, shape = "dot",    size = 3.2, ring = "pulse", glow = 0.45 },
   rock    = { count = 11, shape = "chunk",  size = 4.4, glow = 0.20 },
@@ -262,6 +263,8 @@ EMIT.impact = function(i, n, t, r1, r2, r3)
 end
 
 -- Flames: staggered births, a rising waver, and a cooling tint as they climb.
+-- The angle is a small lean, not a spin -- a flame that tumbles reads as a
+-- leaf, and a flame that sits dead upright in a row reads as a row of dots.
 EMIT.ember = function(i, n, t, r1, r2, r3)
   local born = r1 * 0.35
   local u = (t - born) / (1 - born)
@@ -269,7 +272,8 @@ EMIT.ember = function(i, n, t, r1, r2, r3)
   local x = (r2 - 0.5) * 1.3 * (0.35 + u * 0.65) + sin(u * pi * 3 + r3 * 6.283) * 0.14
   local y = 0.5 - u * 1.5
   local tint = (u < 0.35) and 1 or ((u < 0.75) and 2 or 3)
-  return x, y, (0.45 + r3 * 0.75) * (1 - u * 0.8), 1 - u * u, tint, 0
+  local lean = (r2 - 0.5) * 0.55 + sin(u * pi * 3 + r3 * 6.283) * 0.28
+  return x, y, (0.45 + r3 * 0.75) * (1 - u * 0.8), 1 - u * u, tint, lean
 end
 
 -- Droplets thrown up and out, then pulled back down: gravity is the t^2 term.
@@ -534,9 +538,12 @@ end
 --   burst       at the seat it lands on. The default, and what every contact
 --               move gets: the blow is at the defender, not in between.
 --   projectile  a core travelling attacker -> defender, trailing as it goes,
---               bursting on arrival. What a thrown or fired move looks like.
---   beam        a drawn beam from attacker to defender that widens, holds and
---               fades, with the burst under its far end.
+--               bursting on arrival. Ember, spark, leaf, shard, splash, rock
+--               and psi wear those looks in the air; everything else is a
+--               bright ball (Shadow Ball).
+--   beam        ember / spark / shard / splash / psi wear fire, lightning,
+--               crystals, water and a helix of motes; other styles keep a
+--               widening energy quad, with the burst under the far end.
 --   self        at the user's own seat: a stat boost, a heal, a screen.
 --   field       across the whole arena: Earthquake, Explosion, a Poke Flute.
 --
@@ -663,7 +670,10 @@ M.MOVE_STYLE = {
   BLIZZARD     = { scale = 1.35 },
   FIRE_BLAST   = { delivery = "projectile", scale = 1.40 },
   SACRED_FIRE  = { delivery = "projectile", scale = 1.30 },
-  THUNDER      = { scale = 1.35 },
+  -- Thunder is a strike, not a thrown object: a projectile here is a yellow
+  -- ball in the air for half the life, which is the opposite of lightning.
+  THUNDER      = { delivery = "burst", scale = 1.35 },
+  PETAL_DANCE  = { style = "leaf", scale = 1.20 },
   SANDSTORM    = { style = "quake", palette = "GROUND", delivery = "field",
                    scale = 1.45, duration = 0.60 },
   ROCK_SLIDE   = { scale = 1.30, intensity = 1.2 },
@@ -677,6 +687,7 @@ M.MOVE_STYLE = {
   MEGAHORN     = { style = "impact", palette = "BUG", scale = 1.20 },
 
   -- ------- thrown, not swung
+  RAZOR_LEAF   = { delivery = "projectile", scale = 1.15 },
   LEECH_SEED   = { style = "leaf", delivery = "projectile", scale = 0.85 },
   SHADOW_BALL  = { delivery = "projectile", scale = 1.10 },
   EGG_BOMB     = { delivery = "projectile", scale = 1.10 },

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -22,15 +22,18 @@ local check, eq = T.check, T.eq
 
 local MOD_PATH = "mods/rby_mmo"
 -- Agetor / out-of-tree checkouts may leave mods/rby_mmo pointed at another
--- tree; fall back to this suite's mod root so dual-gen (and the rest) still
--- exercise the checkout under test. Same pattern as tests/trade2.lua.
-if not io.open(MOD_PATH .. "/src/Gen.lua", "rb") then
+-- tree. Prefer the checkout this suite was loaded from whenever it actually
+-- contains the mod -- otherwise a worktree run would silently test the
+-- symlink's target instead of the files under edit.
+do
   local src = debug.getinfo(1, "S").source
   if type(src) == "string" and src:sub(1, 1) == "@" then
     local dir = src:sub(2):match("(.+)[/\\]")
     if dir then
       local fallback = dir:gsub("[/\\]tests$", "")
-      if io.open(fallback .. "/src/Gen.lua", "rb") then
+      local handle = io.open(fallback .. "/src/Gen.lua", "rb")
+      if handle then
+        handle:close()
         MOD_PATH = fallback
       end
     end
@@ -13886,6 +13889,40 @@ end)()
   eq(ember.delivery, "projectile",
      "a Gen1 Special type is fired, which is the rule that covers every move "
      .. "this catalogue has never seen")
+  eq(Vfx.STYLES.ember.shape, "flame",
+     "a Fire look is a teardrop, not a puff -- a puff in flight is a ball")
+  eq(Vfx.STYLES.leaf.shape, "leaf", "Grass wears an ovate leaf, not a dot")
+  eq(Vfx.STYLES.spark.shape, "bolt", "Electric wears a jagged bolt")
+
+  local thunder = Vfx.forMove("THUNDER", { type = "ELECTRIC", power = 120 })
+  eq(thunder.delivery, "burst",
+     "Thunder strikes the target; it is not a thrown ball")
+  eq(thunder.style, "spark", "...and the strike is lightning")
+
+  local razor = Vfx.forMove("RAZOR_LEAF", { type = "GRASS", power = 55 })
+  eq(razor.style, "leaf", "Razor Leaf is foliage")
+  eq(razor.delivery, "projectile", "...thrown, not a beam of green")
+
+  eq(Vfx.STYLES.shard.shape, "shard", "Ice wears crystals, not a ball")
+  eq(Vfx.STYLES.splash.shape, "dot", "Water wears droplets")
+  eq(Vfx.STYLES.rock.shape, "chunk", "Rock wears tumbling chunks")
+  eq(Vfx.STYLES.psi.shape, "dot", "Psychic wears motes, not one orb")
+
+  local iceBeam = Vfx.forMove("ICE_BEAM", { type = "ICE", power = 95 })
+  eq(iceBeam.style, "shard", "Ice Beam keeps Ice's crystals")
+  eq(iceBeam.delivery, "beam", "...and the stream delivery")
+
+  local hydro = Vfx.forMove("HYDRO_PUMP", { type = "WATER", power = 120 })
+  eq(hydro.style, "splash", "Hydro Pump is water")
+  eq(hydro.delivery, "beam", "...as a jet, not a thrown ball")
+
+  local rockThrow = Vfx.forMove("ROCK_THROW", { type = "ROCK", power = 50 })
+  eq(rockThrow.style, "rock", "Rock Throw is a chunk")
+  eq(rockThrow.delivery, "projectile", "...lobbed, not a grey ball")
+
+  local psybeam = Vfx.forMove("PSYBEAM", { type = "PSYCHIC_TYPE", power = 65 })
+  eq(psybeam.style, "psi", "Psybeam is Psychic's look")
+  eq(psybeam.delivery, "beam", "...and still a beam")
 
   -- The fallback that matters: nothing may resolve to nothing.
   local unknown = Vfx.forMove("A_MOD_MOVE_NOBODY_HAS", nil)
@@ -14320,6 +14357,8 @@ end)()
   -- below is compared against this, so a style is only credited with what it
   -- drew rather than with the field it drew over.
   local baseline = drawWith(nil)
+  local baseLine, basePoly = counts.line or 0, counts.polygon or 0
+  local baseCircle = counts.circle or 0
 
   local styles = {}
   for name in pairs(Vfx.STYLES) do styles[#styles + 1] = name end
@@ -14379,6 +14418,109 @@ end)()
   } })
   check(orphan > baseline,
         "a beam whose thrower has left the field falls back to a burst")
+
+  -- Travelling fire / lightning / grass wear their own look in the air, not
+  -- the generic ball-or-laser that made them unreadable. Counted against the
+  -- empty-field baseline so a plate outline cannot pass for a bolt.
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "spark", palette = "ELECTRIC", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.line or 0) > baseLine,
+        "a spark projectile in flight is a bolt, not a thrown ball")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "leaf", palette = "GRASS", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.polygon or 0) > basePoly,
+        "a leaf projectile in flight is a leaf, not a green ball")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "impact", palette = "NORMAL", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  local laserPoly = counts.polygon or 0
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "ember", palette = "FIRE", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.polygon or 0) > laserPoly,
+        "an ember beam is a fire stream, not a two-pass laser")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "spark", palette = "ELECTRIC", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.line or 0) > baseLine,
+        "a spark beam is jagged lightning, not a yellow stick")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "shard", palette = "ICE", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.polygon or 0) > basePoly,
+        "an ice projectile in flight is a crystal, not a white ball")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "rock", palette = "ROCK", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.polygon or 0) > basePoly,
+        "a rock projectile in flight is a chunk, not a grey ball")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "spirit", palette = "GHOST", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  local ballCircle = counts.circle or 0
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "splash", palette = "WATER", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.circle or 0) > ballCircle,
+        "a water projectile in flight is many droplets, not one orb")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.25,
+    style = "psi", palette = "PSYCHIC", delivery = "projectile",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.circle or 0) > ballCircle,
+        "a psychic projectile in flight is a spiral of motes, not a pink ball")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "shard", palette = "ICE", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.polygon or 0) > laserPoly,
+        "an ice beam is a crystal stream, not a two-pass laser")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "splash", palette = "WATER", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.circle or 0) > baseCircle,
+        "a water beam is a jet of droplets, not a blue laser")
+
+  drawWith({ {
+    kind = "vfx", side = "foe", seatIndex = 1, t = 0.4,
+    style = "psi", palette = "PSYCHIC", delivery = "beam",
+    fromSide = "ally", fromSeat = 1, seed = 5,
+  } })
+  check((counts.circle or 0) > baseCircle,
+        "a psychic beam carries motes, not only a coloured stick")
 
   -- Junk on the record is drawn as the defaults rather than refused: every one
   -- of these fields arrives from another process.


### PR DESCRIPTION
## Summary
- Travelling fire, lightning, grass, ice, water, rock, and psychic moves now use their own particles in the air instead of a generic orb or energy quad.
- Flamethrower is a flame stream, Thunderbolt is jagged lightning, Ice Beam is crystals, Hydro Pump is a water jet, Psybeam is a helix of motes, and Rock Throw / Razor Leaf tumble as chunks and leaves.
- Thunder is a strike on the target rather than a thrown ball. Hyper Beam, Solar Beam, and Shadow Ball stay a laser or orb.

## Why
Projectile flight was a coloured circle and beams were a flat quad, so those types looked like the wrong thing until they landed.

## Test plan
- [ ] In a fight, use Ember / Flamethrower, Thunder Shock / Thunderbolt / Thunder, Razor Leaf, Ice Punch / Ice Beam, Water Gun / Hydro Pump, Rock Throw, and Confusion / Psybeam — each should read as its type while travelling.
- [ ] Confirm Hyper Beam, Solar Beam, and Shadow Ball still look like a laser or thrown orb.
- [ ] `luajit tests/rby_mmo_test.lua` from the engine checkout (5206 checks passed on this branch).