### PR TITLE
fix: end wild fights that hang on Waiting for WILD

### DIFF
--- a/server/battle2_turn.test.js
+++ b/server/battle2_turn.test.js
@@ -602,6 +602,49 @@ test('timeout sweep Struggles an empty sheet instead of pushing the clock', () =
     'the timeout closed the turn instead of waiting another window');
 });
 
+test('a dead wild in the choice window ends the fight on tick', () => {
+  const battle = build({
+    id: 'deadwild-tick', mode: 'wild', seed: 3, choiceTimeout: 0, reconnectGrace: 60,
+    sides: {
+      a: [{ playerId: 'p1', name: 'Ann', mons: [
+        mn({ species: 'Alpha', maxHp: 200, atk: 90, spe: 80,
+          moves: [mv('thump', 40, 255, 0)] })] }],
+      b: [{ playerId: 'p2', name: 'WILD', mons: [
+        mn({ species: 'Beta', maxHp: 40, spe: 10,
+          moves: [mv('nudge', 10, 255, 0)] })] }],
+    },
+  });
+  battle.drainEvents();
+  const foe = battle.byId.get('p2');
+  foe.mons[0].hp = 0;
+  foe.active = null;
+  assert.strictEqual(battle.tick(0), true, 'gen2: one tick notices the empty side');
+  const out = battle.outcome();
+  assert.ok(out, 'gen2: and the fight ends rather than waiting for the wild');
+  assert.strictEqual(out.reason, 'ko', 'gen2: as a knockout');
+});
+
+test('FIGHT with nobody to aim at is a skip that closes a dead wild', () => {
+  const battle = build({
+    id: 'deadwild-skip', mode: 'wild', seed: 3, choiceTimeout: 0, reconnectGrace: 60,
+    sides: {
+      a: [{ playerId: 'p1', name: 'Ann', mons: [
+        mn({ species: 'Alpha', maxHp: 200, atk: 90, spe: 80,
+          moves: [mv('thump', 40, 255, 0)] })] }],
+      b: [{ playerId: 'p2', name: 'WILD', mons: [
+        mn({ species: 'Beta', maxHp: 40, spe: 10,
+          moves: [mv('nudge', 10, 255, 0)] })] }],
+    },
+  });
+  battle.drainEvents();
+  const foe = battle.byId.get('p2');
+  foe.mons[0].hp = 0;
+  foe.active = null;
+  assert.ok(battle.submitChoice('p1', { action: 'fight', move: 0 }),
+    'gen2: FIGHT with nobody to aim at is accepted as a skip');
+  assert.ok(battle.outcome(), 'gen2: and the skip closes the fight');
+});
+
 test('every sentence about a move prints its name, and falls back to the id', () => {
   // Gen 2's own copies of the five call sites. Byte-shared with the Gen 1 pair
   // next door, and separate on purpose: BattleSim2 / lib/battle2 are a twin,

--- a/server/battle_turn.test.js
+++ b/server/battle_turn.test.js
@@ -1413,6 +1413,49 @@ test('timeout sweep Struggles an empty sheet instead of pushing the clock', () =
     'the timeout closed the turn instead of waiting another window');
 });
 
+test('a dead wild in the choice window ends the fight on tick', () => {
+  const battle = build({
+    id: 'deadwild-tick', mode: 'wild', seed: 3, choiceTimeout: 0, reconnectGrace: 60,
+    sides: {
+      a: [{ playerId: 'p1', name: 'Ann', mons: [
+        mn({ species: 'Alpha', maxHp: 200, atk: 90, spd: 80,
+          moves: [mv('thump', 40, 255, 0)] })] }],
+      b: [{ playerId: 'p2', name: 'WILD', mons: [
+        mn({ species: 'Beta', maxHp: 40, spd: 10,
+          moves: [mv('nudge', 10, 255, 0)] })] }],
+    },
+  });
+  battle.drainEvents();
+  const foe = battle.byId.get('p2');
+  foe.mons[0].hp = 0;
+  foe.active = null;
+  assert.strictEqual(battle.tick(0), true, 'one tick notices the empty side');
+  const out = battle.outcome();
+  assert.ok(out, 'and the fight ends rather than waiting for the wild');
+  assert.strictEqual(out.reason, 'ko', 'as a knockout');
+});
+
+test('FIGHT with nobody to aim at is a skip that closes a dead wild', () => {
+  const battle = build({
+    id: 'deadwild-skip', mode: 'wild', seed: 3, choiceTimeout: 0, reconnectGrace: 60,
+    sides: {
+      a: [{ playerId: 'p1', name: 'Ann', mons: [
+        mn({ species: 'Alpha', maxHp: 200, atk: 90, spd: 80,
+          moves: [mv('thump', 40, 255, 0)] })] }],
+      b: [{ playerId: 'p2', name: 'WILD', mons: [
+        mn({ species: 'Beta', maxHp: 40, spd: 10,
+          moves: [mv('nudge', 10, 255, 0)] })] }],
+    },
+  });
+  battle.drainEvents();
+  const foe = battle.byId.get('p2');
+  foe.mons[0].hp = 0;
+  foe.active = null;
+  assert.ok(battle.submitChoice('p1', { action: 'fight', move: 0 }),
+    'FIGHT with nobody to aim at is accepted as a skip');
+  assert.ok(battle.outcome(), 'and the skip closes the fight');
+});
+
 // ------------------------------------------------------------------
 // properties a fixture cannot state
 // ------------------------------------------------------------------

