### PR TITLE
fix: offer evolutions from co-op level-ups, including mid-battle (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ here must match `manifest.version`.
 
 ### Fixed
 
+- **Levels gained in a co-op battle now offer evolutions.** The engine
+  moved that check onto `BattleState:finish` (on the battle screen, before
+  the white-out). A 2-on-2 never runs that finish — it pops the buried
+  battle up front and only called `afterBattle`, which does not walk
+  `leveledUp` — so a Caterpie that hit 7 in co-op stayed a Caterpie until
+  the next wild level-up or a Rare Candy. The co-op screen already recorded
+  who levelled; both the walk-in and invite-joiner exits now run the
+  engine's own `Evolution.checkParty` (and Gold's `Evolution.plan`) off
+  that set.
+
 - **After a catch, the name and status screens fill the window.** On the
   Gen 1 battlefield those pages are still 160×144, and the engine keeps the
   640×360 arena underneath them, so the letter grid and the STATUS /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ here must match `manifest.version`.
 
 ### Added
 
+- **Mid-battle evolutions on co-op / MMO / solo custom fights.** A level-up
+  that qualifies now plays the evolution movie on the arena after that
+  mon's "grew to level N!" lines — flash, sparkle, B-cancel after the
+  80-frame grace, same clock as the engine's EvolutionState — instead of
+  waiting until the fight ends. Accept and cancel both stick: the
+  after-battle check will not re-offer a prompt the player already
+  answered. Local only, same contract as exp and levels: the save and
+  this client's sprite update; the hub and everyone else keep the
+  uploaded pre-evo sheet for the rest of this fight.
+
 - **The POKéMON menu shows the POKéMON.** Picking who to send out — the
   `PKMN` command mid-fight, the forced pick after a faint, and the party
   an item is aimed at — used to be a list of names and HP over an

--- a/src/Battlefield.lua
+++ b/src/Battlefield.lua
@@ -704,7 +704,7 @@ local NO_FX = {
 -- NO_FX -- a record that is equal in value but not identical.
 local SEAT_FX = {
   lunge = true, flash = true, faint = true, spawn = true,
-  recall = true, wobble = true,
+  recall = true, wobble = true, evolve = true,
 }
 
 local function fxT(v)
@@ -811,6 +811,14 @@ function M.fxSeat(fx, side, seatIndex)
         out.dx = out.dx + dir * M.FX_LUNGE * M.fxLunge(e.t)
       elseif e.kind == "flash" then
         local f = M.fxFlash(e.t)
+        if f > out.flash then out.flash = f end
+      elseif e.kind == "evolve" then
+        -- Faster than a hit flash: fxFlash is two pulses over the whole
+        -- duration, and this movie lasts ~6s, so that envelope would sit
+        -- dim for most of the swap. The pic is already trading places on
+        -- the cart's accelerating loop; this is the silhouette on top.
+        local t = fxT(e.t)
+        local f = math.abs(math.sin(t * math.pi * 16)) * (0.4 + 0.6 * t)
         if f > out.flash then out.flash = f end
       elseif e.kind == "faint" then
         local drop, alpha = M.fxFaint(e.t)
@@ -1559,6 +1567,20 @@ function M.layout(ctx)
       foe = pendingCount(ctx.pendingSeats, "foe"),
     },
     frame = num(ctx.frame, 0),
+    -- Bench evolution movie: a front pic in the middle of the field, with
+    -- the same white pulse the on-plate `evolve` fx uses.
+    evolveCenter = (function()
+      local evo = ctx.evolveCenter
+      if type(evo) ~= "table" or evo.front == nil then return nil end
+      return {
+        front = evo.front,
+        flash = clamp(num(evo.flash, 0), 0, 1),
+        x = M.MIDLINE,
+        y = math.floor(M.FIELD_TOP + M.FIELD_HEIGHT * 0.42),
+        drawW = M.MON_DRAW * 1.35,
+        drawH = M.MON_DRAW * 1.35,
+      }
+    end)(),
   }
 end
 
@@ -4012,6 +4034,19 @@ function M.draw(battle, ctx, eng)
       for _, mon in ipairs(layout.mons) do
         pcall(drawMonIcon, mon, layout.frame,
           hasFx and M.fxSeat(layout.fx, mon.side, mon.seatIndex) or nil)
+      end
+      if layout.evolveCenter then
+        local evo = layout.evolveCenter
+        pcall(drawMonIcon, {
+          x = evo.x,
+          y = evo.y,
+          front = evo.front,
+          drawW = evo.drawW,
+          drawH = evo.drawH,
+        }, layout.frame, {
+          dx = 0, dy = 0, alpha = 1, scale = 1,
+          flash = evo.flash, hidden = false,
+        })
       end
       -- Balls / poofs sit above the mons (a ball occludes the seat it lands
       -- on) but under the HUD, which never yields the field.

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -382,6 +382,130 @@ function M.buriedFinisher(engine)
   return finish
 end
 
