### PR TITLE
fix: fill the catch name and status screens on the Gen 1 arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **After a catch, the name and status screens fill the window.** On the
+  Gen 1 battlefield those pages are still 160×144, and the engine keeps the
+  640×360 arena underneath them, so the letter grid and the STATUS /
+  Attack / Defense / Speed / Special page sat as a postage stamp in the
+  middle of the fight. They now take the window (fill-scale at Game Boy
+  size) for the catch, and the status page is shown before the nickname
+  question so the numbers are readable.
+
 ### Added
 
 - **The POKéMON menu shows the POKéMON.** Picking who to send out — the

--- a/src/Gen.lua
+++ b/src/Gen.lua
@@ -198,6 +198,107 @@ function M.nicknamePromptText(game, displayName)
   return "Do you want to\ngive a nickname\nto " .. name .. "?"
 end
 
+-- ------- catch pages on the battlefield
+--
+-- NamingScreen, SummaryMenu and the nickname confirm are 160×144 pages.
+-- Game.lua keeps a wide battle's surface (640×360 here) and only X-centres
+-- those pages (`classicOffset`), so after a catch they land as a postage
+-- stamp in the middle of the arena. Claiming the wide-battle slot at GB
+-- size with fill-scale makes the page fill the window the way every other
+-- naming / status screen in this game does.
+--
+-- Only Gen 1, and only while a battlefield fight is actually on the stack:
+-- Gold paints window-space via `drawsWidescreen`, and Oak / the NAME RATER
+-- must keep the ordinary letterbox.
+
+M.CATCH_PAGE_W = 160
+M.CATCH_PAGE_H = 144
+
+function M.catchPageOverBattlefield(game)
+  if M.generation(game) ~= 1 then return false end
+  local states = game and game.stack and game.stack.states
+  if type(states) ~= "table" then return false end
+  for i = 1, #states do
+    local state = states[i]
+    if state and type(state.usesBattlefield) == "function" then
+      local ok, yes = pcall(state.usesBattlefield, state)
+      if ok and yes then return true end
+    end
+  end
+  return false
+end
+
+function M.fitCatchPage(screen, game)
+  if type(screen) ~= "table" then return screen end
+  if not M.catchPageOverBattlefield(game) then return screen end
+  screen.isWideBattleLayout = function() return true end
+  screen.uiSize = function()
+    return M.CATCH_PAGE_W, M.CATCH_PAGE_H
+  end
+  screen.wantsFillScale = function() return true end
+  -- A TextBox only paints the bottom strip. The take-over canvas is
+  -- 160×144; without paper the clipped 640×360 arena would show through
+  -- the top 96px. Opaque pages already fill themselves.
+  if not screen.isOpaque then
+    local baseDraw = screen.draw
+    if type(baseDraw) == "function" then
+      screen.draw = function(self, ...)
+        local love = rawget(_G, "love")
+        local g = love and love.graphics
+        if g and g.setColor and g.rectangle then
+          g.setColor(1, 1, 1, 1)
+          g.rectangle("fill", 0, 0, M.CATCH_PAGE_W, M.CATCH_PAGE_H)
+        end
+        return baseDraw(self, ...)
+      end
+    end
+  end
+  return screen
+end
+
+-- The status screen (HP, STATUS, ATTACK / DEFENSE / SPEED / SPECIAL) for
+-- the monster just caught, sized the same way as the naming grid. `onDone`
+-- runs after the player closes page 2. Returns false when no page went up
+-- so the caller can go straight to the nickname prompt.
+function M.showCaughtStatus(game, mon, onDone)
+  if not (type(game) == "table" and type(mon) == "table") then return false end
+  if not M.catchPageOverBattlefield(game) then return false end
+  local pushed
+  local ok = pcall(function()
+    pushed = mod.ui.push(game, "SummaryMenu", mon)
+  end)
+  if not (ok and type(pushed) == "table") then return false end
+  M.fitCatchPage(pushed, game)
+  local baseUpdate = pushed.update
+  if type(onDone) == "function" and type(baseUpdate) == "function" then
+    local closed = false
+    pushed.update = function(self, dt)
+      local page = self.page
+      local out = baseUpdate(self, dt)
+      -- StatusScreen: A/B on page 2 pops. After that call the page is still
+      -- 2 but the screen is gone; membership is the honest closed test.
+      if not closed and page == 2 then
+        local stack = self.game and self.game.stack and self.game.stack.states
+        local still = false
+        if type(stack) == "table" then
+          for i = 1, #stack do
+            if stack[i] == self then
+              still = true
+              break
+            end
+          end
+        end
+        if not still then
+          closed = true
+          onDone()
+        end
+      end
+      return out
+    end
+  end
+  return true
+end
+
 -- Put the letter grid up for `mon`, and write what was typed onto it.
 --
 -- `onDone` is called with the typed name (or nil) *after* the grid has left