--- a/server/lib/battle/Turn.js
+++ b/server/lib/battle/Turn.js
@@ -1092,7 +1092,13 @@ class Battle {
             if (foe.mustReplace) { targetFighter = foe; break; }
           }
         }
-        if (!targetFighter) return null;
+        if (!targetFighter) {
+          // Same leftover as `_autoChoiceOrSkip`: a living seat with nobody
+          // across the field to aim at spends the turn rather than hanging
+          // the window. Solo's choice clock is 0, so a refused FIGHT used
+          // to mark the band answered and wait for WILD forever.
+          return { action: 'skip' };
+        }
       }
       return { action: 'fight', move: index + 1, target: targetFighter.slot };
     }
@@ -1540,6 +1546,11 @@ class Battle {
   }
 
   _openTurn() {
+    // A side that is already down must not be asked for a move. Without this,
+    // a faint that left the field in `choice` (or `_closeReplace` after an
+    // empty send-out) opened a window nobody across the field could answer,
+    // and Solo's zero timeout left the band on "Waiting for WILD...".
+    if (this._checkOver()) return;
     this.phase = 'choice';
     this.resolveDeadline = null;
     this.forcedPending = false;
@@ -3191,6 +3202,13 @@ class Battle {
     const now = int(nowSeconds, this.now);
     if (now > this.now) this.now = now;
     if (this.result) return false;
+
+    // A side that is already down must not sit out a choice window. Solo's
+    // clock is 0, so a faint that left the field in `choice` used to wait
+    // forever for an answer nobody can file -- the band on "Waiting for WILD...".
+    if ((this.phase === 'choice' || this.phase === 'replace') && this._checkOver()) {
+      return true;
+    }
 
     // Forced-only turns opened by the previous resolve wait here so one drain
     // does not swallow a whole trap / recharge / thrash chain.

--- a/server/lib/battle2/Turn.js
+++ b/server/lib/battle2/Turn.js
@@ -1091,7 +1091,13 @@ class Battle {
             if (foe.mustReplace) { targetFighter = foe; break; }
           }
         }
-        if (!targetFighter) return null;
+        if (!targetFighter) {
+          // Same leftover as `_autoChoiceOrSkip`: a living seat with nobody
+          // across the field to aim at spends the turn rather than hanging
+          // the window. Solo's choice clock is 0, so a refused FIGHT used
+          // to mark the band answered and wait for WILD forever.
+          return { action: 'skip' };
+        }
       }
       return { action: 'fight', move: index + 1, target: targetFighter.slot };
     }
