### PR TITLE
fix: clear status chips when a mon wakes or an item cures it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,19 @@ here must match `manifest.version`.
 
 ### Fixed
 
+- **A status chip stayed on the mon card after the condition lifted.** Sleep
+  that wore off, a thaw, and every status-heal item (Awakening, Antidote,
+  Burn Heal, Ice Heal, Parlyz Heal, Full Heal, Full Restore, Poké Flute)
+  left the SLEEP / PSN / BRN / FRZ / PAR / TOX badge on the plate. The
+  referee already said the condition was gone — a `status` event with no
+  token, the contract `BattleSim/Events.lua` writes down — but both
+  screens only *wrote* a chip when the field was present, so a clear was
+  a no-op. MMO 1v1 now clears the seat (and the save mon behind it) on
+  that event; a refereed co-op fight applies the same reading to
+  `mon.status`, which is what the arena plate draws. A residual `damage`
+  or a `send` that never mentioned a condition still leaves the chip
+  alone.
+
 - **An attack on a POKéMON that had just switched in did nothing at all.**
   Switch a monster out and the attack that answers it landed on nothing you
   could see: no white flash, no nudge of the field, no impact burst, and a HP

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -3114,10 +3114,11 @@ end
 -- True for the three clients that are not the host, and true for **all four** on
 -- the mediated path -- the host included, because a refereed turn was resolved
 -- somewhere else and its `sim` never touched the numbers the events carry. The
--- two branches in `playEvents` that ask are exactly the two that write sim truth
--- (`damage` applies HP, `send` swaps a battler), and a host that skipped them
--- because it "already did it" would draw a field nobody ever changed: bars that
--- never move, and a monster that faints on three screens out of four.
+-- branches in `playEvents` that ask are the ones that write sim truth
+-- (`damage` applies HP, `status` writes or clears a condition, `send` swaps
+-- a battler), and a host that skipped them because it "already did it" would
+-- draw a field nobody ever changed: bars that never move, a chip that never
+-- lifts, and a monster that faints on three screens out of four.
 function M:replaying()
   return (not self.host) or self.mediated
 end