@@ -258,6 +359,7 @@ function M.askNickname(game, mon, displayName, onDone)
       .. "RATER")
     return false
   end
+  M.fitCatchPage(pushed, game)
   return true
 end
 

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -995,10 +995,11 @@ end
 
 -- ------- the prompt a catch earns
 --
--- "Do you want to give a nickname to X?", and the letter grid behind a YES.
--- The engine asks this of every wild the player catches on its own path
--- (BattleState:askNicknameUI); an MMO catch is granted by this mod, so this
--- is where the same two screens are put up for it.
+-- Status screen (when the arena would shrink it), then "Do you want to
+-- give a nickname to X?", then the letter grid behind a YES.
+-- The engine asks the last two of every wild the player catches on its own
+-- path (BattleState:askNicknameUI); an MMO catch is granted by this mod, so
+-- this is where those screens are put up for it.
 --
 -- The rhythm is vanilla's rather than two boxes at once: CONFIRM prints the
 -- sentence and opens the yes/no under it once the text has finished, and only
@@ -1018,22 +1019,33 @@ function M:askNickname(game, mon, displayName, onDone)
     finish(nil)
     return false
   end
-  local pushed = self:confirm(game, Gen.nicknamePromptText(game, displayName),
-    function(yes)
-      if not yes then return finish(nil) end
-      if not Gen.askNickname(game, mon, displayName, finish) then
-        finish(nil)
-      end
-    end)
-  if type(pushed) ~= "table" then
-    -- No box went up (a build with no UI at all), so the answer is the one a
-    -- NO would have given rather than a fight that never ends.
-    mod.log:warn("could not ask about a nickname for the POKeMON you just "
-      .. "caught; it keeps its species name")
-    finish(nil)
-    return false
+  local function askName()
+    local pushed = self:confirm(game, Gen.nicknamePromptText(game, displayName),
+      function(yes)
+        if not yes then return finish(nil) end
+        if not Gen.askNickname(game, mon, displayName, finish) then
+          finish(nil)
+        end
+      end)
+    if type(pushed) ~= "table" then
+      -- No box went up (a build with no UI at all), so the answer is the one a
+      -- NO would have given rather than a fight that never ends.
+      mod.log:warn("could not ask about a nickname for the POKeMON you just "
+        .. "caught; it keeps its species name")
+      finish(nil)
+      return false
+    end
+    -- Same postage-stamp problem as the grid: the confirm is a 160×144
+    -- TextBox X-centred on the 640×360 arena unless it takes the window.
+    Gen.fitCatchPage(pushed, game)
+    return true
   end
-  return true
+  -- Status / numbers first when the arena would have shrunk that page;
+  -- otherwise the nickname question is the first thing up, as before.
+  if Gen.showCaughtStatus(game, mon, askName) then
+    return true
+  end
+  return askName()
 end
 
 -- A question with named answers, where **B is an answer and not an escape**.

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -26940,6 +26940,124 @@ do
   end
 end
 