@@ -1539,6 +1545,11 @@ class Battle {
   }
 
   _openTurn() {
+    // A side that is already down must not be asked for a move. Without this,
+    // a faint that left the field in `choice` (or `_closeReplace` after an
+    // empty send-out) opened a window nobody across the field could answer,
+    // and Solo's zero timeout left the band on "Waiting for WILD...".
+    if (this._checkOver()) return;
     this.phase = 'choice';
     this.resolveDeadline = null;
     this.forcedPending = false;
@@ -3183,6 +3194,13 @@ class Battle {
     const now = int(nowSeconds, this.now);
     if (now > this.now) this.now = now;
     if (this.result) return false;
+
+    // A side that is already down must not sit out a choice window. Solo's
+    // clock is 0, so a faint that left the field in `choice` used to wait
+    // forever for an answer nobody can file -- the band on "Waiting for WILD...".
+    if ((this.phase === 'choice' || this.phase === 'replace') && this._checkOver()) {
+      return true;
+    }
 
     // Forced-only turns opened by the previous resolve wait here so one drain
     // does not swallow a whole trap / recharge / thrash chain.

--- a/src/BattleSim/Turn.lua
+++ b/src/BattleSim/Turn.lua
@@ -1093,7 +1093,13 @@ function Battle:_normaliseChoice(fighter, choice)
           if foe.mustReplace then targetFighter = foe; break end
         end
       end
-      if not targetFighter then return nil end
+      if not targetFighter then
+        -- Same leftover as `_autoChoiceOrSkip`: a living seat with nobody
+        -- across the field to aim at spends the turn rather than hanging
+        -- the window. Solo's choice clock is 0, so a refused FIGHT used
+        -- to mark the band answered and wait for WILD forever.
+        return { action = "skip" }
+      end
     end
     return { action = "fight", move = index + 1, target = targetFighter.slot }
   end
@@ -1558,6 +1564,11 @@ end
 -- ------------------------------------------------------------------
 
 function Battle:_openTurn()
+  -- A side that is already down must not be asked for a move. Without this,
+  -- a faint that left the field in `choice` (or `_closeReplace` after an
+  -- empty send-out) opened a window nobody across the field could answer,
+  -- and Solo's zero timeout left the band on "Waiting for WILD...".
+  if self:_checkOver() then return end
   self.phase = "choice"
   self.resolveDeadline = nil
   self.forcedPending = false
@@ -3220,6 +3231,13 @@ function Battle:tick(nowSeconds)
   local now = int(nowSeconds, self.now)
   if now > self.now then self.now = now end
   if self.result then return false end
+
+  -- A side that is already down must not sit out a choice window. Solo's
+  -- clock is 0, so a faint that left the field in `choice` used to wait
+  -- forever for an answer nobody can file -- the band on "Waiting for WILD...".
+  if (self.phase == "choice" or self.phase == "replace") and self:_checkOver() then
+    return true
+  end
 
   -- Forced-only turns opened by the previous resolve wait here so one drain
   -- does not swallow a whole trap / recharge / thrash chain.

--- a/src/BattleSim2/Turn.lua
+++ b/src/BattleSim2/Turn.lua
@@ -1105,7 +1105,13 @@ function Battle:_normaliseChoice(fighter, choice)
           if foe.mustReplace then targetFighter = foe; break end
         end
       end
-      if not targetFighter then return nil end
+      if not targetFighter then
+        -- Same leftover as `_autoChoiceOrSkip`: a living seat with nobody
+        -- across the field to aim at spends the turn rather than hanging
+        -- the window. Solo's choice clock is 0, so a refused FIGHT used
+        -- to mark the band answered and wait for WILD forever.
+        return { action = "skip" }
+      end
     end
     return { action = "fight", move = index + 1, target = targetFighter.slot }
   end
@@ -1570,6 +1576,11 @@ end
 -- ------------------------------------------------------------------
 
 function Battle:_openTurn()
+  -- A side that is already down must not be asked for a move. Without this,
+  -- a faint that left the field in `choice` (or `_closeReplace` after an
+  -- empty send-out) opened a window nobody across the field could answer,
+  -- and Solo's zero timeout left the band on "Waiting for WILD...".
+  if self:_checkOver() then return end
   self.phase = "choice"
   self.resolveDeadline = nil
   self.forcedPending = false
@@ -3219,6 +3230,13 @@ function Battle:tick(nowSeconds)
   local now = int(nowSeconds, self.now)
   if now > self.now then self.now = now end
   if self.result then return false end
+
+  -- A side that is already down must not sit out a choice window. Solo's
+  -- clock is 0, so a faint that left the field in `choice` used to wait
+  -- forever for an answer nobody can file -- the band on "Waiting for WILD...".
+  if (self.phase == "choice" or self.phase == "replace") and self:_checkOver() then
+    return true
+  end
 
   -- Forced-only turns opened by the previous resolve wait here so one drain
   -- does not swallow a whole trap / recharge / thrash chain.

--- a/src/MediatedBattle.lua
+++ b/src/MediatedBattle.lua
@@ -1053,7 +1053,11 @@ function M.submitChoice(transport, battle, fields)
       .. "sent; press again, or wait for the turn clock")
     return false
   end
-  transport:send(Wire.BATTLE_CHOICE, out)
+  -- `false` is a real refusal (already answered, a switch that names
+  -- nobody). The hub send returns true/nil; only an explicit false must
+  -- keep the menu open. A no-target FIGHT is a skip at the referee now,
+  -- not a failed send.
+  if transport:send(Wire.BATTLE_CHOICE, out) == false then return false end
   return true
 end
 

--- a/src/SoloBattle.lua
+++ b/src/SoloBattle.lua
@@ -706,7 +706,11 @@ function M:_transport(pending)
           pending.party = payload
         end
       elseif msgType == Wire.BATTLE_CHOICE then
-        solo:_choose(payload)
+        -- `false` is a real referee refusal (already answered, a switch
+        -- that names nobody). The screen keeps the menu open then.
+        -- Parked RUN is handled, not refused -- `_choose` returns true
+        -- so `sendChoice` still closes the menu for the pump.
+        return solo:_choose(payload) and true or false
       end
       -- Everything else -- a session leave on the way out, a reconnect nudge
       -- from a transport that never dropped -- is about a hub this fight does
@@ -770,11 +774,11 @@ function M:_choose(payload)
   if payload.action == "run" then
     if self.kind == "trainer" then
       self.refuseRun = true
-      return false
+      return true
     end
     if not self:_escapes() then
       self.failedRun = true
-      return false
+      return true
     end
   end
   return sim:submitChoice(PLAYER_SEAT, payload) and true or false

--- a/tests/battle_sim2_turn.lua
+++ b/tests/battle_sim2_turn.lua
@@ -950,6 +950,50 @@ do
      "the timeout closed the turn instead of waiting another window")
 end
 
