### PR TITLE
feature: let players drop in gym, indoor, and wild battle arenas

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -148,6 +148,7 @@ docs/plans/nire-back-sprite-pixel-ratio.md
 docs/plans/non-blocking-avatars.md
 docs/plans/coop-joiner-refights-the-trainer.md
 docs/plans/in-game-notifications.md
+docs/plans/battle-custom-bg.md
 # The upstream issue behind the mod-sandbox migration: a request for storage
 # scoped to the copy rather than to one playthrough. Same footing as the plans
 # above -- it argues with the engine about Storage.lua, and a player who

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ here must match `manifest.version`.
   Gold hub is not reset to 1. The VPS section of `server/README.md` now
   points at the pair instead of five commands to copy.
 
+## [1.2.1] - 2026-09-02
+
+### Added
+
+- **Custom battle backgrounds.** Drop 640×360 PNGs into
+  `assets/battle/custom/` as `wild.png`, `indoor.png`, and `gym.png` to
+  replace the ROM-stamped arena for that kind of fight. Optional
+  `wild_field.png` / `indoor_field.png` / `gym_field.png` draw on top of
+  the background (or on the ROM / authored fallback when only the field
+  file is present). A missing file keeps today's look. Next fight picks
+  the files up; no extra permission, no bytes shipped.
+
 ## [1.2.0] - 2026-09-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.2.0](https://img.shields.io/badge/version-1.2.0-3aa757?style=for-the-badge)