+local function gen2Daytime()
+  local ok, Palettes = pcall(require, "src.render.Palettes")
+  if not (ok and type(Palettes) == "table"
+      and type(Palettes.clockDaytime) == "function") then
+    return nil
+  end
+  local good, tod = pcall(Palettes.clockDaytime)
+  if good then return tod end
+  return nil
+end
+
+-- Gold's EvolveAfterBattle: flag the slots that levelled, plan the rows, push
+-- Gen2EvolutionAnim one at a time. B-cancel is a real choice there, so a
+-- missing screen skips rather than applying the species change outright.
+local function offerEvolutionsGen2(game, leveledUp)
+  local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.plan) == "function") then
+    mod.log:warn("the engine's Gen 2 evolution module is unavailable, so "
+      .. "POKéMON that levelled in this battle were not offered evolutions "
+      .. "-- level again in a wild fight or use a RARE CANDY")
+    return false
+  end
+  local party = game.save and game.save.party
+  if type(party) ~= "table" then return false end
+  local flags = {}
+  local flagged = false
+  for i, mon in ipairs(party) do
+    if leveledUp[mon] then
+      flags[i] = true
+      flagged = true
+    end
+  end
+  if not flagged then return false end
+  local planned = Evolution.plan(game.data, party, flags,
+    { timeOfDay = gen2Daytime() })
+  if type(planned) ~= "table" or #planned == 0 then return false end
+  if not (mod.ui and type(mod.ui.push) == "function") then
+    mod.log:warn("could not open the evolution screen, so POKéMON that "
+      .. "levelled in this battle were not offered evolutions -- level "
+      .. "again in a wild fight or use a RARE CANDY")
+    return false
+  end
+
+  local pending = {}
+  for i, row in ipairs(planned) do pending[i] = row end
+  local function nextOne()
+    local row = table.remove(pending, 1)
+    if not row then return end
+    local pushed
+    local ran = pcall(function()
+      pushed = mod.ui.push(game, "Gen2EvolutionAnim", {
+        mon = row.mon,
+        entry = row.entry,
+        index = row.index,
+        party = party,
+        save = game.save,
+        onDone = function()
+          local stack = game.stack
+          if stack and stack.pop then stack:pop() end
+          nextOne()
+        end,
+      })
+    end)
+    if not (ran and type(pushed) == "table") then
+      mod.log:warn("could not open the evolution screen for %s; it can still "
+        .. "evolve by levelling again or with a RARE CANDY",
+        tostring(row.mon and (row.mon.nickname or row.mon.species)))
+      nextOne()
+    end
+  end
+  nextOne()
+  return true
+end
+
+-- Level-up evolutions the engine's BattleState:finish would have offered.
+--
+-- A co-op (or solo-mediated) fight never runs that finish: it pops the buried
+-- battle up front and later only calls onFinish, which is OverworldState:
+-- afterBattle. afterBattle does not walk `leveledUp` -- Evolution.checkParty
+-- lives on BattleState:finish, on the battle screen, before the white-out
+-- (end_of_battle.asm / #1656). Stamping the set onto the buried battle and
+-- handing it to afterBattle therefore offered nothing, which is why a mon
+-- that hit its evolution level in a 2-on-2 stayed unevolved until the next
+-- wild level-up or a Rare Candy (#65).
+--
+-- `leveledUp` is the set CoopBattle.levelled (and SoloBattle.levelledSince)
+-- already records, keyed by the save-party monster Evolution.checkParty
+-- walks. Absent or empty is a real no -- nothing levelled, nothing to offer.
+function M.offerEvolutions(game, leveledUp, result)
+  if not (game and type(leveledUp) == "table") then return false end
+  local any = false
+  for _ in pairs(leveledUp) do
+    any = true
+    break
+  end
+  if not any then return false end
+
+  if Gen.generation(game) == 2 then
+    -- Gold only sweeps after a win (ExitBattle's wBattleResult & $f). Co-op
+    -- spells a loss "loss"; the engine spells it "lose".
+    local outcome = result
+    if outcome == "loss" then outcome = "lose" end
+    if outcome == "lose" or outcome == "draw" then return false end
+    return offerEvolutionsGen2(game, leveledUp)
+  end
+
+  local ok, Evolution = pcall(require, "src.pokemon.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.checkParty) == "function") then
+    mod.log:warn("the engine's evolution module is unavailable, so POKéMON "
+      .. "that levelled in this battle were not offered evolutions -- level "
+      .. "again in a wild fight or use a RARE CANDY")
+    return false
+  end
+  local ran, err = pcall(Evolution.checkParty, game, nil, leveledUp)
+  if not ran then
+    mod.log:warn("evolutions from this fight could not be offered (%s); "
+      .. "level again in a wild fight or use a RARE CANDY", tostring(err))
+    return false
+  end
+  return true
+end
+
 -- Tell the buried engine battle how the fight it never ran went.
 --
 -- `engine` is the frozen BattleState underneath, `game` is what holds the
@@ -405,6 +529,12 @@ function M.finishBuriedBattle(engine, game, result, blackout)
     outcome = "lose"
     engineRitual = true
   end
+
+  -- Before afterBattle: vanilla offers evolutions on the battle screen, then
+  -- whites out. This fight already popped that screen, so the offer sits on
+  -- the overworld -- the same place the forget-a-move menu already goes --
+  -- and pumpBlackout waits for it when a warp is owed.
+  M.offerEvolutions(game, engine.leveledUp, result)
 
   local ok, err = pcall(finish, outcome)
   if not ok then
@@ -2369,19 +2499,23 @@ function M:syntheticFinish(game, plan, coopState)
           tostring(class), tostring(err))
       end
     end
-    -- Stub battle for afterBattle: evolutions read leveledUp; kind/oppClass
-    -- keep the Oak's Lab rival blackout exception honest if it ever lands here.
+    -- Stub battle for afterBattle: kind/oppClass keep the Oak's Lab rival
+    -- blackout exception honest if it ever lands here. Evolutions do not
+    -- read leveledUp off this stub -- afterBattle never did; they go through
+    -- M.offerEvolutions, the same check the walk-in path runs.
     local stub = {
       kind = "trainer",
       oppClass = class,
       partyIndex = partyIndex,
       leveledUp = coopState and coopState.leveledUp or nil,
     }
+    M.offerEvolutions(game, stub.leveledUp, "win")
     if type(ow.afterBattle) == "function" then
       local ok, err = pcall(ow.afterBattle, ow, "win", stub)
       if not ok then
-        mod.log:warn("co-op afterBattle could not run (%s); evolutions from "
-          .. "this fight may need a reload from your last save", tostring(err))
+        mod.log:warn("co-op afterBattle could not run (%s); trainer scripts "
+          .. "or map flags for this fight may need a reload from your last "
+          .. "save", tostring(err))
       end
     end
     ow.engaging = false
@@ -2660,9 +2794,9 @@ function M:onBattleOver(result, game, state, toLearn)
   -- place that knows how to finish a trainer off -- can reach it.
   if self.engineBattle then
     -- What levelled, carried across to the battle that is about to be told
-    -- how this went: OverworldState:afterBattle offers evolutions to exactly
-    -- the mons the battle recorded, and the battle that recorded them here is
-    -- the co-op one, not the one holding the flag.
+    -- how this went. finishBuriedBattle runs Evolution.checkParty off this
+    -- set (afterBattle does not); the battle that recorded them here is the
+    -- co-op one, not the one holding the flag.
     -- Read off the *battle*, not the sim: exp is applied per client now, so
     -- the list of what levelled is the one this client built for its own
     -- party -- which is exactly the party the evolution check will walk.

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -63,6 +63,7 @@ local Wire = need("Wire")
 local Gen = need("Gen")
 local CoopBattle = need("CoopBattle")
 local Mediated = need("MediatedBattle")
+local EvolveFx = need("EvolveFx")
 
 -- How often a standing offer is re-attempted while this client is busy.
 --
@@ -382,81 +383,6 @@ function M.buriedFinisher(engine)
   return finish
 end
 
-local function gen2Daytime()
-  local ok, Palettes = pcall(require, "src.render.Palettes")
-  if not (ok and type(Palettes) == "table"
-      and type(Palettes.clockDaytime) == "function") then
-    return nil
-  end
-  local good, tod = pcall(Palettes.clockDaytime)
-  if good then return tod end
-  return nil
-end
-
--- Gold's EvolveAfterBattle: flag the slots that levelled, plan the rows, push
--- Gen2EvolutionAnim one at a time. B-cancel is a real choice there, so a
--- missing screen skips rather than applying the species change outright.
-local function offerEvolutionsGen2(game, leveledUp)
-  local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
-  if not (ok and type(Evolution) == "table"
-      and type(Evolution.plan) == "function") then
-    mod.log:warn("the engine's Gen 2 evolution module is unavailable, so "
-      .. "POKéMON that levelled in this battle were not offered evolutions "
-      .. "-- level again in a wild fight or use a RARE CANDY")
-    return false
-  end
-  local party = game.save and game.save.party
-  if type(party) ~= "table" then return false end
-  local flags = {}
-  local flagged = false
-  for i, mon in ipairs(party) do
-    if leveledUp[mon] then
-      flags[i] = true
-      flagged = true
-    end
-  end
-  if not flagged then return false end
-  local planned = Evolution.plan(game.data, party, flags,
-    { timeOfDay = gen2Daytime() })
-  if type(planned) ~= "table" or #planned == 0 then return false end
-  if not (mod.ui and type(mod.ui.push) == "function") then
-    mod.log:warn("could not open the evolution screen, so POKéMON that "
-      .. "levelled in this battle were not offered evolutions -- level "
-      .. "again in a wild fight or use a RARE CANDY")
-    return false
-  end
-
-  local pending = {}
-  for i, row in ipairs(planned) do pending[i] = row end
-  local function nextOne()
-    local row = table.remove(pending, 1)
-    if not row then return end
-    local pushed
-    local ran = pcall(function()
-      pushed = mod.ui.push(game, "Gen2EvolutionAnim", {
-        mon = row.mon,
-        entry = row.entry,
-        index = row.index,
-        party = party,
-        save = game.save,
-        onDone = function()
-          local stack = game.stack
-          if stack and stack.pop then stack:pop() end
-          nextOne()
-        end,
-      })
-    end)
-    if not (ran and type(pushed) == "table") then
-      mod.log:warn("could not open the evolution screen for %s; it can still "
-        .. "evolve by levelling again or with a RARE CANDY",
-        tostring(row.mon and (row.mon.nickname or row.mon.species)))
-      nextOne()
-    end
-  end
-  nextOne()
-  return true
-end
-
 -- Level-up evolutions the engine's BattleState:finish would have offered.
 --
 -- A co-op (or solo-mediated) fight never runs that finish: it pops the buried
@@ -471,39 +397,16 @@ end
 -- `leveledUp` is the set CoopBattle.levelled (and SoloBattle.levelledSince)
 -- already records, keyed by the save-party monster Evolution.checkParty
 -- walks. Absent or empty is a real no -- nothing levelled, nothing to offer.
-function M.offerEvolutions(game, leveledUp, result)
-  if not (game and type(leveledUp) == "table") then return false end
-  local any = false
-  for _ in pairs(leveledUp) do
-    any = true
-    break
-  end
-  if not any then return false end
-
-  if Gen.generation(game) == 2 then
-    -- Gold only sweeps after a win (ExitBattle's wBattleResult & $f). Co-op
-    -- spells a loss "loss"; the engine spells it "lose".
-    local outcome = result
-    if outcome == "loss" then outcome = "lose" end
-    if outcome == "lose" or outcome == "draw" then return false end
-    return offerEvolutionsGen2(game, leveledUp)
-  end
-
-  local ok, Evolution = pcall(require, "src.pokemon.Evolution")
-  if not (ok and type(Evolution) == "table"
-      and type(Evolution.checkParty) == "function") then
-    mod.log:warn("the engine's evolution module is unavailable, so POKéMON "
-      .. "that levelled in this battle were not offered evolutions -- level "
-      .. "again in a wild fight or use a RARE CANDY")
-    return false
-  end
-  local ran, err = pcall(Evolution.checkParty, game, nil, leveledUp)
-  if not ran then
-    mod.log:warn("evolutions from this fight could not be offered (%s); "
-      .. "level again in a wild fight or use a RARE CANDY", tostring(err))
-    return false
-  end
-  return true
+-- `evoResolved` is the set a mid-battle movie already answered (accept or
+-- cancel): those mons must not be offered again.
+--
+-- Body lives on EvolveFx so Sessions:endMediated can call the same offer
+-- without requiring this module (that graph is a cycle).
+function M.offerEvolutions(game, leveledUp, result, evoResolved)
+  return EvolveFx.offerEvolutions(game, leveledUp, result, evoResolved, {
+    warn = function(fmt, ...) mod.log:warn(fmt, ...) end,
+    ui = mod.ui,
+  })
 end
 
 -- Tell the buried engine battle how the fight it never ran went.
@@ -534,7 +437,7 @@ function M.finishBuriedBattle(engine, game, result, blackout)
   -- whites out. This fight already popped that screen, so the offer sits on
   -- the overworld -- the same place the forget-a-move menu already goes --
   -- and pumpBlackout waits for it when a warp is owed.
-  M.offerEvolutions(game, engine.leveledUp, result)
+  M.offerEvolutions(game, engine.leveledUp, result, engine.evoResolved)
 
   local ok, err = pcall(finish, outcome)
   if not ok then
@@ -2508,8 +2411,9 @@ function M:syntheticFinish(game, plan, coopState)
       oppClass = class,
       partyIndex = partyIndex,
       leveledUp = coopState and coopState.leveledUp or nil,
+      evoResolved = coopState and coopState.evoResolved or nil,
     }
-    M.offerEvolutions(game, stub.leveledUp, "win")
+    M.offerEvolutions(game, stub.leveledUp, "win", stub.evoResolved)
     if type(ow.afterBattle) == "function" then
       local ok, err = pcall(ow.afterBattle, ow, "win", stub)
       if not ok then
@@ -2801,6 +2705,7 @@ function M:onBattleOver(result, game, state, toLearn)
     -- the list of what levelled is the one this client built for its own
     -- party -- which is exactly the party the evolution check will walk.
     self.engineBattle.leveledUp = state and state.leveledUp or nil
+    self.engineBattle.evoResolved = state and state.evoResolved or nil
     self.encounter = { engine = self.engineBattle, game = game }
     self.engineBattle = nil
   end

--- a/src/CoopBattle.lua
+++ b/src/CoopBattle.lua
@@ -75,6 +75,10 @@ local Vfx = need("Vfx")
 -- `src/battle/Experience.lua` twin, so a mediated Gen 2 faint is priced through
 -- the engine's own `src/battle/gen2/Mon` primitives instead.
 local Exp2 = need("Exp2")
+-- Mid-battle evolution movie: timing + apply. Drawing stays on this screen
+-- and on Battlefield -- EvolutionState is a 160x144 page and must not be
+-- pushed onto the arena.
+local EvolveFx = need("EvolveFx")
 -- The 1v1 mediated client, for its snapshots and its senders rather than for
 -- its screen: what a party looks like on the wire must not depend on how many
 -- monsters are on the field.
@@ -1568,6 +1572,13 @@ function M:update(dt)
       self:stepExpFill()
       return
     end
+    -- The evolution movie holds the queue the same way a filling strip does:
+    -- it is not a text page, A does not skip it, and MSG_AUTO_ADVANCE must
+    -- not dismiss "is evolving!" while the flash is still running.
+    if self.evolving then
+      self:stepEvolve()
+      return
+    end
     if self.faintFx then
       self:stepFaint()
       return
@@ -1601,7 +1612,8 @@ function M:update(dt)
       local head = self.messages[1]
       if type(head) == "table"
          and (head.anim or head.drain or head.faintfx or head.expfill
-              or head.wait or head.act or head.ballsend or head.vfxrow) then
+              or head.evolve or head.wait or head.act or head.ballsend
+              or head.vfxrow) then
         -- Hold wait/act/anim behind opening appear line(s). Drop ball chrome
         -- when the post-appear wait starts (not on every page advance), so a
         -- multi-page appear does not begin the gap early.
@@ -1629,6 +1641,8 @@ function M:update(dt)
             self:startDrain(head)
           elseif head.expfill then
             self:startExpFill(head)
+          elseif head.evolve then
+            self:startEvolve(head)
           elseif head.vfxrow then
             -- **Takes no hold.** The sentence this belongs to is the very next
             -- row and the effect is meant to run under it; holding here would
@@ -3809,6 +3823,111 @@ function M:stepExpFill()
   self.expFilling = nil
 end
 
+-- Mid-battle evolution movie. Timing and apply live in EvolveFx; this is the
+-- queue hold, the seat FX, and the line the box keeps up while they run.
+-- Local only: the save and this client's pic update; the hub keeps the
+-- uploaded pre-evo sheet for the rest of this fight.
+function M:evolveSlot(mon)
+  if not (self.sim and mon) then return nil end
+  for _, slot in ipairs(self.sim.slots or {}) do
+    local battler = slot.battler
+    if battler and battler.mon == mon then return slot.index end
+  end
+  return nil
+end
+
+function M:startEvolve(row)
+  local movie = EvolveFx.begin(row)
+  if not movie then return false end
+  self.evolving = movie
+  self.shown = EvolveFx.evolvingLine(movie)
+  self.msgClock = 0
+  local eng = engine
+  EvolveFx.playMusic(self.game, eng and eng.Music)
+  movie.oldSprite = nil
+  movie.newSprite = nil
+  local index = self:evolveSlot(movie.mon)
+  movie.slot = index
+  movie.center = index == nil
+  if index then
+    local slot = self.sim and self.sim:slot(index)
+    local battler = slot and slot.battler
+    movie.oldSprite = battler and battler.sprite
+    self:emitFx("evolve", index, nil, { duration = EvolveFx.MOVIE_SECONDS })
+    self:emitVfx({ style = "sparkle", palette = "FAIRY", delivery = "burst" },
+      index)
+    self:emitVfx({ style = "shine", palette = "NORMAL", delivery = "burst" },
+      index)
+  end
+  return true
+end
+
+function M:stepEvolve()
+  local movie = self.evolving
+  if type(movie) ~= "table" then
+    self.evolving = nil
+    return
+  end
+  local input = self.game and self.game.input
+  local pressedB = input and input:wasPressed("b")
+  EvolveFx.advance(movie, nil, pressedB)
+  if not movie.done then return end
+  self.evolving = nil
+  local line
+  if movie.canceled then
+    EvolveFx.markResolved(self, movie.mon)
+    line = EvolveFx.stoppedLine(movie)
+  else
+    local applied = EvolveFx.applyTo(self.game, movie, self)
+    if applied then
+      EvolveFx.markResolved(self, applied)
+      self:refreshAfterEvolve(applied)
+      EvolveFx.playCry(self.game, engine and engine.Sound, movie.into)
+      for _, moveId in ipairs(EvolveFx.learnMoveIds(self.game, applied)) do
+        self:teach(applied, movie.name, moveId)
+      end
+      line = EvolveFx.evolvedLine(movie, self.game)
+    else
+      -- Apply failed: leave leveledUp so the after-battle fallback still owes
+      -- this mon. The stopped line is honest -- the species did not change.
+      line = EvolveFx.stoppedLine(movie)
+    end
+  end
+  EvolveFx.restoreBattleMusic(self.game, {
+    Music = engine and engine.Music,
+    kind = self:musicKind(),
+    mode = self.mode,
+    trainer = self.trainer,
+    oppClass = self.oppClass,
+    partyIndex = self.partyIndex,
+  })
+  self.shown = line
+  self.msgClock = 0
+end
+
+function M:refreshAfterEvolve(mon)
+  if not mon then return end
+  if not self.sim then return end
+  for _, slot in ipairs(self.sim.slots or {}) do
+    local battler = slot.battler
+    if battler and battler.mon == mon then
+      slot._bfFront = nil
+      slot._bfFrontSpecies = nil
+      local newMax = tonumber(mon.stats and mon.stats.hp) or tonumber(mon.maxHp)
+      if newMax and newMax == newMax and newMax > 0 then
+        newMax = math.floor(newMax)
+        mon.maxHp = newMax
+        battler.mon.maxHp = newMax
+        local hp = tonumber(mon.hp)
+        if hp then
+          hp = math.max(1, math.min(newMax, math.floor(hp)))
+          mon.hp = hp
+        end
+      end
+    end
+  end
+end
+
 -- The fall. The flag goes up *before* the text, which is the engine's order
 -- (BattleState:enemyMonFainted queues the slide and the cry, then says the
 -- line): the sprite is sliding out of its box while the box says why.
@@ -4009,6 +4128,23 @@ function M:snapDisplay()
   -- rather than change what is drawn, and cutting a player's last few lines
   -- off mid-sentence is a worse lie than reading them a moment late.
   self.shownBattler = {}
+  -- A movie in flight is abandoned without applying: the screen is being
+  -- told the field has moved on, and a species change mid-snap would be a
+  -- form the player never saw finish. leveledUp stays so the after-battle
+  -- fallback still offers. Queued (unplayed) evolve rows are kept -- they
+  -- are the fallback's other half, and dropping them here would skip a
+  -- prompt the player never answered.
+  if self.evolving then
+    EvolveFx.restoreBattleMusic(self.game, {
+      Music = engine and engine.Music,
+      kind = self:musicKind(),
+      mode = self.mode,
+      trainer = self.trainer,
+      oppClass = self.oppClass,
+      partyIndex = self.partyIndex,
+    })
+    self.evolving = nil
+  end
   local kept = {}
   for _, row in ipairs(self.messages or {}) do
     -- `ballsend` goes with the swap it belongs to, and it has to: the arc row
@@ -5025,6 +5161,7 @@ function M:drawField()
     local sinking = self:sinkingAt(index)
     local sprite = (sinking and sinking.battler and sinking.battler.sprite)
       or (battler and battler.sprite)
+    sprite = self:evolveDrawSprite(battler, sprite)
     local x, y, scale = self:picOriginFor(index, sprite)
     local hideIntro = introHide and introHide[index]
     if sprite and x and not (hideFoes and theirs)
@@ -5070,6 +5207,7 @@ function M:drawField()
   -- or its focus arrow when they share the edge.
   drawSideStrip(self, self:stripSeats(false), true, self:desiredAllyFocus())
   drawSideStrip(self, self:stripSeats(true), false, self:desiredFoeFocus())
+  self:drawEvolveCenterClassic()
   local foe = self:desiredFoeFocus()
   local Font = engine.Font
   if foe then
@@ -5294,6 +5432,12 @@ local function seatFrontFor(self, slot, battler)
   if not battler then return nil end
   local mon = battler.mon
   local species = mon and mon.species
+  local movie = self.evolving
+  if movie and movie.mon == mon then
+    species = EvolveFx.picSpecies(movie) or species
+    local hit = EvolveFx.formCacheGet(movie, "front", species)
+    if hit ~= nil then return hit or nil end
+  end
   if slot and slot._bfFront ~= nil and slot._bfFrontSpecies == species then
     local cached = slot._bfFront
     return (cached ~= false) and cached or nil
@@ -5326,16 +5470,61 @@ local function seatFrontFor(self, slot, battler)
       end
     end
   elseif eng and eng.BattleState and eng.BattleState.makeBattler and mon and data then
-    local ok, probe = pcall(eng.BattleState.makeBattler, data, mon, false, save)
+    local probeMon = mon
+    if species and species ~= mon.species then
+      probeMon = {
+        species = species,
+        nickname = mon.nickname,
+        level = mon.level or 1,
+        hp = mon.hp or 1,
+        stats = mon.stats or { hp = 1 },
+        moves = mon.moves or { { id = "TACKLE", pp = 1 } },
+        dvs = mon.dvs,
+        shiny = mon.shiny,
+      }
+    end
+    local ok, probe = pcall(eng.BattleState.makeBattler, data, probeMon, false, save)
     if ok and probe and probe.sprite then resolved = probe.sprite end
   end
   -- Fall back to whatever the live battler already holds (may be a back).
   if not resolved then resolved = battler.sprite end
+  if movie and movie.mon == mon then
+    EvolveFx.formCachePut(movie, "front", species, resolved)
+  end
   if slot then
     slot._bfFront = resolved or false
     slot._bfFrontSpecies = species
   end
   return resolved
+end
+
+-- Classic 160x144 pic swap during the movie. Battlefield goes through
+-- seatFrontFor (species key already follows picSpecies); this is the back/front
+-- the GB stage draws from battler.sprite. Lazy: the into pic is probed the
+-- first time the flash wants it, so a missing ROM still plays the text movie.
+function M:evolveDrawSprite(battler, fallback)
+  local movie = self.evolving
+  if not (movie and battler and battler.mon == movie.mon) then
+    return fallback
+  end
+  local species = EvolveFx.picSpecies(movie)
+  local hit = EvolveFx.formCacheGet(movie, "front", species)
+  if hit ~= nil then return hit or fallback end
+  if species == movie.into then
+    if movie.newSprite == nil then
+      local fake = {
+        mon = {
+          species = movie.into,
+          shiny = movie.mon and movie.mon.shiny,
+          level = movie.mon and movie.mon.level,
+        },
+      }
+      movie.newSprite = seatFrontFor(self, nil, fake) or false
+      EvolveFx.formCachePut(movie, "front", movie.into, movie.newSprite)
+    end
+    if movie.newSprite then return movie.newSprite end
+  end
+  return movie.oldSprite or fallback
 end
 
 -- Resolve a party bag icon to a cached Image on the sim slot (once per
@@ -5344,6 +5533,12 @@ local function seatIconFor(self, slot, battler)
   if not battler then return nil end
   local mon = battler.mon
   local species = mon and mon.species
+  local movie = self.evolving
+  if movie and movie.mon == mon then
+    species = EvolveFx.picSpecies(movie) or species
+    local hit = EvolveFx.formCacheGet(movie, "icon", species)
+    if hit ~= nil then return hit or nil end
+  end
   if slot and slot._bfIcon ~= nil and slot._bfIconSpecies == species then
     local cached = slot._bfIcon
     return (cached ~= false) and cached or nil
@@ -5354,10 +5549,11 @@ local function seatIconFor(self, slot, battler)
   local data = self.game and self.game.data
   if Sprites and Sprites.iconPath and mon and data then
     local path = nil
+    local iconSpecies = species or mon.species
     pcall(function()
       local icons = data.icons
-      local def = data.pokemon and data.pokemon[mon.species]
-      local entry = (icons and icons.bySpecies and icons.bySpecies[mon.species])
+      local def = data.pokemon and data.pokemon[iconSpecies]
+      local entry = (icons and icons.bySpecies and icons.bySpecies[iconSpecies])
         or (def and def.icon)
       local name
       if type(entry) == "string" then
@@ -5381,6 +5577,9 @@ local function seatIconFor(self, slot, battler)
       end)
       if ok and img then resolved = img end
     end
+  end
+  if movie and movie.mon == mon then
+    EvolveFx.formCachePut(movie, "icon", species, resolved)
   end
   if slot then
     slot._bfIcon = resolved or false
@@ -5415,6 +5614,45 @@ local function partyFrontFor(self, mon)
     cache[key] = hit
   end
   return hit or nil
+end
+
+function M:evolveCenterFront()
+  local movie = self.evolving
+  if not (movie and movie.center) then return nil end
+  local species = EvolveFx.picSpecies(movie)
+  if species == nil then return nil end
+  local hit = EvolveFx.formCacheGet(movie, "front", species)
+  if hit ~= nil then return hit or nil end
+  local stub = {
+    species = species,
+    shiny = movie.mon and movie.mon.shiny,
+    level = movie.mon and movie.mon.level,
+  }
+  local resolved = partyFrontFor(self, stub)
+  EvolveFx.formCachePut(movie, "front", species, resolved)
+  return resolved
+end
+
+function M:evolveCenterCtx()
+  local movie = self.evolving
+  if not (movie and movie.center) then return nil end
+  local front = self:evolveCenterFront()
+  if not front then return nil end
+  return { front = front, flash = EvolveFx.flashPulse(movie) }
+end
+
+function M:drawEvolveCenterClassic()
+  local movie = self.evolving
+  if not (movie and movie.center) or not love then return end
+  local sprite = self:evolveCenterFront()
+  if not sprite then return end
+  local ok, iw, ih = pcall(sprite.getDimensions, sprite)
+  iw = (ok and type(iw) == "number" and iw) or 56
+  ih = (ok and type(ih) == "number" and ih) or 56
+  local x = math.floor((160 - iw) / 2)
+  local y = math.floor((96 - ih) / 2)
+  love.graphics.setColor(1, 1, 1, 1)
+  pcall(love.graphics.draw, sprite, x, y)
 end
 
 function M:ensureBattlefieldLoaded()
@@ -5785,6 +6023,10 @@ local FX_SPAN = {
   -- is a visual one; a spec that genuinely needs longer carries its own
   -- `duration` (Explosion, a Poke Flute).
   vfx    = 0.50,
+  -- Mid-battle evolution movie. The real lifetime is EvolveFx.MOVIE_SECONDS
+  -- (the cart's 368-frame flash); this default is only what emitFx needs to
+  -- accept the kind, and startEvolve overwrites duration.
+  evolve = 6.14,
 }
 
 -- The beats between the effects, in seconds. Not effects themselves -- nothing
@@ -6569,6 +6811,8 @@ function M:battlefieldCtx()
     -- One direction only: this screen advances `t`, Battlefield draws whatever
     -- `t` says. Absent when nothing is playing -- the renderer tolerates that.
     fx = self:battlefieldFxCtx(allySeats, foeSeats),
+    -- Bench / EXP.ALL movie: no plate to flash, so a front pic in the middle.
+    evolveCenter = self:evolveCenterCtx(),
     -- Arrow/card only during target pick; Battlefield honors this flag.
     showTarget = (self.phase == "target"),
   }
@@ -7698,6 +7942,11 @@ function M:levelled(mon, fallbackName, levels)
   end
   self.leveledUp = self.leveledUp or {}
   self.leveledUp[mon] = true
+  -- After the grew-to / teach lines for this award: queue the movie if this
+  -- mon now qualifies. Bench EXP.ALL still qualifies; the movie has no seat
+  -- FX off the plate, but the text, B-cancel and apply still run.
+  self.messages = self.messages or {}
+  EvolveFx.enqueue(self.messages, self.game, mon, self)
 end
 
 -- ------- learning a move

--- a/src/EvolveFx.lua
+++ b/src/EvolveFx.lua
@@ -1,0 +1,545 @@
+-- Mid-battle evolution movie: timing, qualify, apply.
+--
+-- Vanilla still only evolves after a fight (`BattleState:finish` ->
+-- `Evolution.checkParty`). The custom screens -- CoopBattle, MediatedBattle,
+-- and SoloBattle sitting on the latter -- offer a level-up evolution *on the
+-- arena* after that mon's grew-to / learn-move lines, with the same flash
+-- clock and B-cancel as `src/ui/EvolutionState.lua`.
+--
+-- This file owns **none of the drawing**. Battlefield paints the white pulse;
+-- the screens swap the seat pic via `picSpecies`. Pushing the engine's
+-- EvolutionState / Gen2EvolutionAnim onto a 640x360 arena is the catch-screen
+-- postage-stamp bug, so the movie stays in-place.
+--
+-- **Local only.** Same contract as exp and levels: the save and this client's
+-- sprite update; the hub and the other players keep the uploaded pre-evo
+-- sheet for this fight. No PROTOCOL bump. If the screen pops mid-movie, do
+-- not apply -- leave `leveledUp` so `Coop.offerEvolutions` still runs.
+--
+-- No love. Engine modules are pcall'd so a headless suite can assert the
+-- clock with no ROM and no Evolution.lua.
+
+local need = ...
+local Gen = need("Gen")
+local Exp2 = need("Exp2")
+
+local M = {}
+
+-- evolution.asm EvolveMon delays 80 frames before .animLoop, polling nothing
+-- (#968, #1031). Copied rather than required so this file stays love-free.
+M.CANCEL_GRACE_FRAMES = 80
+-- .animLoop: 8 iterations, hold 18-2k then k swaps of 6 frames (288 in all).
+M.ANIM_LOOP_FRAMES = 288
+M.FLASH_FRAMES = M.CANCEL_GRACE_FRAMES + M.ANIM_LOOP_FRAMES
+-- Seat-FX lifetime the screens pass to emitFx. One movie, one span.
+M.MOVIE_SECONDS = M.FLASH_FRAMES / 60
+
+-- Which pic is on screen `t` frames into .animLoop (t may be negative during
+-- the grace: every negative value is the old form).
+function M.showsNew(t)
+  t = tonumber(t) or 0
+  for b = 1, 8 do
+    local hold = 18 - 2 * b
+    if t < hold then return false end
+    t = t - hold
+    local swap = b * 6
+    if t < swap then return t % 6 < 3 end
+    t = t - swap
+  end
+  return true
+end
+
+function M.canCancel(frame)
+  return (tonumber(frame) or 0) > M.CANCEL_GRACE_FRAMES
+end
+
+-- White-pulse envelope the arena paints over a swapping pic. Same curve
+-- Battlefield.fxSeat uses for `evolve`, so a centered bench pic and an on-
+-- plate flash stay in step. `t` is 0..1 through the movie.
+function M.flashPulse(movie)
+  if type(movie) ~= "table" or movie.done then return 0 end
+  local span = M.FLASH_FRAMES
+  if span <= 0 then return 0 end
+  local t = (tonumber(movie.frame) or 0) / span
+  if t < 0 then t = 0 elseif t > 1 then t = 1 end
+  return math.abs(math.sin(t * math.pi * 16)) * (0.4 + 0.6 * t)
+end
+
+-- Fight-plate HP when max HP changes (a level, then an evolution). The save
+-- mon is not a source: copying its HP onto the plate heals fight damage.
+-- Returns grown, newMax, newHp.
+function M.hpGrowth(oldMax, newMax, currentHp)
+  newMax = math.floor(tonumber(newMax) or 0)
+  oldMax = math.floor(tonumber(oldMax) or newMax)
+  if newMax <= 0 then return 0, nil, tonumber(currentHp) end
+  local grown = newMax - oldMax
+  if grown < 0 then grown = 0 end
+  local hp = tonumber(currentHp)
+  if hp and grown > 0 then
+    hp = math.max(0, math.floor(hp) + grown)
+    if hp > newMax then hp = newMax end
+  end
+  return grown, newMax, hp
+end
+
+local function formFields(kind)
+  if kind == "icon" then return "oldIcon", "newIcon" end
+  return "oldFront", "newFront"
+end
+
+-- Two-pic (or two-icon) cache on the movie so the flash does not reload
+-- makeBattler / bag art every swap. Nil is a miss; false is "loaded, missing".
+function M.formCacheGet(movie, kind, species)
+  if type(movie) ~= "table" or species == nil then return nil end
+  local oldF, newF = formFields(kind)
+  if species == movie.from then
+    if movie[oldF] ~= nil then return movie[oldF] end
+  elseif species == movie.into then
+    if movie[newF] ~= nil then return movie[newF] end
+  end
+  return nil
+end
+
+function M.formCachePut(movie, kind, species, value)
+  if type(movie) ~= "table" or species == nil then return end
+  local oldF, newF = formFields(kind)
+  if species == movie.from then
+    movie[oldF] = value or false
+  elseif species == movie.into then
+    movie[newF] = value or false
+  end
+end
+
+-- Species the seat should draw this frame. After the movie settles, cancel
+-- keeps `from` and a completed flash keeps `into`.
+function M.picSpecies(movie)
+  if type(movie) ~= "table" then return nil end
+  if movie.done then
+    if movie.canceled then return movie.from end
+    return movie.into
+  end
+  if M.showsNew((movie.frame or 0) - M.CANCEL_GRACE_FRAMES) then
+    return movie.into
+  end
+  return movie.from
+end
+
+function M.evolvingLine(movie)
+  local name = (movie and movie.name) or "?"
+  return "What? " .. name .. "\nis evolving!"
+end
+
+function M.stoppedLine(movie)
+  local name = (movie and movie.name) or "?"
+  return "Huh? " .. name .. "\nstopped evolving!"
+end
+
+function M.evolvedLine(movie, game)
+  local name = (movie and movie.name) or "?"
+  local into = movie and movie.into
+  local shown = into
+  local data = game and game.data
+  local def = data and data.pokemon and into and data.pokemon[into]
+  if type(def) == "table" and type(def.name) == "string" and def.name ~= "" then
+    shown = def.name
+  end
+  return name .. " evolved\ninto " .. tostring(shown or "?") .. "!"
+end
+
+function M.begin(row)
+  if type(row) ~= "table" then return nil end
+  local mon = row.evolve or row.mon
+  if type(mon) ~= "table" then return nil end
+  return {
+    mon = mon,
+    from = row.from or mon.species,
+    into = row.into,
+    entry = row.entry,
+    via = row.via or "LEVEL",
+    name = row.name or mon.nickname or "?",
+    frame = 0,
+    done = false,
+    canceled = false,
+    cancelable = row.cancelable ~= false
+      and row.via ~= "TRADE" and row.via ~= "ITEM",
+  }
+end
+
+-- Advance the movie. `dt` nil means one 60Hz frame (CoopBattle's fixed step);
+-- a real dt accumulates into whole frames so MediatedBattle's wall clock
+-- still lands on the same cancel edge. Vanilla increments t first, then
+-- reads a fresh B edge (`wasPressed`), then completes at FLASH_FRAMES.
+--
+-- Returns the movie. `movie.done` is the caller's cue to conclude.
+function M.advance(movie, dt, pressedB)
+  if type(movie) ~= "table" or movie.done then return movie end
+  local add = 1
+  if dt ~= nil then
+    movie._acc = (tonumber(movie._acc) or 0) + (tonumber(dt) or 0)
+    add = math.floor(movie._acc * 60 + 1e-9)
+    movie._acc = movie._acc - add / 60
+    if add < 1 then add = 0 end
+  end
+  movie.frame = (tonumber(movie.frame) or 0) + add
+  if movie.cancelable and pressedB and M.canCancel(movie.frame) then
+    movie.done = true
+    movie.canceled = true
+    return movie
+  end
+  if movie.frame >= M.FLASH_FRAMES then
+    movie.done = true
+    movie.canceled = false
+  end
+  return movie
+end
+
+local function gen2Daytime()
+  local ok, Palettes = pcall(require, "src.render.Palettes")
+  if not (ok and type(Palettes) == "table"
+      and type(Palettes.clockDaytime) == "function") then
+    return nil
+  end
+  local good, tod = pcall(Palettes.clockDaytime)
+  if good then return tod end
+  return nil
+end
+
+-- Does this mon now qualify for a *level-up* evolution? Nil if not, or if
+-- the engine module is missing -- a missing module must not fail the fight.
+function M.pending(game, mon)
+  if not (game and type(mon) == "table") then return nil end
+  if Gen.generation(game) == 2 then
+    local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+    if not (ok and type(Evolution) == "table"
+        and type(Evolution.checkMon) == "function") then
+      return nil
+    end
+    local entry
+    local ran = pcall(function()
+      entry = Evolution.checkMon(game.data, mon, { timeOfDay = gen2Daytime() })
+    end)
+    if ran and type(entry) == "table" and entry.into then
+      return {
+        from = mon.species,
+        into = entry.into,
+        entry = entry,
+        via = entry.method or "LEVEL",
+      }
+    end
+    return nil
+  end
+  local ok, Evolution = pcall(require, "src.pokemon.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.pendingFor) == "function") then
+    return nil
+  end
+  local species, evo
+  local ran = pcall(function()
+    species, evo = Evolution.pendingFor(game, mon, { kind = "levelup" })
+  end)
+  if ran and species then
+    return {
+      from = mon.species,
+      into = species,
+      entry = evo,
+      via = (evo and evo.method) or "LEVEL",
+    }
+  end
+  return nil
+end
+
+-- Append an evolve row after the grew-to / teach lines, if this mon qualifies
+-- and has not already resolved mid-fight. Returns the row or nil.
+function M.enqueue(queue, game, mon, holder)
+  if type(queue) ~= "table" or type(mon) ~= "table" then return nil end
+  if holder and holder.evoResolved and holder.evoResolved[mon] then return nil end
+  local pending = M.pending(game, mon)
+  if not pending then return nil end
+  local def = game and game.data and game.data.pokemon
+      and game.data.pokemon[mon.species]
+  local name = mon.nickname or (def and def.name) or "?"
+  local row = {
+    evolve = mon,
+    from = pending.from,
+    into = pending.into,
+    entry = pending.entry,
+    via = pending.via,
+    name = name,
+  }
+  queue[#queue + 1] = row
+  return row
+end
+
+-- Drop mons that already accepted or cancelled mid-fight, so the after-battle
+-- fallback does not re-offer. Empty leftover is nil, matching checkParty's
+-- "nothing to walk".
+function M.withoutResolved(leveledUp, skip)
+  if type(leveledUp) ~= "table" then return leveledUp end
+  if type(skip) ~= "table" then return leveledUp end
+  local out, any = {}, false
+  for mon, flag in pairs(leveledUp) do
+    if flag and not skip[mon] then
+      out[mon] = true
+      any = true
+    end
+  end
+  if not any then return nil end
+  return out
+end
+
+function M.markResolved(holder, mon)
+  if not (holder and mon) then return end
+  holder.evoResolved = holder.evoResolved or {}
+  holder.evoResolved[mon] = true
+  if type(holder.leveledUp) == "table" then
+    holder.leveledUp[mon] = nil
+  end
+end
+
+-- Gen 2 apply returns a new record. Every pointer that still named the old
+-- one -- the plate, the forget list, the levelled set, the resolved set --
+-- has to move, or the next tick writes the old species back over the new.
+function M.retarget(holder, old, new)
+  if not (holder and old and new and old ~= new) then return new end
+  if type(holder.leveledUp) == "table" and holder.leveledUp[old] then
+    holder.leveledUp[old] = nil
+    holder.leveledUp[new] = true
+  end
+  if type(holder.evoResolved) == "table" and holder.evoResolved[old] then
+    holder.evoResolved[old] = nil
+    holder.evoResolved[new] = true
+  end
+  if type(holder.toLearn) == "table" then
+    for _, entry in ipairs(holder.toLearn) do
+      if type(entry) == "table" and entry.mon == old then
+        entry.mon = new
+      end
+    end
+  end
+  local sim = holder.sim
+  if type(sim) == "table" then
+    for _, slot in ipairs(sim.slots or {}) do
+      local battler = slot and slot.battler
+      if battler and battler.mon == old then battler.mon = new end
+    end
+  end
+  return new
+end
+
+-- Mutate (Gen 1) or replace (Gen 2) the save-party mon. Returns the live
+-- record on success -- the Gen 2 one is a *new* table -- or nil on failure.
+-- Failure must not mark resolved: the after-battle fallback still owes this.
+function M.applyTo(game, movie, holder)
+  if not (game and type(movie) == "table" and type(movie.mon) == "table") then
+    return nil
+  end
+  local mon = movie.mon
+  local into = movie.into
+  if not into then return nil end
+  if Gen.generation(game) == 2 then
+    local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+    if not (ok and type(Evolution) == "table"
+        and type(Evolution.apply) == "function") then
+      return nil
+    end
+    local evolved
+    local ran = pcall(function()
+      evolved = Evolution.apply(game.data, mon, movie.entry)
+    end)
+    if not (ran and type(evolved) == "table") then return nil end
+    local party = game.save and game.save.party
+    if type(party) == "table" then
+      for i, member in ipairs(party) do
+        if member == mon then
+          party[i] = evolved
+          break
+        end
+      end
+    end
+    if type(Evolution.markPokedex) == "function" then
+      pcall(Evolution.markPokedex, game.save, into)
+    end
+    movie.mon = evolved
+    if holder then M.retarget(holder, mon, evolved) end
+    return evolved
+  end
+  local ok, Evolution = pcall(require, "src.pokemon.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.apply) == "function") then
+    return nil
+  end
+  local ran = pcall(Evolution.apply, game, mon, into, movie.via or "LEVEL")
+  if not ran then return nil end
+  return mon
+end
+
+-- Moves the *evolved* species learns at this exact level. Asked after apply,
+-- so `mon.species` is already the new form. Engine `learnEvolutionMoves`
+-- pushes TextBox / MoveLearnMenu -- screens must not -- so this is the list
+-- only, and `:teach` is what announces it.
+function M.learnMoveIds(game, mon)
+  if not (game and type(mon) == "table") then return {} end
+  local data = game.data
+  local def = data and data.pokemon and data.pokemon[mon.species]
+  if Gen.generation(game) == 2 then
+    local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+    if ok and type(Evolution) == "table"
+        and type(Evolution.learnedOnEvolve) == "function" then
+      local got
+      local ran = pcall(function()
+        got = Evolution.learnedOnEvolve(data, mon.species, mon.level, mon)
+      end)
+      if ran and type(got) == "table" then return got end
+    end
+    if def and Exp2 and type(Exp2.movesLearnedAt) == "function" then
+      local got
+      local ran = pcall(function()
+        got = Exp2.movesLearnedAt(def, mon.level)
+      end)
+      if ran and type(got) == "table" then return got end
+    end
+    return {}
+  end
+  local ok, Experience = pcall(require, "src.battle.Experience")
+  if ok and type(Experience) == "table"
+      and type(Experience.movesLearnedAt) == "function" and def then
+    local got
+    local ran = pcall(function()
+      got = Experience.movesLearnedAt(def, mon.level)
+    end)
+    if ran and type(got) == "table" then return got end
+  end
+  return {}
+end
+
+-- Soft: missing Music must not fail the fight.
+function M.playMusic(game, Music)
+  if not (game and Music and type(Music.play) == "function") then return end
+  pcall(function()
+    if Music.stop then Music.stop() end
+    if Music.special then
+      Music.play(game.data, Music.special(game.data, "evolution"))
+    end
+  end)
+end
+
+function M.restoreBattleMusic(game, opts)
+  if not game then return end
+  pcall(Gen.playBattleMusic, game, opts or {})
+end
+
+function M.playCry(game, Sound, species)
+  if not (game and Sound and type(Sound.playCry) == "function" and species) then
+    return
+  end
+  pcall(Sound.playCry, game.data, species)
+end
+
+-- After-battle fallback the custom screens owe when an evolve row never
+-- played (snap, pop, queue drop). Sessions cannot require Coop -- that
+-- graph is a cycle -- so the offer lives here, and Coop.offerEvolutions is
+-- the wrapper that stamps mod.log / mod.ui. `opts.warn` is `function(fmt, ...)`
+-- and `opts.ui` is the facade with `:push` (Gen 2 only).
+local offerEvolutionsGen2
+
+function M.offerEvolutions(game, leveledUp, result, evoResolved, opts)
+  leveledUp = M.withoutResolved(leveledUp, evoResolved)
+  if not (game and type(leveledUp) == "table") then return false end
+  local any = false
+  for _ in pairs(leveledUp) do
+    any = true
+    break
+  end
+  if not any then return false end
+  opts = type(opts) == "table" and opts or {}
+  local warn = opts.warn
+  local function note(fmt, ...)
+    if type(warn) == "function" then warn(fmt, ...) end
+  end
+
+  if Gen.generation(game) == 2 then
+    local outcome = result
+    if outcome == "loss" then outcome = "lose" end
+    if outcome == "lose" or outcome == "draw" then return false end
+    return offerEvolutionsGen2(game, leveledUp, opts.ui, note)
+  end
+
+  local ok, Evolution = pcall(require, "src.pokemon.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.checkParty) == "function") then
+    note("the engine's evolution module is unavailable, so POKéMON "
+      .. "that levelled in this battle were not offered evolutions -- level "
+      .. "again in a wild fight or use a RARE CANDY")
+    return false
+  end
+  local ran, err = pcall(Evolution.checkParty, game, nil, leveledUp)
+  if not ran then
+    note("evolutions from this fight could not be offered (%s); "
+      .. "level again in a wild fight or use a RARE CANDY", tostring(err))
+    return false
+  end
+  return true
+end
+
+offerEvolutionsGen2 = function(game, leveledUp, ui, note)
+  local ok, Evolution = pcall(require, "src.core.gen2.Evolution")
+  if not (ok and type(Evolution) == "table"
+      and type(Evolution.plan) == "function") then
+    note("the engine's Gen 2 evolution module is unavailable, so "
+      .. "POKéMON that levelled in this battle were not offered evolutions "
+      .. "-- level again in a wild fight or use a RARE CANDY")
+    return false
+  end
+  local party = game.save and game.save.party
+  if type(party) ~= "table" then return false end
+  local flags = {}
+  local flagged = false
+  for i, mon in ipairs(party) do
+    if leveledUp[mon] then
+      flags[i] = true
+      flagged = true
+    end
+  end
+  if not flagged then return false end
+  local planned = Evolution.plan(game.data, party, flags,
+    { timeOfDay = gen2Daytime() })
+  if type(planned) ~= "table" or #planned == 0 then return false end
+  if not (ui and type(ui.push) == "function") then
+    note("could not open the evolution screen, so POKéMON that "
+      .. "levelled in this battle were not offered evolutions -- level "
+      .. "again in a wild fight or use a RARE CANDY")
+    return false
+  end
+
+  local pending = {}
+  for i, row in ipairs(planned) do pending[i] = row end
+  local function nextOne()
+    local row = table.remove(pending, 1)
+    if not row then return end
+    local pushed
+    local ran = pcall(function()
+      pushed = ui.push(game, "Gen2EvolutionAnim", {
+        mon = row.mon,
+        entry = row.entry,
+        index = row.index,
+        party = party,
+        save = game.save,
+        onDone = function()
+          local stack = game.stack
+          if stack and stack.pop then stack:pop() end
+          nextOne()
+        end,
+      })
+    end)
+    if not (ran and type(pushed) == "table") then
+      note("could not open the evolution screen for %s; it can still "
+        .. "evolve by levelling again or with a RARE CANDY",
+        tostring(row.mon and (row.mon.nickname or row.mon.species)))
+      nextOne()
+    end
+  end
+  nextOne()
+  return true
+end
+
+return M

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -54,6 +54,9 @@ local Vfx = need("Vfx")
 -- inside a live `src/battle/gen2/Battle.lua` this screen never owns. `Exp2` is
 -- the mod-side orchestration over Gen 2's own `Mon` primitives; see its header.
 local Exp2 = need("Exp2")
+-- Mid-battle evolution movie: timing + apply. Twin of CoopBattle's own
+-- require -- the two screens must not drift on qualify / cancel / apply.
+local EvolveFx = need("EvolveFx")
 
 local M = {}
 M.__index = M
@@ -1121,6 +1124,9 @@ local FX_SPAN = {
   -- the defender flashes. It outliving its beat costs nothing -- `stepFx` runs
   -- on its own clock and retires it wherever the queue has got to.
   vfx    = 0.50,
+  -- Mid-battle evolution movie. Real lifetime is EvolveFx.MOVIE_SECONDS;
+  -- this default is only what emitFx needs to accept the kind.
+  evolve = 6.14,
 }
 
 -- The per-attack chronology's two deliberate gaps. One attack is four beats on
@@ -1567,6 +1573,11 @@ end
 -- cart draws for every Unown that is not its own letter anyway.
 function M:seatFront(speciesKey, monHint, slot, isOwn)
   if type(speciesKey) ~= "string" or speciesKey == "" then return nil end
+  local movie = self.evolving
+  if movie and isOwn then
+    local hit = EvolveFx.formCacheGet(movie, "front", speciesKey)
+    if hit ~= nil then return hit or nil end
+  end
   if slot and slot._bfFront ~= nil and slot._bfFrontSpecies == speciesKey then
     local cached = slot._bfFront
     return (cached ~= false) and cached or nil
@@ -1663,6 +1674,9 @@ function M:seatFront(speciesKey, monHint, slot, isOwn)
     local ok, probe = pcall(eng.BattleState.makeBattler, data, mon, false, save)
     if ok and probe and probe.sprite then resolved = probe.sprite end
   end
+  if movie and isOwn then
+    EvolveFx.formCachePut(movie, "front", speciesKey, resolved)
+  end
   if slot then
     slot._bfFront = resolved or false
     slot._bfFrontSpecies = speciesKey
@@ -1701,17 +1715,37 @@ function M:battlefieldSeat(slotIndex, isPlayer)
     end
   end
   local key = self:seatSpeciesKey(slot, isPlayer) or slot.species
+  local movie = self.evolving
+  local evolvingHere = movie and isPlayer
+    and self:saveMon(self.active) == movie.mon
+  if evolvingHere then
+    key = EvolveFx.picSpecies(movie) or key
+  end
   local acting = false
   if self.anim and self.anim.slot == slotIndex then acting = true end
-  local icon = slot.icon
-  if icon == nil then
-    icon = self:seatIcon(key, monHint and {
-      species = monHint.speciesId or key,
-      hp = slot.hp,
-    } or { species = key })
-    slot.icon = icon or false
-  elseif icon == false then
-    icon = nil
+  local icon
+  if evolvingHere then
+    local cached = EvolveFx.formCacheGet(movie, "icon", key)
+    if cached ~= nil then
+      icon = cached or nil
+    else
+      icon = self:seatIcon(key, monHint and {
+        species = monHint.speciesId or key,
+        hp = slot.hp,
+      } or { species = key })
+      EvolveFx.formCachePut(movie, "icon", key, icon)
+    end
+  else
+    icon = slot.icon
+    if icon == nil then
+      icon = self:seatIcon(key, monHint and {
+        species = monHint.speciesId or key,
+        hp = slot.hp,
+      } or { species = key })
+      slot.icon = icon or false
+    elseif icon == false then
+      icon = nil
+    end
   end
   local frontMon = monHint
   if not frontMon then
@@ -2019,6 +2053,9 @@ function M:battlefieldCtx()
     -- One direction only: this screen advances `t`, Battlefield draws whatever
     -- `t` says. Absent when nothing is playing -- the renderer tolerates that.
     fx = self.fx,
+    -- Bench / EXP.ALL movie: no plate to flash, so a front pic in the middle
+    -- of the field. Nil when the evolving mon is on a seat.
+    evolveCenter = self:evolveCenterCtx(),
   }
 end
 
@@ -3110,10 +3147,10 @@ function M:syncLevelHp(paidIndex, oldMax, mon, onField)
   end
 end
 
--- What a level-up costs, wherever it happened: a line, and whatever moves come
--- with the level. CoopBattle's twin, minus its evolution note -- a mediated
--- battle has no `afterBattle` of its own to run the check in, so evolution
--- stays where the round pinned it: out.
+-- What a level-up costs, wherever it happened: a line, whatever moves come
+-- with the level, and -- when this mon now qualifies -- the mid-battle
+-- evolution movie. The after-battle fallback (`Coop.offerEvolutions`) still
+-- runs for a level-up whose row never played; `leveledUp` is that set.
 function M:levelled(mon, fallbackName, levels)
   if not (levels and #levels > 0) then return false end
   local data = self.game and self.game.data
@@ -3147,6 +3184,10 @@ function M:levelled(mon, fallbackName, levels)
       self:teach(mon, name, moveId)
     end
   end
+  self.leveledUp = self.leveledUp or {}
+  self.leveledUp[mon] = true
+  self.lines = self.lines or {}
+  EvolveFx.enqueue(self.lines, self.game, mon, self)
   return true
 end
 
@@ -4388,6 +4429,14 @@ function M:tickMessages(dt, input)
     self.dwell = 0
     return true
   end
+  -- The evolution movie holds the queue the same way a filling strip does:
+  -- it is not a text page, A does not skip it, and MSG_AUTO_ADVANCE must
+  -- not dismiss "is evolving!" while the flash is still running.
+  if self.evolving then
+    self:stepEvolve(dt, input)
+    self.dwell = 0
+    return true
+  end
   if self.faintFx then
     -- Retired by stepFx once its `t` reaches 1.
     self.dwell = 0
@@ -4422,6 +4471,10 @@ function M:tickMessages(dt, input)
       -- A strip already where it was going costs nothing but the row:
       -- `startExpFill` answers false and the queue moves on this same tick.
       self:startExpFill(next)
+      return true
+    end
+    if type(next) == "table" and next.evolve ~= nil then
+      self:startEvolve(next)
       return true
     end
     if type(next) == "table" and next.faintfx ~= nil then
@@ -5702,6 +5755,186 @@ function M:stepExpFill(dt)
   self.expFilling = nil
 end
 
+-- Mid-battle evolution movie. Twin of CoopBattle's: timing and apply in
+-- EvolveFx, queue hold and seat FX here. Local only -- the hub keeps the
+-- uploaded pre-evo sheet for the rest of this fight.
+function M:evolveSlot(mon)
+  if not mon then return nil end
+  for i = 1, #(self.mine or {}) do
+    if self:saveMon(i) == mon then
+      if i == (self.active or 1) then return self:mySlot() end
+      return nil
+    end
+  end
+  return nil
+end
+
+-- Front pic for a bench / EXP.ALL movie: no plate, so the arena (or the
+-- classic stage) paints it in the middle of the field.
+function M:evolveCenterFront()
+  local movie = self.evolving
+  if not (movie and movie.center) then return nil end
+  local species = EvolveFx.picSpecies(movie)
+  if type(species) ~= "string" then return nil end
+  local hit = EvolveFx.formCacheGet(movie, "front", species)
+  if hit ~= nil then return hit or nil end
+  local resolved = self:seatFront(species, movie.mon, nil, true)
+  EvolveFx.formCachePut(movie, "front", species, resolved)
+  return resolved
+end
+
+function M:evolveCenterCtx()
+  local movie = self.evolving
+  if not (movie and movie.center) then return nil end
+  local front = self:evolveCenterFront()
+  if not front then return nil end
+  return { front = front, flash = EvolveFx.flashPulse(movie) }
+end
+
+function M:startEvolve(row)
+  local movie = EvolveFx.begin(row)
+  if not movie then return false end
+  self.evolving = movie
+  self.shown = EvolveFx.evolvingLine(movie)
+  self.dwell = 0
+  local eng = loadEngine()
+  EvolveFx.playMusic(self.game, eng and eng.Music)
+  local index = self:evolveSlot(movie.mon)
+  movie.slot = index
+  movie.center = index == nil
+  if index then
+    local slot = self.slots[index]
+    movie.oldSprite = slot and slot.sprite
+    if slot then slot.icon = nil end
+    if self:usesBattlefield() then
+      self:emitFx("evolve", index, self:fxSideFor(index), 1,
+        { duration = EvolveFx.MOVIE_SECONDS })
+      self:emitVfx({ style = "sparkle", palette = "FAIRY", delivery = "burst" },
+        index)
+      self:emitVfx({ style = "shine", palette = "NORMAL", delivery = "burst" },
+        index)
+    end
+  end
+  return true
+end
+
+function M:stepEvolve(dt, input)
+  local movie = self.evolving
+  if type(movie) ~= "table" then
+    self.evolving = nil
+    return
+  end
+  local pressedB = input and input:wasPressed("b")
+  EvolveFx.advance(movie, dt, pressedB)
+  -- Classic path: refresh the slot pic when the flash wants the other form.
+  if not self:usesBattlefield() and movie.slot then
+    local want = EvolveFx.picSpecies(movie)
+    if want ~= movie._shownPic then
+      movie._shownPic = want
+      local slot = self.slots[movie.slot]
+      if slot then
+        local saved = slot.speciesId
+        slot.speciesId = want
+        self:refreshSlotSprite(movie.slot, true)
+        slot.speciesId = saved
+      end
+    end
+  end
+  if not movie.done then return end
+  local snapMax, snapHp
+  if movie.slot then
+    local slot = self.slots[movie.slot]
+    if type(slot) == "table" then
+      snapMax = slot.maxHp
+      snapHp = slot.hp
+    end
+  end
+  self.evolving = nil
+  local eng = loadEngine()
+  local line
+  if movie.canceled then
+    EvolveFx.markResolved(self, movie.mon)
+    if movie.slot then self:refreshSlotSprite(movie.slot, true) end
+    line = EvolveFx.stoppedLine(movie)
+  else
+    local applied = EvolveFx.applyTo(self.game, movie, self)
+    if applied then
+      EvolveFx.markResolved(self, applied)
+      self:refreshAfterEvolve(applied, snapMax, snapHp)
+      EvolveFx.playCry(self.game, eng and eng.Sound, movie.into)
+      for _, moveId in ipairs(EvolveFx.learnMoveIds(self.game, applied)) do
+        self:teach(applied, movie.name, moveId)
+      end
+      line = EvolveFx.evolvedLine(movie, self.game)
+    else
+      line = EvolveFx.stoppedLine(movie)
+      if movie.slot then self:refreshSlotSprite(movie.slot, true) end
+    end
+  end
+  EvolveFx.restoreBattleMusic(self.game, {
+    Music = eng and eng.Music,
+    kind = self:musicKind(),
+    mode = self.mode,
+  })
+  self.shown = line
+  self.dwell = 0
+end
+
+function M:refreshAfterEvolve(mon, snapMax, snapHp)
+  if not mon then return end
+  local data = self.game and self.game.data
+  local def = data and data.pokemon and data.pokemon[mon.species]
+  local saveMax = tonumber(mon.stats and mon.stats.hp) or tonumber(mon.maxHp)
+  if saveMax and saveMax == saveMax and saveMax > 0 then
+    saveMax = floor(saveMax)
+    mon.maxHp = saveMax
+  end
+  for i = 1, #(self.mine or {}) do
+    if self:saveMon(i) == mon then
+      local sheet = self.mine[i]
+      local oldMax = tonumber(snapMax)
+        or (type(sheet) == "table" and tonumber(sheet.maxHp))
+      local oldHp = tonumber(snapHp)
+        or (type(sheet) == "table" and tonumber(sheet.hp))
+      local grown, newMax, newHp = EvolveFx.hpGrowth(oldMax, saveMax, oldHp)
+      if type(sheet) == "table" then
+        sheet.speciesId = mon.species
+        if def and type(def.name) == "string" then
+          sheet.species = def.name
+        end
+        sheet.level = mon.level
+        if newMax then sheet.maxHp = newMax end
+        if newHp then sheet.hp = newHp end
+      end
+      if i == (self.active or 1) then
+        local index = self:mySlot()
+        local slot = index and self.slots[index]
+        if type(slot) == "table" then
+          slot.speciesId = mon.species
+          if def and type(def.name) == "string" then
+            slot.species = def.name
+          end
+          slot._bfFront = nil
+          slot._bfFrontSpecies = nil
+          slot.sprite = nil
+          slot.icon = nil
+          if grown > 0 then
+            slot.maxHp = newMax
+            if newHp then slot.hp = newHp end
+            slot.levelHpGrown = (tonumber(slot.levelHpGrown) or 0) + grown
+            if self:usesBattlefield() then
+              self:queueDrain(index)
+            else
+              slot.shownHp = slot.hp
+            end
+          end
+          self:refreshSlotSprite(index, true)
+        end
+      end
+    end
+  end
+end
+
 -- Is a bar still falling, or a monster still on its way down?
 --
 -- The fanfare waits on this (#36): a win announced while the loser's bar is
@@ -5726,7 +5959,8 @@ function M:hasPendingHpFx()
   -- plainest reading of the same rule: the award is the last thing a knockout
   -- owes, so a jingle over a bar still crawling is a fight congratulating
   -- itself before it has finished paying out.
-  if self.draining or self.faintFx or self.hitHold or self.expFilling then
+  if self.draining or self.faintFx or self.hitHold or self.expFilling
+      or self.evolving then
     return true
   end
   -- A send-out counts for the same reason a throw does, and it is the same
@@ -5742,7 +5976,8 @@ function M:hasPendingHpFx()
   end
   for _, row in ipairs(self.lines or {}) do
     if type(row) == "table" then
-      if row.drain ~= nil or row.faintfx ~= nil or row.expfill ~= nil then
+      if row.drain ~= nil or row.faintfx ~= nil or row.expfill ~= nil
+          or row.evolve ~= nil then
         return true
       end
       if row.sendball ~= nil or row.spawnfx ~= nil then return true end
@@ -5785,6 +6020,17 @@ function M:snapDisplay()
   self.draining = nil
   self.faintFx = nil
   self.expFilling = nil
+  -- A movie in flight is abandoned without applying: leveledUp stays so the
+  -- after-battle fallback still offers. Unplayed evolve rows stay in `lines`.
+  if self.evolving then
+    local eng = loadEngine()
+    EvolveFx.restoreBattleMusic(self.game, {
+      Music = eng and eng.Music,
+      kind = self:musicKind(),
+      mode = self.mode,
+    })
+    self.evolving = nil
+  end
   -- The arrival window closes here too, and it closes *forwards*: this is
   -- "put the arena where the referee says the field is", and the referee says
   -- the newcomer is out. A parked arrival is therefore installed rather than
@@ -6015,6 +6261,20 @@ function M:zones()
     w, h = Battlefield.WIDTH, Battlefield.HEIGHT
   end
   return { { colors = false, x = 0, y = 0, w = w, h = h } }
+end
+
+function M:drawEvolveCenterClassic()
+  local movie = self.evolving
+  if not (movie and movie.center) or not love then return end
+  local sprite = self:evolveCenterFront()
+  if not sprite then return end
+  local ok, iw, ih = pcall(sprite.getDimensions, sprite)
+  iw = (ok and type(iw) == "number" and iw) or 56
+  ih = (ok and type(ih) == "number" and ih) or 56
+  local x = math.floor((160 - iw) / 2)
+  local y = math.floor((96 - ih) / 2)
+  love.graphics.setColor(1, 1, 1, 1)
+  pcall(love.graphics.draw, sprite, x, y)
 end
 
 function M:drawFieldPics()
@@ -6596,6 +6856,7 @@ function M:drawSafe()
   local HudTiles = eng.HudTiles
 
   self:drawFieldPics()
+  self:drawEvolveCenterClassic()
   self:drawEnemyHUD(Font, HudTiles)
   self:drawPlayerHUD(Font, HudTiles)
   self:drawAnim()

--- a/src/Sessions.lua
+++ b/src/Sessions.lua
@@ -56,6 +56,7 @@ local SessionNet = need("SessionNet")
 local MediatedBattle = need("MediatedBattle")
 local Gen = need("Gen")
 local Trade2 = need("Trade2")
+local EvolveFx = need("EvolveFx")
 
 local M = {}
 M.__index = M
@@ -593,7 +594,19 @@ function M:endMediated(game, toLearn)
   local fight = self.fight
   self.fight = nil
   if fight then self.transport:send(Wire.SESSION_LEAVE, {}) end
-  self:offerForgets(game or (fight and fight.game), toLearn)
+  game = game or (fight and fight.game)
+  -- Forgets first, then the #65 fallback: same order Coop.onBattleOver uses.
+  -- The fight is already off `self.fight`, so the sets have to be read off
+  -- the snapshot -- a mid-movie snapDisplay abandoned apply and left
+  -- leveledUp for this offer; evoResolved subtracts a prompt the player
+  -- already answered on the arena.
+  self:offerForgets(game, toLearn)
+  if fight then
+    EvolveFx.offerEvolutions(game, fight.leveledUp, fight.result, fight.evoResolved, {
+      warn = function(fmt, ...) mod.log:warn(fmt, ...) end,
+      ui = (self.ui and self.ui.push and self.ui) or mod.ui,
+    })
+  end
 end
 
 -- Moves a monster levelled into during a mediated fight but had no room for.

--- a/src/SoloBattle.lua
+++ b/src/SoloBattle.lua
@@ -104,6 +104,7 @@ local Config = need("Config")
 local Wire = need("Wire")
 local Gen = need("Gen")
 local Coop = need("Coop")
+local EvolveFx = need("EvolveFx")
 local MediatedBattle = need("MediatedBattle")
 local SoloBrain = need("SoloBrain")
 
@@ -1276,6 +1277,10 @@ end
 function M:_ended(result, toLearn)
   local game, engine, sim = self.game, self.engine, self.sim
   local reason, save, levels = self.reason, self.save, self.levels
+  -- Snapshot before the fight is released: a mid-battle movie that already
+  -- answered (accept or cancel) must not be re-offered by checkParty, and
+  -- `self.fight` is about to be nilled.
+  local evoResolved = self.fight and self.fight.evoResolved
   -- Released before any of it runs. Everything below can push a screen, and a
   -- screen that pushes is a `screen.pushed` back into the divert -- which must
   -- find no fight in the slot rather than a half-finished one.
@@ -1290,7 +1295,9 @@ function M:_ended(result, toLearn)
   self:_reconcile(sim, game, save)
 
   local levelled = M.levelledSince(game, save, levels)
+  levelled = EvolveFx.withoutResolved(levelled, evoResolved)
   if engine and levelled then engine.leveledUp = levelled end
+  if engine and evoResolved then engine.evoResolved = evoResolved end
 
   local outcome = M.engineResult(result, reason)
   local blackout = Coop.blacksOut(outcome, game)
@@ -1462,12 +1469,14 @@ end
 -- set keyed by the save-party monster.
 --
 -- Derived rather than recorded, because the level-ups happened inside the
--- screen and it keeps no such list (`CoopBattle` does; `MediatedBattle` does
--- not, and this file may not change it). The difference between the level a
+-- screen and this file may not reach into `MediatedBattle.leveledUp` after
+-- `_ended` has released the fight. The difference between the level a
 -- monster had when the fight opened and the level it has now is the same fact
 -- by a shorter route -- and a monster the snapshot never saw is one that
 -- joined the party during the fight, which is a monster that was caught and
--- has therefore not levelled into anything.
+-- has therefore not levelled into anything. Subtract `evoResolved` (a movie
+-- the player already answered mid-fight) before handing this to
+-- `Coop.offerEvolutions`.
 function M.levelledSince(game, save, levels)
   local party = game and game.save and game.save.party
   if not (type(levels) == "table" and type(party) == "table") then return nil end

--- a/tests/drivers/battlefield_shot.lua
+++ b/tests/drivers/battlefield_shot.lua
@@ -30,7 +30,10 @@
 -- Captures, in order: idle (choose, RED/BLUE) -> action (choose, damage fx)
 -- -> move (moves list) -> party (the switch list and its front-pic gutter)
 -- -> ball (throw fx, target seat hidden from HIDEPIC on) -> bubble (rounded
--- callout) -> nire (self as SPRITE_NIRE, saturation pin).
+-- callout) -> nire (self as SPRITE_NIRE, saturation pin) -> evolve-grace
+-- (on-plate "is evolving!" before the flash) -> evolve-flash (white pulse
+-- mid-swap) -> evolve-done (settled into form) -> evolve-bench (centered
+-- pic for a mon that is not on a seat).
 --
 -- Coordinate approach (point 4 in the TT2 brief): the battlefield draws into
 -- a 640x360 canvas that Renderer fill-scales to the window, aspect
@@ -1070,6 +1073,132 @@ return function(game)
     end
   else
     log("warn", "nire frame did not reach disk", path6)
+  end
+
+  -- ---- mid-battle evolution movie (on-plate, then bench/center) ----
+  --
+  -- The rest of this driver never levels a mon, so the new EvolveFx path
+  -- would otherwise leave no PNG. Stamp a well-formed movie on the live
+  -- screen (same startEvolve the fight uses) and pin the clock so each
+  -- capture is a known beat: grace, flash, settled, then a centered bench
+  -- pic. Pixel asserts stay light -- these frames exist for eyeballing.
+  local evolveOk, evolveErr = pcall(function()
+    local EvolveFx = resolve("EvolveFx")
+    local pokedex = (game.data and game.data.pokemon) or {}
+    local function present(key)
+      return type(pokedex[key]) == "table" and key or nil
+    end
+    local intoOnPlate = present("RAICHU") or present("CROBAT") or "RAICHU"
+    local benchFrom = present(BENCH_SPECIES[1]) or present("NIDORINA")
+      or present("CATERPIE") or BENCH_SPECIES[1]
+    local benchInto = present("NIDOQUEEN") or present("METAPOD")
+      or present("CHARMELEON") or intoOnPlate
+    -- Real save mons so conclude/apply paints the evolved form. Gen 2 uses
+    -- Mon.new; Gen 1 Pokemon.new. A plain table is enough for identity if
+    -- both constructors miss, but then apply no-ops and the settled shot
+    -- stays on "is evolving!".
+    local function makeMon(species, level, nick)
+      local mon
+      if GEN == 2 then
+        local ok, Mon = pcall(require, "src.battle.gen2.Mon")
+        if ok and Mon and type(Mon.new) == "function" then
+          local ran, result = pcall(Mon.new, game.data, species, level)
+          if ran then mon = result end
+        end
+      else
+        local ok, Pokemon = pcall(require, "src.pokemon.Pokemon")
+        if ok and Pokemon and type(Pokemon.new) == "function" then
+          local ran, result = pcall(Pokemon.new, game.data, species, level)
+          if ran then mon = result end
+        end
+      end
+      if type(mon) ~= "table" then
+        mon = { species = species, level = level, hp = 40, stats = { hp = 55 } }
+      end
+      mon.nickname = nick
+      return mon
+    end
+    local lead = makeMon(MINE_SPECIES, 25, "SPARKY")
+    local benchMon = benchFrom and makeMon(benchFrom, 16, "BENCH") or nil
+    game.save = game.save or {}
+    game.save.party = { lead }
+    screen.active = 1
+    screen.phase = "messages"
+    local started = screen:startEvolve({
+      evolve = lead, from = MINE_SPECIES, into = intoOnPlate,
+      via = "LEVEL", name = "SPARKY",
+    })
+    check(started == true, "evolve: startEvolve accepts an on-plate row")
+    local movie = screen.evolving
+    check(movie ~= nil and movie.center ~= true,
+      "evolve: on-plate movie is tied to a seat, not centered")
+
+    if movie then
+      movie.frame = 40
+      U.wait(2)
+      local pathG = SHOT_DIR .. "/battlefield-evolve-grace.png"
+      if U.shot(game, pathG) then
+        log("captured", pathG)
+        check(true, "evolve: grace frame reached disk")
+      else
+        check(false, "evolve: grace frame reached disk", pathG)
+      end
+
+      movie.frame = 140
+      movie.done = false
+      U.wait(2)
+      local pathF = SHOT_DIR .. "/battlefield-evolve-flash.png"
+      if U.shot(game, pathF) then
+        log("captured", pathF)
+        check(true, "evolve: flash frame reached disk")
+      else
+        check(false, "evolve: flash frame reached disk", pathF)
+      end
+
+      movie.frame = EvolveFx.FLASH_FRAMES
+      movie.done = true
+      movie.canceled = false
+      U.wait(2)
+      local pathD = SHOT_DIR .. "/battlefield-evolve-done.png"
+      if U.shot(game, pathD) then
+        log("captured", pathD)
+        check(true, "evolve: settled frame reached disk")
+      else
+        check(false, "evolve: settled frame reached disk", pathD)
+      end
+    end
+
+    screen.evolving = nil
+    if benchMon then
+      game.save.party = { lead, benchMon }
+      local benchStarted = screen:startEvolve({
+        evolve = benchMon, from = benchFrom, into = benchInto,
+        via = "LEVEL", name = "BENCH",
+      })
+      check(benchStarted == true, "evolve: startEvolve accepts a bench row")
+      local benchMovie = screen.evolving
+      check(benchMovie ~= nil and benchMovie.center == true,
+        "evolve: bench movie is centered (no seat)")
+      if benchMovie then
+        benchMovie.frame = 140
+        benchMovie.done = false
+        U.wait(2)
+        local pathB = SHOT_DIR .. "/battlefield-evolve-bench.png"
+        if U.shot(game, pathB) then
+          log("captured", pathB)
+          check(true, "evolve: bench-center frame reached disk")
+        else
+          check(false, "evolve: bench-center frame reached disk", pathB)
+        end
+      end
+      screen.evolving = nil
+    else
+      check(false, "evolve: bench mon resolved from this boot's dex")
+    end
+  end)
+  if not evolveOk then
+    log("warn", "evolve frames threw:", tostring(evolveErr))
+    check(false, "evolve: frames ran without throwing", tostring(evolveErr))
   end
 
   log("GAPS:" .. tostring(fail))

--- a/tests/drivers/mmo_util.lua
+++ b/tests/drivers/mmo_util.lua
@@ -2715,6 +2715,14 @@ end
 function M.shotCoopPhases(game, shotFn, seen)
   seen = seen or {}
   local now = M.top(game)
+  -- Mid-battle evolution is not a phase: the movie sits on `evolving` while
+  -- the screen is still in messages/wait. Capture it once so a live fight
+  -- that actually levels into an evo leaves a reviewable frame.
+  if now and now.evolving and not seen.evolving then
+    seen.evolving = true
+    U.wait(2)
+    shotFn("phase-evolving")
+  end
   if not (now and now.sim and type(now.phase) == "string") then return seen end
   local phase = now.phase
   if phase ~= "choose" and phase ~= "move" and phase ~= "target"

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -9507,6 +9507,454 @@ end)()
 
 end)()
 
+-- ------- mid-battle evolutions (EvolveFx + queue + B-cancel + fallback skip)
+--
+-- Vanilla still only evolves after a fight. The custom screens offer a
+-- level-up evolution on the arena after that mon's grew-to lines, with the
+-- same 80-frame grace and flash clock as EvolutionState. Local only: the
+-- save updates; the hub keeps the pre-evo sheet. A movie the player already
+-- answered (accept or cancel) must not be re-offered by offerEvolutions.
+
+;(function()
+  local EvolveFx = need("EvolveFx")
+  local CoopBattle = need("CoopBattle")
+  local MediatedBattle = need("MediatedBattle")
+  local Coop = need("Coop")
+  local Battlefield = need("Battlefield")
+  local Sessions = need("Sessions")
+
+  eq(EvolveFx.CANCEL_GRACE_FRAMES, 80, "grace matches EvolutionState")
+  eq(EvolveFx.ANIM_LOOP_FRAMES, 288, "anim loop matches EvolutionState")
+  eq(EvolveFx.FLASH_FRAMES, 368, "flash is grace plus the loop")
+
+  check(not EvolveFx.showsNew(-1), "grace (negative t) shows the old form")
+  check(not EvolveFx.showsNew(0), "the loop opens on the old form")
+  -- Iteration 1: hold 16 frames of the old pic, then 6 swap frames.
+  check(not EvolveFx.showsNew(15), "still the old form at the end of the first hold")
+  check(EvolveFx.showsNew(16), "first swap frame shows the new form")
+  check(not EvolveFx.showsNew(19), "the second half of that swap is the old form again")
+  check(not EvolveFx.canCancel(80), "B is illegal on the last grace frame")
+  check(EvolveFx.canCancel(81), "B is legal on the first flash frame")
+
+  local movie = EvolveFx.begin({
+    evolve = { species = "WORM", nickname = "WIGGLY" },
+    from = "WORM", into = "MOTH", name = "WIGGLY",
+  })
+  eq(EvolveFx.picSpecies(movie), "WORM", "the movie opens on the old form")
+  EvolveFx.advance(movie, nil, true)
+  check(not movie.done, "B during the first frame does not cancel")
+  eq(movie.canceled, false, "...and does not mark canceled")
+
+  movie.frame = EvolveFx.CANCEL_GRACE_FRAMES
+  EvolveFx.advance(movie, nil, true)
+  -- advance adds 1 then checks t > GRACE, so frame becomes 81 and B is legal
+  check(movie.done, "B after grace ends the movie")
+  check(movie.canceled, "and marks it canceled")
+  eq(EvolveFx.picSpecies(movie), "WORM", "cancel keeps the old form on screen")
+
+  local run = EvolveFx.begin({
+    evolve = { species = "WORM", nickname = "WIGGLY" },
+    from = "WORM", into = "MOTH", name = "WIGGLY",
+  })
+  for _ = 1, EvolveFx.FLASH_FRAMES do
+    EvolveFx.advance(run, nil, false)
+  end
+  check(run.done, "driving the clock to FLASH_FRAMES completes the movie")
+  check(not run.canceled, "...without a cancel")
+  eq(EvolveFx.picSpecies(run), "MOTH", "and settles on the new form")
+
+  local mon = { species = "WORM", nickname = "WIGGLY", level = 7 }
+  local skip = { [mon] = true }
+  local leveled = { [mon] = true }
+  eq(EvolveFx.withoutResolved(leveled, skip), nil,
+     "a resolved mon is dropped from the after-battle set")
+  local keptEmpty = EvolveFx.withoutResolved(leveled, {})
+  check(keptEmpty and keptEmpty[mon],
+        "an empty skip set still walks the mon")
+  local other = { species = "BIRD" }
+  local mixed = { [mon] = true, [other] = true }
+  local left = EvolveFx.withoutResolved(mixed, skip)
+  check(left and left[other] and not left[mon],
+        "only the resolved mon is subtracted")
+
+  local holder = { leveledUp = { [mon] = true } }
+  EvolveFx.markResolved(holder, mon)
+  check(holder.evoResolved and holder.evoResolved[mon],
+        "markResolved records the answer")
+  check(not holder.leveledUp[mon],
+        "...and drops leveledUp so checkParty will not re-offer")
+
+  -- Queue: a LEVEL row at the current level is an evolve row; a mon that
+  -- does not qualify is not. say is stubbed so grew-to lines stay out of
+  -- the queue -- enqueue writes the special row itself.
+  local evoData = {
+    pokemon = {
+      WORM = {
+        name = "WORM",
+        evolutions = { { method = "LEVEL", species = "MOTH", level = 7 } },
+      },
+      MOTH = { name = "MOTH" },
+      BIRD = { name = "BIRD", evolutions = {} },
+    },
+  }
+  local qualifying = setmetatable({
+    game = { data = evoData },
+    messages = {},
+    say = function() end,
+  }, { __index = CoopBattle })
+  local worm = { species = "WORM", nickname = "WIGGLY", level = 7, hp = 10,
+    stats = { hp = 10 } }
+  qualifying:levelled(worm, "WIGGLY", { 7 })
+  local found
+  for _, row in ipairs(qualifying.messages) do
+    if type(row) == "table" and row.evolve == worm then found = row end
+  end
+  check(found ~= nil, "levelled queues an evolve row when pendingFor matches")
+  eq(found.into, "MOTH", "...into the LEVEL-row species")
+  check(qualifying.leveledUp and qualifying.leveledUp[worm],
+        "...and still records leveledUp for the fallback")
+
+  local birdBattle = setmetatable({
+    game = { data = evoData },
+    messages = {},
+    say = function() end,
+  }, { __index = CoopBattle })
+  local bird = { species = "BIRD", nickname = "PIP", level = 20, hp = 10,
+    stats = { hp = 10 } }
+  birdBattle:levelled(bird, "PIP", { 20 })
+  local birdRow
+  for _, row in ipairs(birdBattle.messages) do
+    if type(row) == "table" and row.evolve then birdRow = row end
+  end
+  eq(birdRow, nil, "a mon with no LEVEL row is not queued")
+
+  local mediated = setmetatable({
+    game = { data = evoData },
+    lines = {},
+    say = MediatedBattle.say,
+  }, { __index = MediatedBattle })
+  mediated:levelled(worm, "WIGGLY", { 7 })
+  check(mediated.leveledUp and mediated.leveledUp[worm],
+        "MediatedBattle.levelled now records leveledUp")
+  local medFound
+  for _, row in ipairs(mediated.lines) do
+    if type(row) == "table" and row.evolve == worm then medFound = row end
+  end
+  check(medFound ~= nil, "...and queues the same evolve row")
+
+  -- Drive the movie on a stub screen: complete applies; B after grace does
+  -- not. Engine Evolution.apply needs a real Stats.calc; pcall the apply
+  -- path and only assert species when it actually ran.
+  local applyMon = {
+    species = "WORM", nickname = "WIGGLY", level = 7, hp = 10,
+    dvs = { hp = 8, attack = 8, defense = 8, speed = 8, special = 8 },
+    statExp = { hp = 0, attack = 0, defense = 0, speed = 0, special = 0 },
+    stats = { hp = 10, attack = 10, defense = 10, speed = 10, special = 10 },
+    moves = { { id = "TACKLE", pp = 35 } },
+  }
+  local applyGame = {
+    data = evoData,
+    save = { party = { applyMon }, pokedex = { seen = {}, owned = {} } },
+    input = { wasPressed = function() return false end },
+  }
+  -- Pad the species defs so Stats.calc (if loaded) has something to eat.
+  evoData.pokemon.WORM.baseStats = evoData.pokemon.WORM.baseStats
+    or { hp = 10, attack = 10, defense = 10, speed = 10, special = 10 }
+  evoData.pokemon.MOTH.baseStats = evoData.pokemon.MOTH.baseStats
+    or { hp = 20, attack = 10, defense = 10, speed = 10, special = 10 }
+
+  local screen = setmetatable({
+    game = applyGame,
+    messages = {},
+    say = function() end,
+  }, { __index = CoopBattle })
+  local row = {
+    evolve = applyMon, from = "WORM", into = "MOTH", via = "LEVEL",
+    name = "WIGGLY",
+  }
+  check(screen:startEvolve(row), "startEvolve accepts a well-formed row")
+  check(screen.evolving, "and holds the movie")
+  check(tostring(screen.shown):find("evolving", 1, true),
+        "...under the 'is evolving!' line")
+  for _ = 1, EvolveFx.FLASH_FRAMES + 2 do
+    screen:stepEvolve()
+    if not screen.evolving then break end
+  end
+  check(not screen.evolving, "the movie ends of its own clock")
+  if applyMon.species == "MOTH" then
+    check(screen.evoResolved and screen.evoResolved[applyMon],
+          "a successful apply marks evoResolved")
+    check(tostring(screen.shown):find("evolved", 1, true),
+          "success prints the evolved-into line")
+  else
+    -- Headless apply can no-op (no Stats.calc); the clock still finished
+    -- and must not have claimed a species change it did not make.
+    eq(applyMon.species, "WORM",
+       "a failed apply leaves the species so the fallback can still offer")
+  end
+
+  -- B after grace: species unchanged, still resolved so the fallback skips.
+  local cancelMon = {
+    species = "WORM", nickname = "WIGGLY", level = 7, hp = 10,
+    stats = { hp = 10 },
+  }
+  local cancelGame = {
+    data = evoData,
+    save = { party = { cancelMon } },
+    input = { wasPressed = function(_, key) return key == "b" end },
+  }
+  local cancelScreen = setmetatable({
+    game = cancelGame,
+    messages = {},
+    say = function() end,
+  }, { __index = CoopBattle })
+  cancelScreen:startEvolve({
+    evolve = cancelMon, from = "WORM", into = "MOTH", via = "LEVEL",
+    name = "WIGGLY",
+  })
+  -- Walk the grace with B held: wasPressed is a fresh edge every tick in
+  -- this stub, but the clock refuses it until frame > 80.
+  cancelGame.input.wasPressed = function() return false end
+  for _ = 1, EvolveFx.CANCEL_GRACE_FRAMES do
+    cancelScreen:stepEvolve()
+  end
+  check(cancelScreen.evolving, "still running at the end of grace")
+  eq(cancelMon.species, "WORM", "...and has not applied")
+  cancelGame.input.wasPressed = function(_, key) return key == "b" end
+  cancelScreen:stepEvolve()
+  check(not cancelScreen.evolving, "B after grace ends the movie")
+  eq(cancelMon.species, "WORM", "cancel does not change the species")
+  check(cancelScreen.evoResolved and cancelScreen.evoResolved[cancelMon],
+        "...but still marks resolved so the fallback will not re-offer")
+  check(tostring(cancelScreen.shown):find("stopped evolving", 1, true),
+        "...and prints the stopped-evolving line")
+
+  -- offerEvolutions subtracts evoResolved.
+  local Evolution = require("src.pokemon.Evolution")
+  local realCheck = Evolution.checkParty
+  local seen
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seen = leveledUp
+    return 0
+  end
+  local caterpie = { species = "CATERPIE", level = 7 }
+  Coop.offerEvolutions(
+    { data = { pokemon = {} }, save = { party = { caterpie } } },
+    { [caterpie] = true },
+    "win",
+    { [caterpie] = true })
+  Evolution.checkParty = realCheck
+  check(seen == nil,
+        "offerEvolutions does not call checkParty for a resolved mon")
+
+  seen = nil
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seen = leveledUp
+    return 0
+  end
+  Coop.offerEvolutions(
+    { data = { pokemon = {} }, save = { party = { caterpie } } },
+    { [caterpie] = true },
+    "win",
+    nil)
+  Evolution.checkParty = realCheck
+  check(seen and seen[caterpie],
+        "and still offers when no mid-battle movie played")
+
+  -- Gen 2 apply replaces the party slot and retargets on-plate pointers.
+  local old = { species = "SLUG", level = 8 }
+  local new = { species = "SNAIL", level = 8 }
+  local g2holder = {
+    leveledUp = { [old] = true },
+    toLearn = { { mon = old, move = "TACKLE" } },
+    sim = { slots = { { battler = { mon = old } } } },
+  }
+  EvolveFx.retarget(g2holder, old, new)
+  check(g2holder.leveledUp[new] and not g2holder.leveledUp[old],
+        "Gen 2 retarget moves the leveledUp key")
+  eq(g2holder.toLearn[1].mon, new, "...and the toLearn pointer")
+  eq(g2holder.sim.slots[1].battler.mon, new, "...and the on-plate battler")
+
+  local grown, newMax, newHp = EvolveFx.hpGrowth(50, 70, 20)
+  eq(grown, 20, "evo HP growth is the max-HP delta")
+  eq(newMax, 70, "...the new ceiling")
+  eq(newHp, 40, "...and fight current HP, not save HP")
+  local noGrow, sameMax, sameHp = EvolveFx.hpGrowth(50, 50, 20)
+  eq(noGrow, 0, "no growth when max HP is unchanged")
+  eq(sameMax, 50, "...")
+  eq(sameHp, 20, "...and current HP is left alone")
+
+  local cacheMovie = EvolveFx.begin({
+    evolve = { species = "WORM" }, from = "WORM", into = "MOTH",
+  })
+  EvolveFx.formCachePut(cacheMovie, "front", "WORM", "old-pic")
+  EvolveFx.formCachePut(cacheMovie, "front", "MOTH", "new-pic")
+  eq(EvolveFx.formCacheGet(cacheMovie, "front", "WORM"), "old-pic",
+     "movie cache keeps the old front")
+  eq(EvolveFx.formCacheGet(cacheMovie, "front", "MOTH"), "new-pic",
+     "...and the new one, so a flash does not reload")
+  eq(EvolveFx.formCacheGet(cacheMovie, "front", "BIRD"), nil,
+     "a third species is a miss")
+  check(EvolveFx.flashPulse(cacheMovie) >= 0, "flashPulse is defined on an open movie")
+  cacheMovie.done = true
+  eq(EvolveFx.flashPulse(cacheMovie), 0, "...and 0 once the movie has settled")
+
+  -- Post-evo plate: grow the arena pair, remember it on levelHpGrown, and
+  -- survive a hub snapshot that still carries the pre-evo maximum.
+  local saveEvo = {
+    species = "MOTH", level = 7, hp = 99,
+    stats = { hp = 70 },
+  }
+  local arena = { maxHp = 50, hp = 20, levelHpGrown = 10, species = "WORM" }
+  local hpFight = setmetatable({
+    game = { data = evoData, save = { party = { saveEvo } } },
+    mine = { { species = "WORM", maxHp = 50, hp = 20, slot = 0 } },
+    slots = { [0] = arena },
+    active = 1,
+    mySide = "a",
+    usesBattlefield = function() return false end,
+    refreshSlotSprite = function() end,
+  }, { __index = MediatedBattle })
+  hpFight:refreshAfterEvolve(saveEvo, 50, 20)
+  eq(arena.maxHp, 70, "the plate ceiling is the evolved max HP")
+  eq(arena.hp, 40, "...and current HP grew by the same delta, not save HP")
+  eq(arena.levelHpGrown, 30, "...which is added to the level-only grown")
+  eq(hpFight.mine[1].hp, 40, "the fight sheet matches the plate, not save HP")
+  hpFight:noteSlot({ t = "hp", slot = 0, hp = 10, maxHp = 40 })
+  eq(arena.maxHp, 70, "a pre-evo hub pair does not snap the evolved ceiling")
+  eq(arena.hp, 40, "...nor the grown current HP (10 + 30 grown)")
+
+  -- Off the plate: a benched (or switched-out) mon that hits its evo level
+  -- still queues the movie, still applies to *that* save record, and does
+  -- not flash the fighter standing on the field. EXP.ALL / EXP.SHARE / a
+  -- participant sitting in its ball all land here via levelled().
+  local fieldMon = {
+    species = "BIRD", nickname = "LEAD", level = 10, hp = 30,
+    stats = { hp = 30 },
+  }
+  local benchMon = {
+    species = "WORM", nickname = "BENCH", level = 7, hp = 10,
+    dvs = { hp = 8, attack = 8, defense = 8, speed = 8, special = 8 },
+    statExp = { hp = 0, attack = 0, defense = 0, speed = 0, special = 0 },
+    stats = { hp = 10, attack = 10, defense = 10, speed = 10, special = 10 },
+    moves = { { id = "TACKLE", pp = 35 } },
+  }
+  local fxCalls = {}
+  local benchFight = setmetatable({
+    game = {
+      data = evoData,
+      save = { party = { fieldMon, benchMon }, pokedex = { seen = {}, owned = {} } },
+      input = { wasPressed = function() return false end },
+    },
+    mine = { { slot = 0, species = "BIRD" }, { slot = 1, species = "WORM" } },
+    active = 1,
+    slots = { [0] = { species = "BIRD", speciesId = "BIRD", hp = 20, maxHp = 30 } },
+    mySide = "a",
+    usesBattlefield = function() return false end,
+    emitFx = function(_, kind, index)
+      fxCalls[#fxCalls + 1] = { kind = kind, index = index }
+    end,
+    emitVfx = function() end,
+    refreshSlotSprite = function() end,
+    teach = function() end,
+    musicKind = function() return "wild" end,
+  }, { __index = MediatedBattle })
+  benchFight:levelled(benchMon, "BENCH", { 7 })
+  local benchRow
+  for _, row in ipairs(benchFight.lines) do
+    if type(row) == "table" and row.evolve == benchMon then benchRow = row end
+  end
+  check(benchRow ~= nil, "levelled on a benched mon still queues an evolve row")
+  eq(benchFight:evolveSlot(benchMon), nil, "...and evolveSlot finds no plate")
+  eq(benchFight:evolveSlot(fieldMon), 0, "...while the fighter still owns the seat")
+  check(benchFight:startEvolve(benchRow), "startEvolve accepts the bench row")
+  check(benchFight.evolving and benchFight.evolving.center,
+        "a bench evolve row plays as a centered pic")
+  check(benchFight.evolving.slot == nil, "...with no plate to flash")
+  eq(#fxCalls, 0, "...and emits no seat FX on the fighter")
+  for _ = 1, EvolveFx.FLASH_FRAMES + 2 do
+    benchFight:stepEvolve()
+    if not benchFight.evolving then break end
+  end
+  check(not benchFight.evolving, "the bench movie ends of its own clock")
+  eq(fieldMon.species, "BIRD", "the fighter on the plate is untouched")
+  eq(benchFight.slots[0].speciesId, "BIRD", "...including its seat pic")
+  if benchMon.species == "MOTH" then
+    check(benchFight.evoResolved and benchFight.evoResolved[benchMon],
+          "a successful bench apply marks evoResolved on the benched mon")
+  else
+    eq(benchMon.species, "WORM",
+       "a failed bench apply leaves the species for the after-battle fallback")
+  end
+
+  -- Same contract on CoopBattle: sim has the fighter, not the bench.
+  local coopField = { species = "BIRD", nickname = "LEAD" }
+  local coopBench = { species = "WORM", nickname = "BENCH", level = 7 }
+  local coop = setmetatable({
+    game = { data = evoData, save = { party = { coopField, coopBench } } },
+    sim = { slots = { { index = 1, battler = { mon = coopField } } } },
+    messages = {},
+    say = function() end,
+  }, { __index = CoopBattle })
+  eq(coop:evolveSlot(coopBench), nil, "CoopBattle: a benched mon has no seat")
+  eq(coop:evolveSlot(coopField), 1, "...the fighter does")
+  coop:levelled(coopBench, "BENCH", { 7 })
+  local coopRow
+  for _, row in ipairs(coop.messages) do
+    if type(row) == "table" and row.evolve == coopBench then coopRow = row end
+  end
+  check(coopRow ~= nil, "CoopBattle.levelled queues the bench evolve row")
+  check(coop:startEvolve(coopRow), "...")
+  check(coop.evolving and coop.evolving.center,
+        "CoopBattle plays a bench movie off the plate too")
+  eq(coopField.species, "BIRD", "and does not retarget the fighter")
+
+  local laid = Battlefield.layout({
+    evolveCenter = { front = "PIC", flash = 0.5 },
+  })
+  check(laid.evolveCenter and laid.evolveCenter.front == "PIC",
+        "Battlefield.layout passes a centered evo pic through")
+  eq(laid.evolveCenter.x, Battlefield.MIDLINE,
+     "...on the field midline")
+
+  -- MMO 1v1 exit: leftover leveledUp still reaches checkParty.
+  local Evolution = require("src.pokemon.Evolution")
+  local realCheck = Evolution.checkParty
+  local seenEnd
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seenEnd = leveledUp
+    return 0
+  end
+  local leftover = { species = "CATERPIE", level = 7 }
+  local sessions = Sessions.new({ send = function() end }, {})
+  local leftoverGame = { data = { pokemon = {} }, save = { party = { leftover } } }
+  sessions.fight = {
+    leveledUp = { [leftover] = true },
+    result = "win",
+    game = leftoverGame,
+  }
+  sessions:endMediated(leftoverGame, {})
+  Evolution.checkParty = realCheck
+  check(seenEnd and seenEnd[leftover],
+        "endMediated offers evolutions a mid-movie snap left unanswered")
+
+  seenEnd = nil
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seenEnd = leveledUp
+    return 0
+  end
+  sessions.fight = {
+    leveledUp = { [leftover] = true },
+    evoResolved = { [leftover] = true },
+    result = "win",
+    game = leftoverGame,
+  }
+  sessions:endMediated(leftoverGame, {})
+  Evolution.checkParty = realCheck
+  check(seenEnd == nil,
+        "...and still skips a prompt the player already answered")
+end)()
+
 -- ------------------------------------------------------------------
 -- 7b. the co-op "!" latch, the corner line, and the mark's real life
 -- ------------------------------------------------------------------
@@ -13990,6 +14438,13 @@ end)()
   local scoped = Battlefield.fxSeat(
     { { kind = "flash", side = "ally", seatIndex = 1, t = 0.25 } }, "ally", 2)
   eq(scoped.flash, 0, "a seat-scoped fx entry does not reach a different seat")
+
+  local evoFlash = Battlefield.fxSeat(
+    { { kind = "evolve", side = "ally", seatIndex = 1, t = 0.5 } }, "ally", 1)
+  check(evoFlash.flash > 0, "an evolve fx whites the matching seat")
+  local evoMiss = Battlefield.fxSeat(
+    { { kind = "evolve", side = "ally", seatIndex = 1, t = 0.5 } }, "ally", 2)
+  eq(evoMiss.flash, 0, "...and no other")
 
   -- Nothing matched: the neutral answer is one shared record, so a caller that
   -- wrote into what fxSeat handed back would move every unaffected seat on the

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -9388,6 +9388,123 @@ check(fightsAlone(ann),
      "syntheticFinish did not run on top of consume")
 end)()
 
+-- ------- issue #65 — co-op level-ups must run Evolution.checkParty
+--
+-- The engine offers level-up evolutions from BattleState:finish via
+-- Evolution.checkParty(game, onDone, battle.leveledUp). A co-op fight never
+-- runs that finish: it pops the buried battle up front and later only calls
+-- onFinish, which is OverworldState:afterBattle — and afterBattle no longer
+-- walks leveledUp. CoopBattle.levelled still records the set; handing it to
+-- afterBattle is not enough. The check has to run on the way out, or a
+-- Caterpie that hit 7 in a 2-on-2 stays a Caterpie until the next wild
+-- level-up or a Rare Candy.
+
+;(function()
+  local Evolution = require("src.pokemon.Evolution")
+  local CoopBattle = need("CoopBattle")
+  local realCheck = Evolution.checkParty
+  local seen
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seen = { game = game, onDone = onDone, leveledUp = leveledUp }
+    return 0
+  end
+
+  local function restore() Evolution.checkParty = realCheck end
+
+  -- The screen still records what levelled. That set is what checkParty
+  -- walks; without it the offer below would have nothing to offer.
+  local recorded = setmetatable({
+    game = { data = { pokemon = {} } },
+    say = function() end,
+  }, { __index = CoopBattle })
+  local abra = { species = "FIXMON_A", nickname = "ABBY" }
+  recorded:levelled(abra, "ABBY", { 16 })
+  check(recorded.leveledUp and recorded.leveledUp[abra],
+        "CoopBattle.levelled notes the save-party mon for the evolution check")
+
+  local caterpie = { species = "CATERPIE", level = 7, hp = 20, stats = { hp = 20 } }
+  local function bareStack(states)
+    return {
+      states = states,
+      top = function(self) return self.states[#self.states] end,
+      pop = function(self) return table.remove(self.states) end,
+      push = function(self, st) self.states[#self.states + 1] = st end,
+    }
+  end
+  local buried = {
+    kind = "trainer",
+    trainer = { baseMoney = 10 },
+    enemyParty = { { level = 8 } },
+    onFinish = function() end,
+  }
+  local game = {
+    stack = bareStack({ {} }),
+    save = { party = { caterpie }, money = 0 },
+  }
+  local walkIn = setmetatable({
+    running = false,
+    engineBattle = buried,
+    battle = { plan = {} },
+    transport = { send = function() end },
+    ui = { say = function() end },
+  }, { __index = Coop })
+  walkIn:onBattleOver("win", game, { leveledUp = { [caterpie] = true } }, {})
+  restore()
+
+  check(seen ~= nil,
+        "a co-op win that levelled a mon runs Evolution.checkParty")
+  eq(seen.game, game, "against the save that took the level")
+  check(seen.leveledUp and seen.leveledUp[caterpie],
+        "for the same party mon CoopBattle.levelled recorded")
+
+  -- Invite / menu joiner: no buried BattleState, so consume is a no-op and
+  -- syntheticFinish is the path that has to offer. Same stub as TT3.
+  seen = nil
+  Evolution.checkParty = function(game, onDone, leveledUp)
+    seen = { game = game, leveledUp = leveledUp }
+    return 0
+  end
+  local ow = {
+    engaging = true,
+    map = { def = { label = "FIX_TOWN" } },
+    npcPool = {
+      route3_bug_a = {
+        frozen = true,
+        def = { trainerClass = "OPP_BUG_CATCHER", trainerParty = 1, index = 1 },
+      },
+    },
+    checkVictoryRewards = function() end,
+    afterBattle = function() end,
+  }
+  local inviteGame = {
+    save = { money = 100, defeatedTrainers = {}, flags = {}, party = { caterpie } },
+    data = {
+      trainers = {
+        OPP_BUG_CATCHER = {
+          baseMoney = 10,
+          parties = { { { level = 12 } } },
+        },
+      },
+    },
+    stack = bareStack({ ow }),
+  }
+  local invite = setmetatable({
+    running = false,
+    battle = { plan = { npcId = "route3_bug_a" } },
+    transport = { send = function() end },
+    ui = { say = function() end },
+  }, { __index = Coop })
+  local savedWorld = stubMod.world
+  stubMod.world = { overworld = function() return ow end }
+  invite:onBattleOver("win", inviteGame, { leveledUp = { [caterpie] = true } }, {})
+  stubMod.world = savedWorld
+  restore()
+  check(seen ~= nil,
+        "an invite-joiner win that levelled a mon also runs checkParty")
+  check(seen.leveledUp and seen.leveledUp[caterpie],
+        "off the co-op screen's set, not a second copy")
+end)()
+
 end)()
 
 -- ------------------------------------------------------------------

--- a/tmp/e2e-battlefield/suite.tail.txt
+++ b/tmp/e2e-battlefield/suite.tail.txt
@@ -1,5 +1,5 @@
-[info] loaded mod rby_mmo 1.1.0
-[info] loaded mod rby_mmo 1.1.0
-[info] loaded mod rby_mmo 1.1.0
-[info] loaded mod rby_mmo 1.1.0
-5174/5174 checks passed  (rby_mmo)
+[info] loaded mod rby_mmo 1.1.1
+[info] loaded mod rby_mmo 1.1.1
+[info] loaded mod rby_mmo 1.1.1
+[info] loaded mod rby_mmo 1.1.1
+5341/5341 checks passed  (rby_mmo)


### PR DESCRIPTION
## Summary
- Co-op fights never ran the engine’s after-battle evolution check (they pop the buried `BattleState` and skip `finish`), so a Caterpie that hit 7 in a 2-on-2 stayed a Caterpie. Walk-in and invite-joiner exits now offer evolutions for whoever actually levelled.
- Custom fight screens (co-op / MMO / solo) now play the evolution movie **on the arena** after that mon’s “grew to level N!” lines — same flash clock and B-cancel as vanilla — instead of waiting until the fight ends. Accept and cancel both stick so the after-battle check does not re-ask.
- Local only, same contract as exp and levels: this client’s save and sprite update; the hub and everyone else keep the uploaded pre-evo sheet for the rest of the fight. Bench mons that level off-field get a centered pic.

## Test plan
- [ ] Co-op: level a Caterpie (or similar) to its evo level in a 2-on-2; confirm the evolution prompt appears after the fight (and mid-battle if it qualifies during the movie).
- [ ] MMO 1v1 / solo custom fight: same, including B-cancel after the grace, and that a cancelled (or accepted) evo is not offered again at the end.
- [ ] Bench / EXP.ALL: a mon that levels while not on the field still gets the centered movie; the fighter on the plate is unchanged.
- [ ] Partner client still draws the pre-evo species for the rest of that fight.

Closes #65