+-- A dead side left in `choice` must end the fight. Same hang the Gen 1
+-- twin pins: FIGHT used to return nil (no living foe) and a zero timeout
+-- sat on "Waiting for WILD...".
+do
+  local battle = battleOf({
+    choiceTimeout = 0,
+    mode = "wild",
+    sides = {
+      a = { { playerId = "p1", name = "Ann",
+              mons = { mon({ species = "Alpha", maxHp = 200, atk = 90, spe = 80 }) } } },
+      b = { { playerId = "p2", name = "Bob",
+              mons = { mon({ species = "Beta", maxHp = 40, spe = 10 }) } } },
+    },
+  })
+  drain(battle)
+  local foe = battle.byId.p2
+  foe.mons[1].hp = 0
+  foe.active = nil
+  ok(battle:tick(0) == true, "gen2: one tick notices the empty side")
+  local out = battle:outcome()
+  ok(out ~= nil, "gen2: and the fight ends rather than waiting for the wild")
+  eq(out and out.reason, "ko", "gen2: as a knockout")
+end
+
+do
+  local battle = battleOf({
+    choiceTimeout = 0,
+    mode = "wild",
+    sides = {
+      a = { { playerId = "p1", name = "Ann",
+              mons = { mon({ species = "Alpha", maxHp = 200, atk = 90, spe = 80 }) } } },
+      b = { { playerId = "p2", name = "Bob",
+              mons = { mon({ species = "Beta", maxHp = 40, spe = 10 }) } } },
+    },
+  })
+  drain(battle)
+  local foe = battle.byId.p2
+  foe.mons[1].hp = 0
+  foe.active = nil
+  ok(battle:submitChoice("p1", { action = "fight", move = 0 }),
+     "gen2: FIGHT with nobody to aim at is accepted as a skip")
+  ok(battle:outcome() ~= nil, "gen2: and the skip closes the fight")
+end
+
 -- ------------------------------------------------------------------
 
 io.write(string.format("battle_sim2_turn: %d passed, %d failed\n", passed, failed))

--- a/tests/battle_sim_turn.lua
+++ b/tests/battle_sim_turn.lua
@@ -4823,6 +4823,49 @@ do
 end
 
 -- ------------------------------------------------------------------