@@ -3186,6 +3187,22 @@ function M:playEvents(events)
       -- before the one it belongs to.
       self.messages[#self.messages + 1] =
         { vfxrow = event.spec, slot = event.slot, from = event.from }
+
+    elseif event.kind == "status" then
+      -- The referee's reading of a condition, applied the same way HP is:
+      -- only when this copy is replaying somebody else's arithmetic. A
+      -- `status` field inflicted it; none cleared it (wake, thaw, item).
+      -- The arena plate and the classic readout both read `mon.status`, and
+      -- on our own seat that table *is* the save party, so a cure persists.
+      local slot = self.sim:slot(event.slot)
+      if slot and slot.battler and slot.battler.mon and self:replaying() then
+        local status = event.status
+        if type(status) ~= "string" or status == "" then
+          slot.battler.mon.status = nil
+        else
+          slot.battler.mon.status = status
+        end
+      end
 
     elseif event.kind == "damage" then
       -- The replayers are told the resulting HP rather than the amount, so a
@@ -8923,12 +8940,12 @@ function M:medRows(msg)
     say(msg.text)
 
   elseif kind == "status" then
-    -- **New branch, and it only draws.** The sentence for a condition already
-    -- arrives as its own `msg` event, which is why this handler never needed a
-    -- case for `status` before; what it adds is the sight of one landing. An
-    -- event carrying a `status` inflicted it, one carrying none cleared it, and
-    -- a condition lifting is a sentence rather than a sight -- the catalogue
-    -- answers nil for the token that is not there.
+    -- Truth first: the plate reads `mon.status`, and a condition the referee
+    -- lifted (wake, thaw, Awakening, Full Heal) arrives with no token. The
+    -- VFX row still only draws -- a lift is a sentence rather than a sight.
+    if index then
+      rows[#rows + 1] = { kind = "status", slot = index, status = msg.status }
+    end
     local look = Vfx.forStatus(msg.status)
     if look and index then
       rows[#rows + 1] = { kind = "vfx", spec = look, slot = index }

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -2367,11 +2367,15 @@ function M:onEvent(msg)
     end
 
   elseif kind == "status" then
+    -- `noteSlot` writes the token, or clears the chip when the event carries
+    -- none -- wake, thaw, and every status-heal item travel that way. The
+    -- sheet and the save mon stay in step so a party card and the fight after
+    -- this one do not keep a condition the referee already lifted.
     self:noteSlot(msg)
-    -- An event carrying a `status` inflicted it; one carrying none cleared it,
-    -- and a condition lifting is a sentence rather than a sight -- the
-    -- catalogue answers nil for the token that is not there, so nothing is
-    -- filed. Anchored on the seat that took it, in that condition's colours.
+    self:syncMineStatus(msg)
+    -- A condition lifting is a sentence rather than a sight: the catalogue
+    -- answers nil for the token that is not there, so nothing is filed.
+    -- Anchored on the seat that took it, in that condition's colours.
     self:queueVfx(Vfx.forStatus(msg.status), msg.slot)
 
   elseif kind == "stat" then
@@ -2542,6 +2546,21 @@ function M:syncMineHp(msg)
   elseif msg.amount ~= nil and msg.t == "damage" then
     mon.hp = max(0, (mon.hp or 0) - msg.amount)
   end
+end
+
+-- Keep the fight sheet -- and the save mon behind it -- on the referee's
+-- condition. `noteSlot` owns the seat chip; this is the party copy the
+-- POKéMON panel and the next fight both read. A `status` event with no
+-- token is a cure, the same contract the seat uses.
+function M:syncMineStatus(msg)
+  if msg.t ~= "status" then return end
+  if msg.slot ~= self:mySlot() then return end
+  local status = msg.status
+  if type(status) ~= "string" or status == "" then status = nil end
+  local sheet = self.mine and self.mine[self.active]
+  if sheet then sheet.status = status end
+  local save = self:saveMon()
+  if save then save.status = status end
 end
 
 -- ------- exp
@@ -3095,6 +3114,27 @@ end
 -- same reason and against the same failure. An arrival into an *empty* seat
 -- lands immediately and is covered by `spawnHide` instead (`queueSpawnFx`);
 -- both windows end at the same row.
+
+-- The referee's reading of a condition, onto a seat or a parked arrival.
+-- A `status` event with no token **cleared** it -- wake, thaw, item cure --
+-- which is the contract in BattleSim/Events.lua. Every other event only
+-- writes a condition when it states one: a residual `damage` carries the
+-- status that dealt it, a `send` carries the newcomer's, and neither is
+-- allowed to wipe a chip they never mentioned.
+local function applyMsgStatus(target, msg)
+  if type(target) ~= "table" or type(msg) ~= "table" then return end
+  if msg.t == "status" then
+    local status = msg.status
+    if type(status) ~= "string" or status == "" then
+      target.status = nil
+    else
+      target.status = status
+    end
+  elseif msg.status ~= nil then
+    target.status = msg.status
+  end
+end
+
 function M:noteSlot(msg)
   local index = msg.slot
   if index == nil then return nil end
@@ -3123,7 +3163,7 @@ function M:noteSlot(msg)
     elseif msg.amount ~= nil and msg.t == "damage" then
       parked.hp = max(0, (parked.hp or 0) - msg.amount)
     end
-    if msg.status ~= nil then parked.status = msg.status end
+    applyMsgStatus(parked, msg)
     if msg.t == "faint" then parked.hp = 0 end
     return slot
   end
@@ -3201,7 +3241,7 @@ function M:noteSlot(msg)
   if slot.shownHp == nil or fresh or not self:usesBattlefield() then
     slot.shownHp = slot.hp
   end
-  if msg.status ~= nil then slot.status = msg.status end
+  applyMsgStatus(slot, msg)
   -- Do not clear the pic here. Faint often arrives in the same batch as the
   -- move's `anim`, which is only played later from `lines` -- nil'ing the
   -- sprite the moment HP hits 0 made the mon vanish under the still-queued

--- a/tests/coop_mediated.lua
+++ b/tests/coop_mediated.lua
@@ -911,6 +911,25 @@ do
   eq(#vfxRows({ t = "status", slot = 0, text = "is cured!" }), 0,
      "a condition lifting files none -- a sentence rather than a sight")
 
+  -- The plate reads `mon.status`. A `status` event used to file VFX only, so a
+  -- wake or an Awakening left the SLEEP chip on the card. Truth is a row now.
+  local statusRows = fxScreen:medRows({ t = "status", slot = 0, text = "woke up" })
+  eq(#statusRows, 1, "a lift still yields a row -- the truth, not a sight")
+  eq(statusRows[1].kind, "status", "...that playEvents applies to the battler")
+  eq(statusRows[1].status, nil, "...with no token, which is the clear")
+
+  local sleeper = fxScreen.sim:slot(1).battler.mon
+  sleeper.status = "SLP"
+  fxScreen:playEvents({ { kind = "status", slot = 1 } })
+  eq(sleeper.status, nil, "a wake (or an item cure) takes the chip off")
+  for _, token in ipairs({ "PSN", "BRN", "FRZ", "PAR", "TOX" }) do
+    sleeper.status = token
+    fxScreen:playEvents({ { kind = "status", slot = 1 } })
+    eq(sleeper.status, nil, token .. " lifts the same way")
+  end
+  fxScreen:playEvents({ { kind = "status", slot = 1, status = "BRN" } })
+  eq(sleeper.status, "BRN", "an inflict still writes the token")
+
   local rose = vfxRows({ t = "stat", slot = 0, amount = 2,
                          text = "PIKACHU's ATTACK rose" })
   eq(#rose, 1, "a stat stage files one")

--- a/tests/mediated_battle_client.lua
+++ b/tests/mediated_battle_client.lua
@@ -1457,6 +1457,8 @@ do
     if type(row) == "table" and row.vfxrow then burnFiled = true end
   end
   check(burnFiled, "a condition landing files a row")
+  eq(a.slots[2] and a.slots[2].status, "BRN",
+     "...and writes the chip the plate draws")
   check(drain() < 900, "...which drains")
 
   local cleared = #a.lines
@@ -1467,6 +1469,8 @@ do
   end
   eq(clearRows, 0,
      "a condition lifting is a sentence rather than a sight -- no row filed")
+  eq(a.slots[2] and a.slots[2].status, nil,
+     "...and the chip comes off, the same way a wake or an item cure must")
   check(#a.lines >= cleared, "...and nothing else is disturbed")
   check(drain() < 900, "the queue drains")
 
@@ -1525,6 +1529,77 @@ do
   eq(classic.slots[2].species, "RATTATA",
      "off the arena a send relabels at parse exactly as it always did")
   eq(classic.slots[2].pending, nil, "...and parks nothing that could never land")
+end
+
+-- ------------------------------------------------------------------
+-- 11a. status chips: inflict writes, a lift (wake / item) clears
+-- ------------------------------------------------------------------
+--
+-- The referee says a condition is gone by sending a `status` event with no
+-- token (BattleSim/Events.lua). The plate reads `slot.status`, so a client
+-- that only wrote when the field was present kept SLEEP after a wake and
+-- every badge after an Awakening / Full Heal / Antidote.
+
+do
+  local Battlefield = need("Battlefield")
+  local screen = setmetatable({
+    game = {
+      data = DATA,
+      save = { party = { mon("CHARMANDER", { status = "SLP" }) } },
+    },
+    usesBattlefield = function() return true end,
+    slots = {},
+    lines = {},
+    mine = { { species = "CHARMANDER", status = "SLP", slot = 0 } },
+    active = 1,
+    mySlot = function() return 0 end,
+  }, { __index = Mediated })
+
+  screen:noteSlot({ t = "send", slot = 0, text = "CHARMANDER", hp = 30,
+                    status = "SLP" })
+  eq(screen.slots[0].status, "SLP", "a send that walked in asleep shows SLEEP")
+  eq(Battlefield.cardModel(screen.slots[0]).status, "SLP",
+     "...and the card the arena draws agrees")
+
+  screen:noteSlot({ t = "status", slot = 0, text = "CHARMANDER woke up" })
+  screen:syncMineStatus({ t = "status", slot = 0, text = "CHARMANDER woke up" })
+  eq(screen.slots[0].status, nil, "a wake with no token takes the chip off")
+  eq(Battlefield.cardModel(screen.slots[0]).status, nil, "...the card too")
+  eq(screen.mine[1].status, nil, "...and the fight sheet")
+  eq(screen.game.save.party[1].status, nil, "...and the save mon behind it")
+
+  -- Every other standing condition, the way an item cure arrives.
+  for _, token in ipairs({ "PSN", "BRN", "FRZ", "PAR", "TOX" }) do
+    screen:noteSlot({ t = "status", slot = 0, status = token,
+                      text = "was afflicted" })
+    eq(screen.slots[0].status, token, token .. " lands on the chip")
+    screen:noteSlot({ t = "status", slot = 0, text = "recovered" })
+    eq(screen.slots[0].status, nil, "...and an item cure clears " .. token)
+  end
+
+  -- A residual `damage` names the status that dealt it; it must not be
+  -- readable as a lift, and a damage that names none must not wipe the chip.
+  screen:noteSlot({ t = "status", slot = 0, status = "BRN", text = "burned" })
+  screen:noteSlot({ t = "damage", slot = 0, hp = 28 })
+  eq(screen.slots[0].status, "BRN",
+     "a hit that did not mention a condition leaves the chip")
+  screen:noteSlot({ t = "damage", slot = 0, hp = 24, status = "BRN" })
+  eq(screen.slots[0].status, "BRN",
+     "...and a residual that names it keeps it")
+
+  -- Parked arrival: the departing monster keeps its chip; a cure in the
+  -- window belongs to the newcomer.
+  screen:noteSlot({ t = "send", slot = 2, text = "PIDGEY", hp = 24,
+                    status = "SLP" })
+  screen:noteSlot({ t = "send", slot = 2, text = "RATTATA", hp = 21,
+                    status = "PSN" })
+  eq(screen.slots[2].status, "SLP",
+     "the departing chip stays while the arrival is parked")
+  eq(screen.slots[2].pending.status, "PSN", "...the newcomer carries its own")
+  screen:noteSlot({ t = "status", slot = 2, text = "recovered" })
+  eq(screen.slots[2].status, "SLP",
+     "a cure in the window is not the departing mon's")
+  eq(screen.slots[2].pending.status, nil, "...it clears the newcomer")
 end
 
 -- ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Status chips on the mon card stayed after a wake, a thaw, or a status-heal item (Awakening, Antidote, Burn Heal, Ice Heal, Parlyz Heal, Full Heal, Full Restore, Poké Flute). Same bug for SLP, PSN, BRN, FRZ, PAR, and TOX.
- The referee already sent a `status` event with no token for a lift (`BattleSim/Events.lua`). Both screens only wrote the chip when that field was present, so a clear was a no-op.
- MMO 1v1 now clears the seat (and the save mon behind it). Refereed co-op applies the same reading to `mon.status`, which is what the arena plate draws. A residual `damage` or a `send` that never mentioned a condition still leaves the chip alone.

## Test plan
- [ ] Sleep a mon, let it wake: SLEEP chip leaves the card
- [ ] Cure each of PSN / BRN / FRZ / PAR / TOX with the matching item (and Full Heal / Full Restore): chip leaves
- [ ] Inflict a status mid-fight: chip still appears
- [ ] After an item cure, the party is still healthy in the next fight
- [ ] `luajit mods/rby_mmo/tests/mediated_battle_client.lua`
- [ ] `luajit mods/rby_mmo/tests/coop_mediated.lua`