+![v1.2.1](https://img.shields.io/badge/version-1.2.1-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -313,6 +313,13 @@ tileset into the two platforms — ROM pixels at runtime, never shipped.
   <img src="docs/screenshots/arena-gym.png" width="760" alt="Pewter Gym fight stamped from that room's own GYM tileset">
 </p>
 <p align="center"><em>Gym / cave — still that room's own sheet</em></p>
+
+Want your own look? Drop 640×360 PNGs in `assets/battle/custom/` named
+`wild.png`, `indoor.png`, and `gym.png`. Those replace the ROM stamp for
+that kind of fight (caves and routes use wild; houses use indoor; gyms
+use gym). An optional `wild_field.png` (same for indoor/gym) draws on
+top — keep the room and swap only the platforms, or ship both. Your art,
+not a ROM dump. A missing file keeps the default. The next battle reloads.
 
 ### 🤜 CO-OP — YOUR PARTY IS THE YES
 Walk into a trainer while you're partied and standing on the same map, and
@@ -1519,7 +1526,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.2.0` (`experimental: false` — on by default when installed). The full
+It's `1.2.1` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,6 +19,7 @@ Working notes for features that were (or are being) implemented in this repo.
 | [`battle-sim-move-effects.md`](battle-sim-move-effects.md) | Complete; locked BattleSim decisions |
 | [`offline-solo-battles.md`](offline-solo-battles.md) | Solo wild + trainer fights on BattleSim, option default off, no wire change — in progress |
 | [`3x3-battles-and-3-player-parties.md`](3x3-battles-and-3-player-parties.md) | Party max 3; 3×3 PvP / 3×NPC / 3×Wild; PvP square-only — awaiting approval |
+| [`battle-custom-bg.md`](battle-custom-bg.md) | Player drop-in gym / indoor / wild arena PNGs — shipped |
 
 ## Historical
 

--- a/docs/plans/battle-custom-bg.md
+++ b/docs/plans/battle-custom-bg.md
@@ -1,0 +1,117 @@
+# Plan — Custom battle backgrounds (gym / indoor / wild)
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-02 |
+| Source | conversation: support for battle custom bg/field |
+| Config | AGENTS_CONFIG.yml (quality; host cursor) |
+| Flags | none (grill questions skipped — proceed on logged assumptions) |
+| Gates | assumptions logged after skipped grill; implementing on that basis |
+| Branch | feature/support-for-battle-custom-bg |
+| Base SHA | 93d2a3354ce1a3ae5db8401eabb8a36765f5d40f |
+
+## 1. Objective & success criteria
+
+Players can drop their own 640×360 PNGs so gym, indoor, and wild fights use
+that art instead of the ROM-stamped two-platform arena. A missing file keeps
+today's look. No new permission, no wire change, no ROM bytes shipped.
+
+Success: a present `assets/battle/custom/wild.png` (or indoor/gym) is what
+`Battlefield.load` returns for that kind, even when `composeRomArena` would
+succeed; the suite pins kind, paths, and that load order.
+
+## 2. Context & constraints
+
+Live fights stamp the current overworld tileset into a 640×360 canvas
+(`Battlefield.composeRomArena`). Classification already exists:
+
+- Gym: `GYM` / `DOJO` / `TILESET_GYM` (Johto gyms stay gym even when
+  `environment=INDOOR`) — `gymSheet` in `src/Battlefield.lua`
+- Indoor: houses, marts, centers — `arenaIndoor`
+- Wild: routes, caves, forest, overworld — everything else
+
+Authored fallbacks (`assets/battle/outdoor_grass_arena.png`,
+`indoor_house_arena.png`) only run when ROM compose fails. There is no gym
+fallback PNG and no player-override hook. `love.filesystem` is sandboxed;
+`mod.assets:path` is the load seam. Manifest has `network` +
+`engine_internals`, not `filesystem`.
+
+Legal: custom files are the player's. This repo still ships only the original
+authored fallbacks.
+
+Peer: `keen-cedar-021b` is on `Battlefield.lua` for a PP-HUD fix on
+`fix/realtime-pp-fix`. This work stays in the arena-load / kind path.
+
+## 3. Approach & key decisions
+
+Grill was skipped. Assumptions (reversible except #2, which is the feature):
+
+1. **Drop-in files**, not options and not `filesystem`. Fixed names under
+   `assets/battle/custom/`. `mod.assets:path` + `love.graphics.newImage`.
+2. **Custom beats ROM compose.** Otherwise an imported ROM (everyone) never
+   sees the files.
+3. **Three buckets** via existing classifiers. Caves → wild.
+4. **`{kind}.png` is the full arena.** Optional `{kind}_field.png` composites
+   on top (ROM/fallback underlay when only the field file exists).
+5. **No shipped placeholders.** Presence means override. Directory kept with
+   `.gitkeep`.
+6. **No gym authored fallback** in this run. Gym without custom still uses
+   ROM, then the outdoor PNG — same as today.
+7. **Per-client cosmetic.** No hub message. Each player sees their own files.
+8. **Next fight picks them up.** `reloadArena` already runs at fight entry.
+
+Rejected: text-option paths (naming-grid UX), adding `filesystem`,
+server-pushed BGs (protocol + legal), replacing only the no-ROM PNGs
+(invisible on a real import).
+
+## 4. Work breakdown — implementation
+
+| ID | Goal | Files | Deps | Acceptance |
+| --- | --- | --- | --- | --- |
+| I1 | Path constants + custom dir | `src/Config.lua`, `assets/battle/custom/.gitkeep` | — | Six documented relative paths |
+| I2 | Kind, custom load, ROM-second | `src/Battlefield.lua` | I1 | `arenaKind`; custom bg wins; field overlays; no-game still does not lock the authored PNG |
+| I3 | Docs | `CHANGELOG.md`, `README.md`, `docs/plans/README.md`, `.modkitignore` | I1 | Unreleased note + drop-in convention |
+
+## 5. Work breakdown — tests
+
+E2e: not applicable (no new user-visible flow that needs LOVE + ROM; the
+shot driver still captures the default three looks when custom files are
+absent).
+
+| ID | Covers | File |
+| --- | --- | --- |
+| T1 | `arenaKind` gym/indoor/wild; custom paths; `load` prefers stub custom over stub ROM; field-only composites onto ROM; missing custom unchanged | `tests/rby_mmo_test.lua` |
+
+## 6. Execution waves
+
+Wave 1: I1 + I2 + I3 + T1 (single surface; no fan-out).
+
+## 7. Blast radius & risks
+
+Callers of `Battlefield.load` / `reloadArena` (`MediatedBattle`, `CoopBattle`,
+`drawArena`) pick up the new source automatically. A corrupt custom PNG
+falls through to ROM/fallback (pcall). Pack stays clean: no new ROM-like
+PNG, plan listed in `.modkitignore`.
+
+## 8. Open questions / assumptions
+
+| Question | Answer | Source | Confidence |
+| --- | --- | --- | --- |
+| How do players supply art? | Drop-in PNGs in the mod folder | sandbox + existing `mod.assets` | high |
+| bg vs field layers? | Full `{kind}.png`; optional `{kind}_field.png` overlay | parse of “bg/field”; reversible | medium |
+| Beat ROM or fallback-only? | Beat ROM | otherwise feature is invisible | high |
+| Caves? | Wild | existing field bucket | high |
+| Options / filesystem? | No | reversible later | high |
+
+## 9. Completeness ledger
+
+| Item | Disposition |
+| --- | --- |
+| `M.load` / `drawArena` / fight-entry reload | in this run (I2) |
+| Kind classifier + paths + load-order tests | in this run (T1) |
+| README / CHANGELOG / custom dir | in this run (I3) |
+| Authored gym fallback PNG + generator | out of scope — different art ticket |
+| Mod-manager file picker / `filesystem` | out of scope — different ticket |
+| Hub-shared arena (both clients same art) | out of scope — protocol |
+| `arena_bg_shot.lua` recapture | out of scope — defaults unchanged when custom absent |
+| PP HUD work on same file | out of scope — other branch |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Battlefield.lua
+++ b/src/Battlefield.lua
@@ -369,11 +369,13 @@ end
 
 -- ------- asset load
 --
--- Prefer the player's own ROM tiles at runtime (the overworld tileset the
--- fight is standing on). Those pixels never ship in this repo -- they live
--- in assets/generated/ after a ROM import, the same cache the sprites
--- already read. The authored PNG and the two-platform stand-in are only
--- what a headless boot or a missing cache falls back to.
+-- Prefer a player drop-in at assets/battle/custom/{wild,indoor,gym}.png
+-- (optional {kind}_field.png overlay) when that file loads. Otherwise stamp
+-- the player's own ROM tiles (the overworld tileset the fight is standing
+-- on). Those pixels never ship in this repo -- they live in assets/generated/
+-- after a ROM import, the same cache the sprites already read. The authored
+-- PNG and the two-platform stand-in are only what a headless boot or a
+-- missing cache falls back to.
 
 local function peekGame()
   local game = nil
@@ -384,38 +386,8 @@ local function peekGame()
   return nil
 end
 
-function M.load(modFacade, game)
-  modFacade = modFacade or mod
-  if arenaTried then return arenaImage end
-
-  game = game or peekGame()
-  if type(M.composeRomArena) == "function" then
-    local rom = M.composeRomArena(game)
-    if rom then
-      arenaImage = rom
-      arenaTried = true
-      return arenaImage
-    end
-  end
-  -- No game yet (fight entry before the world facade is live): do not lock
-  -- the PNG in, or the first draw could never upgrade to the ROM tiles.
-  if not game then return nil end
-
-  local indoor = false
-  pcall(function()
-    local ow = modFacade and modFacade.world and modFacade.world.overworld
-      and modFacade.world:overworld()
-    local map = ow and ow.map
-    local id = (map and map.tileset and map.tileset.id)
-      or (map and map.def and map.def.tileset)
-    indoor = M.arenaIndoor(id, map and map.def)
-  end)
-  local path = indoor and Config.BATTLEFIELD_ARENA_INDOOR or Config.BATTLEFIELD_ARENA
-  if type(path) ~= "string" or path == "" then
-    path = Config.BATTLEFIELD_ARENA
-  end
+local function resolveArenaPath(modFacade, path)
   if type(path) ~= "string" or path == "" then return nil end
-
   local resolved = path
   local assets = modFacade and modFacade.assets
   if assets and assets.path then
@@ -424,22 +396,166 @@ function M.load(modFacade, game)
       resolved = got
     end
   end
+  return resolved
+end
 
+local function loadArenaImage(modFacade, path)
+  local resolved = resolveArenaPath(modFacade, path)
+  if not resolved then return nil end
   if not (love and love.graphics and love.graphics.newImage) then
     return nil
   end
-
   local ok, img = pcall(love.graphics.newImage, resolved)
-  if ok and img then
-    pcall(function()
-      if img.setFilter then img:setFilter("nearest", "nearest") end
-    end)
-    arenaImage = img
-    arenaTried = true
-    return arenaImage
+  if not (ok and img) then return nil end
+  pcall(function()
+    if img.setFilter then img:setFilter("nearest", "nearest") end
+  end)
+  return img
+end
+
+-- kind is wild | indoor | gym. layer is "bg" (the full arena) or "field"
+-- (optional overlay). Unknown kind is no path. Any layer other than
+-- "field" is the full-arena bg.
+function M.customArenaPath(kind, layer)
+  if kind ~= "wild" and kind ~= "indoor" and kind ~= "gym" then
+    return nil
+  end
+  local pack = (layer == "field")
+    and Config.BATTLEFIELD_ARENA_CUSTOM_FIELD
+    or Config.BATTLEFIELD_ARENA_CUSTOM
+  if type(pack) ~= "table" then return nil end
+  local path = pack[kind]
+  if type(path) ~= "string" or path == "" then return nil end
+  return path
+end
+
+function M.customArenaLayers(modFacade, kind)
+  return {
+    bg = loadArenaImage(modFacade, M.customArenaPath(kind, "bg")),
+    field = loadArenaImage(modFacade, M.customArenaPath(kind, "field")),
+  }
+end
+
+-- Stretch both images onto the theatre canvas so a 640×360 drop-in and a
+-- differently sized overlay still line up with the seats.
+function M.compositeArena(under, over)
+  if over == nil then return under end
+  if under == nil then return over end
+  if not (love and love.graphics and love.graphics.newCanvas) then
+    return under
+  end
+  local okC, canvas = pcall(love.graphics.newCanvas, M.WIDTH, M.HEIGHT)
+  if not (okC and canvas) then return under end
+  local prev = nil
+  local painted = false
+  pcall(function()
+    prev = love.graphics.getCanvas()
+    love.graphics.setCanvas(canvas)
+    love.graphics.clear(0, 0, 0, 1)
+    love.graphics.setColor(1, 1, 1, 1)
+    local function blit(img)
+      if img == nil then return end
+      local iw, ih = M.WIDTH, M.HEIGHT
+      pcall(function() iw, ih = img:getDimensions() end)
+      love.graphics.draw(img, 0, 0, 0,
+        M.WIDTH / math.max(iw, 1), M.HEIGHT / math.max(ih, 1))
+    end
+    blit(under)
+    blit(over)
+    painted = true
+  end)
+  pcall(function() love.graphics.setCanvas(prev) end)
+  if not painted then return under end
+  pcall(function()
+    if canvas.setFilter then canvas:setFilter("nearest", "nearest") end
+  end)
+  return canvas
+end
+
+local function lockArena(img)
+  if img == nil then return nil end
+  arenaImage = img
+  arenaTried = true
+  return arenaImage
+end
+
+function M.load(modFacade, game)
+  modFacade = modFacade or mod
+  if arenaTried then return arenaImage end
+
+  game = game or peekGame()
+  -- Do not guess "wild" before the map is known: a gym fight's first
+  -- draw would otherwise lock wild.png and never upgrade. A game table
+  -- without an overworld map is not a classification -- only a live map is.
+  -- M.overworldFrom, not the local: this function is declared above that
+  -- helper, and a bare name here would be a global nil.
+  local kind = nil
+  local ow = nil
+  if type(M.overworldFrom) == "function" then
+    ow = M.overworldFrom(game)
+  end
+  if type(ow) == "table" and type(ow.map) == "table" then
+    kind = M.arenaKindFromWorld(game)
   end
 
-  if modFacade and modFacade.log and modFacade.log.warn then
+  local layers = { bg = nil, field = nil }
+  if kind and type(M.customArenaLayers) == "function" then
+    local ok, got = pcall(M.customArenaLayers, modFacade, kind)
+    if ok and type(got) == "table" then
+      layers.bg = got.bg
+      layers.field = got.field
+    end
+  end
+
+  local function withField(base)
+    if base == nil then return nil end
+    if layers.field == nil then return base end
+    if type(M.compositeArena) ~= "function" then return base end
+    local ok, mixed = pcall(M.compositeArena, base, layers.field)
+    if ok and mixed ~= nil then return mixed end
+    return base
+  end
+
+  -- Custom bg wins over ROM, but only once the kind is known.
+  if layers.bg ~= nil then
+    return lockArena(withField(layers.bg))
+  end
+
+  if type(M.composeRomArena) == "function" then
+    local rom = M.composeRomArena(game)
+    if rom then
+      return lockArena(withField(rom))
+    end
+  end
+  -- No game yet (fight entry before the world facade is live): do not lock
+  -- the PNG in, or the first draw could never upgrade to the ROM tiles.
+  -- Field-only custom waits here too, so it can sit on the ROM stamp.
+  if not game then return nil end
+
+  local indoor = (kind == "indoor")
+  if not indoor then
+    pcall(function()
+      local ow = M.overworldFrom(game)
+      local map = ow and ow.map
+      local id = (map and map.tileset and map.tileset.id)
+        or (map and map.def and map.def.tileset)
+      indoor = M.arenaIndoor(id, map and map.def)
+    end)
+  end
+  local path = indoor and Config.BATTLEFIELD_ARENA_INDOOR or Config.BATTLEFIELD_ARENA
+  if type(path) ~= "string" or path == "" then
+    path = Config.BATTLEFIELD_ARENA
+  end
+  local img = loadArenaImage(modFacade, path)
+  if img then
+    return lockArena(withField(img))
+  end
+  if layers.field ~= nil then
+    return lockArena(layers.field)
+  end
+
+  if type(path) == "string" and path ~= ""
+      and modFacade and modFacade.log and modFacade.log.warn then
     modFacade.log:warn("could not load battlefield arena %s; top-down "
       .. "theatre paints the two-platform stand-in -- reinstall the mod so "
       .. "%s is present", tostring(path), tostring(path))
@@ -2285,6 +2401,33 @@ function M.arenaIndoor(tilesetId, mapDef)
   end
   if type(tilesetId) ~= "string" or tilesetId == "" then return false end
   return true
+end
+
+-- The three drop-in buckets. Gym wins over a house environment (Johto).
+-- Empty input is wild -- same default as the outdoor authored PNG.
+function M.arenaKind(tilesetId, mapDef)
+  local id = tilesetId
+  if (type(id) ~= "string" or id == "") and type(mapDef) == "table" then
+    id = mapDef.tileset
+  end
+  if gymSheet(id) then return "gym" end
+  if M.arenaIndoor(tilesetId, mapDef) then return "indoor" end
+  return "wild"
+end
+
+function M.arenaKindFromWorld(game)
+  local ow = overworldFrom(game)
+  local map = ow and ow.map
+  local id = nil
+  if type(map) == "table" then
+    if type(map.tileset) == "table" then
+      id = map.tileset.id
+    end
+    if (type(id) ~= "string" or id == "") and type(map.def) == "table" then
+      id = map.def.tileset
+    end
+  end
+  return M.arenaKind(id, map and map.def)
 end
 
 local function lookupTileset(sets, id)

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -969,6 +969,20 @@ M.BATTLE_HUD_META_HEIGHT = 5
 -- caps so fill-scale can stretch it to the window.
 M.BATTLEFIELD_ARENA = "assets/battle/outdoor_grass_arena.png"
 M.BATTLEFIELD_ARENA_INDOOR = "assets/battle/indoor_house_arena.png"
+-- Player drop-ins. A present file beats ROM compose for that kind; a missing
+-- file is not an error. `{kind}.png` is the full 640×360 arena; optional
+-- `{kind}_field.png` is drawn on top (ROM / authored fallback underneath
+-- when only the field file exists).
+M.BATTLEFIELD_ARENA_CUSTOM = {
+  wild = "assets/battle/custom/wild.png",
+  indoor = "assets/battle/custom/indoor.png",
+  gym = "assets/battle/custom/gym.png",
+}
+M.BATTLEFIELD_ARENA_CUSTOM_FIELD = {
+  wild = "assets/battle/custom/wild_field.png",
+  indoor = "assets/battle/custom/indoor_field.png",
+  gym = "assets/battle/custom/gym_field.png",
+}
 M.BATTLEFIELD_WIDTH = 640
 M.BATTLEFIELD_HEIGHT = 360
 

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -14039,12 +14039,112 @@ end)()
         "arena art path ends with outdoor_grass_arena.png")
   check(Config.BATTLEFIELD_ARENA_INDOOR:match("indoor_house_arena%.png$") ~= nil,
         "indoor arena art path ends with indoor_house_arena.png")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM.wild,
+     "assets/battle/custom/wild.png",
+     "custom wild arena path")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM.indoor,
+     "assets/battle/custom/indoor.png",
+     "custom indoor arena path")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM.gym,
+     "assets/battle/custom/gym.png",
+     "custom gym arena path")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM_FIELD.wild,
+     "assets/battle/custom/wild_field.png",
+     "custom wild field overlay path")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM_FIELD.indoor,
+     "assets/battle/custom/indoor_field.png",
+     "custom indoor field overlay path")
+  eq(Config.BATTLEFIELD_ARENA_CUSTOM_FIELD.gym,
+     "assets/battle/custom/gym_field.png",
+     "custom gym field overlay path")
+  check(type(Battlefield.customArenaPath) == "function",
+        "customArenaPath is a Battlefield entry")
+  eq(Battlefield.customArenaPath("wild"),
+     "assets/battle/custom/wild.png", "wild bg drop-in")
+  eq(Battlefield.customArenaPath("indoor", "bg"),
+     "assets/battle/custom/indoor.png", "indoor bg drop-in")
+  eq(Battlefield.customArenaPath("gym", "field"),
+     "assets/battle/custom/gym_field.png", "gym field drop-in")
+  eq(Battlefield.customArenaPath("cave"), nil,
+     "unknown kind is not a path")
+  eq(Battlefield.customArenaPath("wild", "sky"),
+     "assets/battle/custom/wild.png",
+     "unknown layer is the full-arena bg, not a fourth file")
   check(type(Battlefield.composeRomArena) == "function",
         "ROM tileset compose is a Battlefield entry")
   eq(Battlefield.composeRomArena(nil), nil,
      "no game means no ROM compose (headless / no cache)")
   eq(Battlefield.composeRomArena({}), nil,
      "an empty game with no tilesets does not invent ROM art")
+  do
+    local savedRom = Battlefield.composeRomArena
+    local savedLayers = Battlefield.customArenaLayers
+    local savedComposite = Battlefield.compositeArena
+    local savedKind = Battlefield.arenaKindFromWorld
+    local savedOw = Battlefield.overworldFrom
+    local stubMod = { log = { warn = function() end }, assets = {
+      path = function(_, rel) return rel end,
+    } }
+    local function gymWorld()
+      return { map = { tileset = { id = "GYM" }, def = { tileset = "GYM" } } }
+    end
+    Battlefield.reloadArena()
+    Battlefield.composeRomArena = function() return "ROM" end
+    Battlefield.overworldFrom = gymWorld
+    local seenKind = nil
+    Battlefield.arenaKindFromWorld = function() return "gym" end
+    Battlefield.customArenaLayers = function(_, kind)
+      seenKind = kind
+      return { bg = "CUSTOM", field = nil }
+    end
+    eq(Battlefield.load(stubMod, {}), "CUSTOM",
+       "custom bg wins over ROM compose")
+    eq(seenKind, "gym", "custom layers are asked for the classified kind")
+    Battlefield.reloadArena()
+    Battlefield.overworldFrom = function() return nil end
+    Battlefield.arenaKindFromWorld = savedKind
+    Battlefield.customArenaLayers = function()
+      return { bg = "CUSTOM", field = nil }
+    end
+    eq(Battlefield.load(stubMod, {}), "ROM",
+       "a game table without a map does not lock custom wild")
+    Battlefield.reloadArena()
+    Battlefield.composeRomArena = function() return nil end
+    eq(Battlefield.load(stubMod, nil), nil,
+       "no game does not lock custom wild before the map is known")
+    Battlefield.composeRomArena = function() return "ROM" end
+    Battlefield.overworldFrom = gymWorld
+    Battlefield.reloadArena()
+    Battlefield.customArenaLayers = function()
+      return { bg = nil, field = nil }
+    end
+    eq(Battlefield.load(stubMod, {}), "ROM",
+       "missing custom falls through to ROM compose")
+    Battlefield.reloadArena()
+    Battlefield.customArenaLayers = function()
+      return { bg = nil, field = "FIELD" }
+    end
+    Battlefield.compositeArena = function(under, over)
+      return tostring(under) .. "+" .. tostring(over)
+    end
+    eq(Battlefield.load(stubMod, {}), "ROM+FIELD",
+       "field-only custom overlays the ROM stamp")
+    Battlefield.reloadArena()
+    Battlefield.overworldFrom = function() return nil end
+    Battlefield.composeRomArena = function() return nil end
+    Battlefield.customArenaLayers = function()
+      return { bg = nil, field = nil }
+    end
+    Battlefield.compositeArena = savedComposite
+    eq(Battlefield.load(stubMod, nil), nil,
+       "no game and no custom does not lock the authored PNG")
+    Battlefield.composeRomArena = savedRom
+    Battlefield.customArenaLayers = savedLayers
+    Battlefield.compositeArena = savedComposite
+    Battlefield.arenaKindFromWorld = savedKind
+    Battlefield.overworldFrom = savedOw
+    Battlefield.reloadArena()
+  end
   check(type(Battlefield.arenaFieldTileset) == "function",
         "arenaFieldTileset classifies indoor vs field")
   eq(Battlefield.arenaFieldTileset("HOUSE"), false,
@@ -14077,6 +14177,30 @@ end)()
      true, "Johto gyms stay on TILESET_GYM even though environment is INDOOR")
   eq(Battlefield.arenaIndoor("TILESET_GYM", { environment = "INDOOR" }), false,
      "TILESET_GYM is not the house indoor fallback")
+  check(type(Battlefield.arenaKind) == "function",
+        "arenaKind is the custom-bg bucket")
+  eq(Battlefield.arenaKind("OVERWORLD"), "wild", "OVERWORLD is wild")
+  eq(Battlefield.arenaKind("FOREST"), "wild", "FOREST is wild")
+  eq(Battlefield.arenaKind("CAVERN"), "wild", "caves bucket as wild")
+  eq(Battlefield.arenaKind(nil), "wild",
+     "no tileset is wild -- outdoor PNG stays the default")
+  eq(Battlefield.arenaKind("HOUSE"), "indoor", "HOUSE is indoor")
+  eq(Battlefield.arenaKind("REDS_HOUSE_2"), "indoor",
+     "REDS_HOUSE_2 is indoor")
+  eq(Battlefield.arenaKind(nil, { environment = "INDOOR" }), "indoor",
+     "Gen2 INDOOR environment is indoor")
+  eq(Battlefield.arenaKind("GYM"), "gym", "GYM is gym")
+  eq(Battlefield.arenaKind("DOJO"), "gym", "DOJO is gym")
+  eq(Battlefield.arenaKind("TILESET_GYM", { environment = "INDOOR" }), "gym",
+     "Johto gyms stay gym even though environment is INDOOR")
+  eq(Battlefield.arenaKind(nil, {
+       tileset = "TILESET_GYM", environment = "INDOOR",
+     }), "gym", "AZALEA_GYM-shaped def is gym")
+  eq(Battlefield.arenaKind("OVERWORLD", { outdoor = false }), "indoor",
+     "outdoor=false is indoor even on OVERWORLD")
+  eq(Battlefield.arenaKindFromWorld({
+       world = { map = { tileset = { id = "GYM" }, def = { tileset = "GYM" } } },
+     }), "gym", "Gold game.world gym map is gym")
   eq(Battlefield.arenaFieldTileset(nil, {
        tileset = "TILESET_GYM", environment = "INDOOR",
      }), true, "AZALEA_GYM-shaped def keeps TILESET_GYM")


### PR DESCRIPTION
## Summary
- Players can replace the ROM-stamped battle field by dropping 640×360 PNGs in `assets/battle/custom/` as `wild.png`, `indoor.png`, and `gym.png`.
- Optional `*_field.png` overlays sit on top of that background, or on the ROM/authored fallback when only the field file is present.
- Custom art only applies once a live overworld map classifies the fight, so a gym cannot lock `wild.png` on the first frame.

## Test plan
- [x] `luajit tests/rby_mmo_test.lua` from the engine checkout (5599/5599)
- [ ] Start a route fight with `assets/battle/custom/wild.png` present and confirm it replaces the ROM stamp
- [ ] Repeat in a house (`indoor.png`) and a gym (`gym.png`)
- [ ] Confirm a missing file keeps today’s ROM/authored look
- [ ] Confirm a gym fight without a map yet does not lock `wild.png`