+-- 12n. a dead side in the choice window ends the fight
+-- ------------------------------------------------------------------
+--
+-- A faint that left the field in `choice` (active cleared, hp 0, no
+-- `_checkOver`) used to hang: the player filed FIGHT, `_normaliseChoice`
+-- returned nil (no living foe), Solo's clock is 0 so nothing timed out,
+-- and the band sat on "Waiting for WILD...". tick() now ends that window,
+-- and a FIGHT with nobody to aim at is a skip so the turn can close.
+
+do
+  local battle = battleOf({
+    choiceTimeout = 0,
+    mode = "wild",
+    aMons = { mon({ species = "Alpha", maxHp = 200, atk = 90, spd = 80 }) },
+    bMons = { mon({ species = "Beta", maxHp = 40, spd = 10 }) },
+  })
+  drain(battle)
+  local foe = battle.byId.p2
+  foe.mons[1].hp = 0
+  foe.active = nil
+  ok(battle:tick(0) == true, "one tick notices the empty side")
+  local out = battle:outcome()
+  ok(out ~= nil, "and the fight ends rather than waiting for the wild")
+  eq(out and out.reason, "ko", "as a knockout")
+end
+
+do
+  local battle = battleOf({
+    choiceTimeout = 0,
+    mode = "wild",
+    aMons = { mon({ species = "Alpha", maxHp = 200, atk = 90, spd = 80 }) },
+    bMons = { mon({ species = "Beta", maxHp = 40, spd = 10 }) },
+  })
+  drain(battle)
+  local foe = battle.byId.p2
+  foe.mons[1].hp = 0
+  foe.active = nil
+  ok(battle:submitChoice("p1", { action = "fight", move = 0 }),
+     "FIGHT with nobody to aim at is accepted as a skip")
+  ok(battle:outcome() ~= nil, "and the skip closes the fight")
+end
+
+-- ------------------------------------------------------------------
 -- 13. the vocabulary, on everything every scenario above produced
 -- ------------------------------------------------------------------
 

--- a/tests/solo_battle.lua
+++ b/tests/solo_battle.lua
@@ -585,7 +585,10 @@ end)()
   local sim, fight = f.sim, f.fight
   local hpBefore = sim.byId[PLAYER].mons[1].hp
   local turnBefore = sim.turn
-  fight:sendChoice({ action = "run" })
+  ok(fight:sendChoice({ action = "run" }),
+     "a failed escape is handled, not a refused send")
+  eq(fight.answeredTurn, true, "so the menu closes for the pump")
+  eq(fight.phase, "play", "and the command slab is gone while the line plays")
   f.solo:update(1 / 60, f.game)
   f.solo:update(1 / 60, f.game)
 
@@ -651,6 +654,8 @@ end)()
 
   eq(saidTimes(fight, "running from"), 1, "the screen refuses, once")
   eq(f.solo.refuseRun, true, "and the referee parked the refusal for the pump")
+  eq(fight.answeredTurn, true, "the send is handled, so the menu closes")
+  eq(fight.phase, "play", "until the pump feeds the turn that reopens it")
 
   f.solo:update(1 / 60, f.game)
   eq(saidTimes(fight, "running from"), 1,
@@ -795,6 +800,94 @@ end)()
   f.solo:update(1 / 60, f.game)
   ok(f.sim.turn > turnBefore or f.sim:outcome() ~= nil,
      "one pump after the player files is enough")