+-- ------- catch pages must fill the window, not the arena's postage stamp
+--
+-- NamingScreen / SummaryMenu / the nickname confirm are 160×144. Game.lua
+-- keeps a wide battle's 640×360 surface and only X-centres those pages, so
+-- they used to render tiny in the middle of the battlefield. fitCatchPage
+-- claims the wide-battle slot at GB size with fill-scale; only while a
+-- Gen 1 battlefield fight is actually on the stack.
+
+local gen1Data = POKEDEX
+local gen2Data = { gen2Constants = {}, pokemon = { PIDGEY = { name = "PIDGEY" } } }
+
+do
+  local battle = { usesBattlefield = function() return true end }
+  local game = { data = gen1Data, stack = { states = { battle } } }
+  local page = {}
+  Gen.fitCatchPage(page, game)
+  check(page.isWideBattleLayout and page:isWideBattleLayout(),
+        "a catch page over the arena claims the wide-battle slot")
+  local uw, uh = page:uiSize()
+  eq(uw, 160, "at Game Boy width, so fill-scale owns the window")
+  eq(uh, 144, "and Game Boy height")
+  check(page:wantsFillScale(), "and asks to fill the window")
+end
+
+do
+  local page = {}
+  Gen.fitCatchPage(page, { data = gen1Data, stack = { states = {} } })
+  eq(page.isWideBattleLayout, nil,
+     "Oak / the NAME RATER keep the ordinary letterbox -- no fight underneath")
+end
+
+do
+  local battle = { usesBattlefield = function() return true end }
+  local gold = { data = gen2Data, stack = { states = { battle } } }
+  local page = {}
+  Gen.fitCatchPage(page, gold)
+  eq(page.isWideBattleLayout, nil,
+     "Gold is left alone -- it already paints window-space")
+end
+
+do
+  local painted
+  local page = {
+    draw = function() painted = true end,
+  }
+  local battle = { usesBattlefield = function() return true end }
+  local game = { data = gen1Data, stack = { states = { battle } } }
+  Gen.fitCatchPage(page, game)
+  local rects = {}
+  local prevLove = _G.love
+  _G.love = { graphics = {
+    setColor = function() end,
+    rectangle = function(_, _, _, w, h)
+      rects[#rects + 1] = { w = w, h = h }
+    end,
+  } }
+  page:draw()
+  _G.love = prevLove
+  eq(painted, true, "the confirm still draws its own box")
+  eq(rects[1] and rects[1].w, 160,
+     "...after a full-page paper fill, so the clipped arena does not show")
+  eq(rects[1] and rects[1].h, 144, "...covering the take-over canvas")
+end
+
+do
+  local page = { isOpaque = true, draw = function() end }
+  local battle = { usesBattlefield = function() return true end }
+  local game = { data = gen1Data, stack = { states = { battle } } }
+  local baseDraw = page.draw
+  Gen.fitCatchPage(page, game)
+  eq(page.draw, baseDraw,
+     "an opaque naming / status page already fills 160×144 -- no extra paper")
+end
+
+-- Status first when the arena is up: the numbers page, then the nickname.
+do
+  local pushed, asked
+  local prevUi = stubMod.ui
+  stubMod.ui = {
+    push = function(_, id, mon)
+      pushed = { id = id, mon = mon, page = 1, game = nil }
+      function pushed:update()
+        if self.page == 1 then
+          self.page = 2
+        else
+          local stack = self.game.stack.states
+          for i = #stack, 1, -1 do
+            if stack[i] == self then table.remove(stack, i) end
+          end
+        end
+      end
+      return pushed
+    end,
+  }
+  local battle = { usesBattlefield = function() return true end }
+  local game = { data = gen1Data, stack = { states = { battle } } }
+  local mon = { species = "PIDGEY", level = 5, hp = 12, stats = { hp = 20 } }
+  local shown = Gen.showCaughtStatus(game, mon, function() asked = true end)
+  stubMod.ui = prevUi
+  eq(shown, true, "the status page goes up over the arena")
+  eq(pushed.id, "SummaryMenu", "and it is the engine STATUS screen")
+  eq(pushed.mon, mon, "for the monster that was just caught")
+  check(pushed.isWideBattleLayout and pushed:isWideBattleLayout(),
+        "sized to fill the window, not the arena's postage stamp")
+  pushed.game = game
+  game.stack.states[#game.stack.states + 1] = pushed
+  pushed:update(1 / 60)
+  eq(asked, nil, "page 1 only turns the page")
+  pushed:update(1 / 60)
+  eq(asked, true, "closing page 2 is what releases the nickname prompt")
+end
+
+do
+  eq(Gen.showCaughtStatus({ data = gen1Data, stack = { states = {} } },
+                          { species = "PIDGEY" }, function() end),
+     false, "no status page when there is no arena underneath")
+end
+
 -- CoopBattle's grant records the same things: it is a twin of the mediated
 -- one, and a co-op catcher's save must not end up different from a 1v1's.
 do


### PR DESCRIPTION
## Summary
- After a Gen 1 catch on the battlefield, the nickname grid, confirm box, and STATUS / numbers page were still 160×144 and sat as a postage stamp in the middle of the 640×360 arena.
- Those pages now claim the wide-battle slot at Game Boy size with fill-scale so they take the window. The status screen is shown first, then the nickname question.
- Oak, the Name Rater, and Gold are unchanged. No PROTOCOL bump: nothing new travels on the wire.

## Test plan
- [x] `luajit tests/rby_mmo_test.lua` — 5223/5223
- [ ] Catch a wild POKéMON in a Gen 1 arena fight and confirm the status page and naming grid fill the window
- [ ] Decline a nickname and confirm the fight can still be left
- [ ] Confirm a Gold catch and an overworld naming screen (Oak / Name Rater) still look as they did