+end)()
+
+-- ------------------------------------------------------------------
+-- 7c. a fainted wild in the choice window does not wait forever
+-- ------------------------------------------------------------------
+--
+-- The screenshot hang: Drowzee's bar empty, Marcel asleep, band on
+-- "Waiting for WILD...". The wild is already down, so `_owes` is false
+-- for it and autoPick will not file. The player can still press FIGHT;
+-- that used to be refused (no living target) while the screen marked
+-- the turn answered, and SOLO_CHOICE_TIMEOUT is 0, so the wait never
+-- ended. One pump must close the fight.
+
+;(function()
+  local f = fightOf("wild", {
+    party = { mon({ species = "ALPHA", spd = 90, atk = 40, maxHp = 200 }) },
+    wildMon = mon({ species = "BETA", spd = 5, maxHp = 40, atk = 5 }),
+  })
+  ok(f.started, "the encounter opened")
+  local foe = f.sim.byId[FOE]
+  foe.mons[1].hp = 0
+  foe.active = nil
+  f.solo:update(1 / 60, f.game)
+  local out = f.sim:outcome()
+  ok(out ~= nil, "one pump ends a wild that is already down")
+  eq(out and out.reason, "ko", "as a knockout, not a timeout")
+  eq(f.fight.phase, "over", "and the screen leaves the wait line")
+  eq(f.fight.finished, true, "finish ran, so draw no longer calls holdLine")
+  for _ = 1, 30 do f.solo:update(1 / 60, f.game) end
+  ok(f.sim:outcome() ~= nil, "later pumps do not reopen the window")
+  eq(f.fight.phase, "over", "thirty frames later it is still over")
+end)()
+
+;(function()
+  local f = fightOf("wild", {
+    party = { mon({ species = "ALPHA", spd = 90, atk = 40, maxHp = 200 }) },
+    wildMon = mon({ species = "BETA", spd = 5, maxHp = 40, atk = 5 }),
+  })
+  local player = f.sim.byId[PLAYER]
+  player.mons[1].status = "sleep"
+  player.mons[1].statusTurns = 3
+  local foe = f.sim.byId[FOE]
+  foe.mons[1].hp = 0
+  foe.active = nil
+  -- The player still files, the way an asleep seat does in Gen 1. The
+  -- referee must not refuse the fight and leave the band waiting.
+  ok(f.fight:sendChoice({ action = "fight", move = 0 }),
+     "FIGHT against a downed wild is not a silent refusal")
+  f.solo:update(1 / 60, f.game)
+  ok(f.sim:outcome() ~= nil, "and the asleep player is not stuck waiting")
+  eq(f.fight.phase, "over", "the hold line is gone")
+  eq(f.fight.finished, true, "the ending is on the screen, not Waiting for WILD")
+end)()
+
+-- Sleep alone is not the hang: an asleep lead still finishes a living wild.
+;(function()
+  local f = fightOf("wild", {
+    party = { mon({ species = "ALPHA", spd = 90, atk = 120, maxHp = 200 }) },
+    wildMon = mon({ species = "BETA", spd = 5, maxHp = 20, atk = 5 }),
+  })
+  f.sim.byId[PLAYER].mons[1].status = "sleep"
+  f.sim.byId[PLAYER].mons[1].statusTurns = 2
+  local out = playOut(f, 80)
+  ok(out ~= nil, "sleep alone does not wedge a wild fight")
+end)()
+
+-- The client contract: a transport that returns false must not mark the
+-- turn answered. A hub send that returns nil is still a success.
+;(function()
+  local Mediated = need("MediatedBattle")
+  local seen = 0
+  eq(Mediated.submitChoice({
+    send = function() seen = seen + 1; return false end,
+  }, "solo_1", { action = "fight", move = 0 }), false,
+     "an explicit false send keeps the turn unspent")
+  eq(seen, 1, "the choice still reached the transport")
+
+  eq(Mediated.submitChoice({
+    send = function() end,
+  }, "solo_1", { action = "fight", move = 0 }), true,
+     "a hub send that returns nil is still a success")
+
+  local f = fightOf("wild", {})
+  eq(f.fight.answeredTurn, false, "the opening window is unanswered")
+  eq(f.fight:sendChoice({ action = "switch", slot = 5 }), false,
+     "a switch that names nobody is refused")
+  eq(f.fight.answeredTurn, false,
+     "and the screen does not pretend the turn was spent")
 end)()
 
 -- ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- A fainted wild left in the choice window could not autoPick, FIGHT was refused (no living target), and Solo's zero timeout never expired — the band sat on "Waiting for WILD..." forever.
- The referee now ends that window (`tick` / `_openTurn` call `_checkOver`) and treats a no-target FIGHT as a skip so the turn can close. Same change on the Lua and JS twins.
- A parked RUN (trainer refuse, failed wild escape) is handled, not a failed send, so the menu still closes for the pump.

## Test plan
- [x] `luajit tests/solo_battle.lua` — dead wild, sleep + dead wild, failed escape / trainer RUN menu contract
- [x] `luajit tests/battle_sim_turn.lua` / `tests/battle_sim2_turn.lua`
- [x] `node server/battle_turn.test.js` / `server/battle2_turn.test.js`
- [ ] In-game: faint a wild and confirm the fight ends instead of waiting for WILD
- [ ] In-game: fail a wild RUN (Can't escape! + free attack) and refuse a trainer RUN (menu comes back)