### PR TITLE
feature: add Party-menu toggles for wild and NPC coop battles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+### Added
+
+- **Party menu WILD / NPC coop toggles, on by default.** While partied,
+  PARTY offers separate `WILD: ON`/`OFF` and `NPC: ON`/`OFF` rows so you
+  can walk together and still fight grass or trainers alone. Off skips
+  divert and auto-join of that kind (Gen 1 and Gen 2); JOIN on the
+  partner still takes a standing offer. An opted-out member of a
+  3-person party is not pulled in when someone else joins (`skip` on
+  the wait, not a decline). Toggles re-read from the save on a
+  playthrough swap.
+
 ## [1.3.1] - 2026-09-06
 
 ### Fixed

--- a/server/lib/relay.js
+++ b/server/lib/relay.js
@@ -954,6 +954,20 @@ handlers['mmo.coop_cancel'] = (relay, client, msg) => {
     relay.clearCoopOffer(client, reason);
     return;
   }
+  // Partner opted out of this wait (PARTY WILD/NPC off). Record them on the
+  // waiter's offer so coop_join does not seat them, but do not clear the
+  // offer and do not tell the host -- another partner can still join.
+  // Must not reuse `no`: that would force the host solo.
+  if (reason === 'skip') {
+    for (const partner of relay.partnersOf(client)) {
+      if (partner.coopOffer) {
+        partner.coopOffer.skip = partner.coopOffer.skip || {};
+        partner.coopOffer.skip[client.id] = true;
+        return;
+      }
+    }
+    return;
+  }
   // Partner declined our invite: clear the waiter's offer and tell them so
   // they can go in alone. Only `no` takes this path. Walk every other member:
   // partnerOf alone can miss the waiter in a 3-person party.
@@ -996,15 +1010,29 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
   host.coopOffer = null;
   client.coopOffer = null;
 
-  const party = relay.partyMembers(client.partyId);
-  const members = party.map((m) => ({ id: m.id, name: m.name }));
-  const memberIds = party.map((m) => m.id);
+  // Seat host + joiner + every other party member who has not opted out of
+  // this wait (`offer.skip`). The joiner is always seated -- JOIN is the
+  // override after a skip. All-ON 3-person parties still seat everyone:
+  // nobody skipped. A silent 2vN for an all-ON trio is the bug this keeps.
+  const skip = offer.skip || {};
+  const members = [];
+  const memberIds = [];
+  const seated = new Set();
+  const seat = (who) => {
+    if (!who || seated.has(who.id)) return;
+    seated.add(who.id);
+    members.push({ id: who.id, name: who.name });
+    memberIds.push(who.id);
+  };
+  seat(host);
+  seat(client);
+  for (const member of relay.partyMembers(client.partyId)) {
+    if (!skip[member.id]) seat(member);
+  }
 
   // Told differently on purpose: the player who was waiting learns *who*
   // joined -- it is the answer they have been standing there for -- and the
   // player who joined is handed the roster, because they never had one.
-  // Seat every current party member (hub order), not only host+joiner --
-  // otherwise a 3-person party vs NPC is silently 2vN.
   // The mode is taken from the offer when the waiter named one: coop_wild for
   // Party vs Wild (auto-join grass), otherwise coop_npc for the trainer path.
   // The four-way path below is the only one that makes a coop_pvp, because it
@@ -1022,7 +1050,7 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
   // fight silently stays on host CoopSim while the joiner alone holds `c*`.
   // `id` remains the joiner (who joined), matching what clients already read.
   relay.send(host, 'mmo.coop_joined',
-    { id: client.id, name: client.name, plan: battleId });
+    { id: client.id, name: client.name, plan: battleId, allies: members });
   // `host` names the client that simulates: the player who was already standing
   // at the fight, since they are the one guaranteed to have walked into the
   // encounter -- the joiner usually has too, but a join taken from the ACTIONS
@@ -1030,8 +1058,9 @@ handlers['mmo.coop_join'] = (relay, client, msg) => {
   // as coop_wild without re-deriving from an offer that is already cleared.
   // `npcId` / `event` (PROTOCOL 20) ride so a menu joiner can finish the
   // trainer off without a local BattleState -- never fuzzy-matched by class.
-  // Every non-host party member gets coop_battle so a third seat is not
-  // left holding a mediated id with no screen.
+  // Every seated non-host gets coop_battle so a third seat is not left
+  // holding a mediated id with no screen -- and an opted-out member is
+  // not handed one they turned off.
   const battleMsg = {
     id: battleId, side: 'a', allies: members, battle, host: host.id, mode,
   };

--- a/server/lib/sanitize.js
+++ b/server/lib/sanitize.js
@@ -268,6 +268,8 @@ const COOP_REASONS = {
   alone: true, left: true, started: true, no: true, gone: true, timeout: true,
   // party-vs-party size not equal / not 2-or-3 (hub refuse; T7 phrases)
   mismatch: true,
+  // partner turned this kind of coop off; does not end the wait
+  skip: true,
 };
 
 function cleanSide(value) {

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -719,6 +719,19 @@ M.SOLO_BATTLES_DEFAULT = false
 -- battle and a flip mid-fight cannot swap chrome under a live turn.
 M.CLASSIC_BATTLE_UI_DEFAULT = false
 
+-- Party-menu toggles for co-op divert: whether a partied player pulls (and
+-- is pulled into) wild encounters and NPC trainers.
+--
+-- On by default, because forming the party is still the consent -- these
+-- rows are the out for a player who wants to walk together and fight grass
+-- or gyms alone, without dissolving the party. Read at the encounter (and
+-- at auto-join), so a flip on PARTY takes effect on the next fight rather
+-- than on the next launch. Independent of each other, and of SOLO BATTLES:
+-- a partnered player with WILD: OFF still fights the engine's own grass,
+-- whatever that row says.
+M.COOP_WILD_DEFAULT = true
+M.COOP_NPC_DEFAULT = true
+
 -- Which BattleSim mode each solo fight is seated as.
 --
 -- Two modes rather than one, and the difference is mechanical rather than

--- a/src/Coop.lua
+++ b/src/Coop.lua
@@ -42,7 +42,9 @@
 --    this client is free, and the waiter's own clock is what ends a wait
 --    nobody ever takes. The outs did not go anywhere and are the whole reason
 --    no ask is needed: the SOLO_FALLBACK_AFTER self-release, STOP once a fight
---    is up -- and, for a player who wants none of this, cancelling the party.
+--    is up, the PARTY menu's WILD / NPC rows (off skips divert and auto-join
+--    of that kind; JOIN on the partner still takes a standing offer) -- and,
+--    for a player who wants none of this, cancelling the party.
 -- 2. **The fight cannot be dodged.**  Once a trainer has been triggered, every
 --    exit from every prompt this module raises ends in a battle.  The engine
 --    has already committed to the encounter by the time this module is called,
@@ -103,6 +105,43 @@ local SOLO_FALLBACK_AFTER = 6
 local M = {}
 M.__index = M
 
+-- Save keys for the PARTY-menu WILD / NPC rows. Not mod-manager options:
+-- they live next to MEMBERS / SAY / LEAVE because they only mean anything
+-- while partied. Defaults live on Config so a silent flip to off would be
+-- a test failure, not a comment.
+M.WILD_OPTION = "coopwild"
+M.NPC_OPTION = "coopnpc"
+
+local function savedBool(key, default)
+  default = default ~= false
+  local ok, value = pcall(function()
+    return mod.save and mod.save.get and mod.save:get(key)
+  end)
+  if not ok then return default end
+  if value == true then return true end
+  if value == false then return false end
+  return default
+end
+
+local function storeBool(key, value)
+  pcall(function()
+    if mod.save and mod.save.set then
+      mod.save:set(key, value and true or false)
+    end
+  end)
+end
+
+-- Labels the PARTY menu prints. ON/OFF is the current state, not "what
+-- pressing does" -- these are policy rows, and OPTIONS toggles already
+-- teach that reading. Both fit the PARTY box (tw = 11).
+function M.wildMenuLabel(on)
+  return on and "WILD: ON" or "WILD: OFF"
+end
+
+function M.npcMenuLabel(on)
+  return on and "NPC: ON" or "NPC: OFF"
+end
+
 function M.new(transport, ui, party, roster, chat)
   return setmetatable({
     transport = transport,
@@ -110,6 +149,13 @@ function M.new(transport, ui, party, roster, chat)
     party = party,
     roster = roster,
     chat = chat,
+    -- Party-menu coop divert. Initialized from mod.save so a flip survives
+    -- a disconnect; default ON. Read at the encounter, not latched at
+    -- party formation, so PARTY > WILD: OFF takes effect on the next grass
+    -- tile. Tests that want off assign the field directly (avoids polluting
+    -- the shared stub save).
+    wildCoop = savedBool(M.WILD_OPTION, Config.COOP_WILD_DEFAULT),
+    npcCoop = savedBool(M.NPC_OPTION, Config.COOP_NPC_DEFAULT),
     -- our own standing offer: { battle, label, map, start }
     waiting = nil,
     -- the partner's, as it arrived: { from, name, battle, label, map, clock }
@@ -164,6 +210,38 @@ function M.new(transport, ui, party, roster, chat)
     running = false,
     clock = 0,
   }, M)
+end
+
+-- Whether this client still wants co-op of that kind. Nil and true are ON
+-- (the default); only an explicit false is off. Instance field wins so a
+-- test can flip one side without writing the shared stub save.
+function M:wantsWild()
+  return self.wildCoop ~= false
+end
+
+function M:wantsNpc()
+  return self.npcCoop ~= false
+end
+
+function M:setWantsWild(on)
+  self.wildCoop = on ~= false
+  storeBool(M.WILD_OPTION, self.wildCoop)
+  return self.wildCoop
+end
+
+function M:setWantsNpc(on)
+  self.npcCoop = on ~= false
+  storeBool(M.NPC_OPTION, self.npcCoop)
+  return self.npcCoop
+end
+
+-- Trainer waits have no mode token on the wire (nil); wild waits send
+-- coop_wild. JOIN-from-menu does not consult this -- that row is the
+-- explicit override.
+function M:wantsOffer(offer)
+  if not offer then return false end
+  if offer.mode == "coop_wild" then return self:wantsWild() end
+  return self:wantsNpc()
 end
 
 -- ------- naming a fight
@@ -241,6 +319,12 @@ function M:reset()
   self.pendingWarp = nil
   self.running = false
   self.clock = 0
+  -- Re-read the PARTY toggles. Coop is a process-lifetime singleton, and
+  -- save.loaded / save.created call reset() after a playthrough swap: keeping
+  -- the previous file's ON/OFF would apply the last player's choice to this
+  -- one. Missing keys are the Config defaults (ON).
+  self.wildCoop = savedBool(M.WILD_OPTION, Config.COOP_WILD_DEFAULT)
+  self.npcCoop = savedBool(M.NPC_OPTION, Config.COOP_NPC_DEFAULT)
 end
 
 -- Let the encounter proceed, exactly once.
@@ -829,6 +913,10 @@ function M:onTrainerBattle(game, state, mapId)
   if kind ~= "trainer" then return false end
   if not (self.transport:isReady() and self.party:has()) then return false end
   if self.running then return false end
+  -- PARTY > NPC: OFF: fight the engine trainer, post nothing. Same answer
+  -- as "not in a party" -- co-op is an addition, and a player who turned
+  -- this row off must not be pulled into (or pull anyone into) an NPC fight.
+  if not self:wantsNpc() then return false end
   -- Every partner has to be standing on this map. Refused *before* the
   -- encounter is claimed and before anything is sent: no COOP_WAIT, no offer
   -- for anyone to hold, no wait to time out. A 3-person party with one person
@@ -951,6 +1039,10 @@ function M:onWildEncounter(game, state, mapId)
   if kind ~= "wild" then return false end
   if not (self.transport:isReady() and self.party:has()) then return false end
   if self.running or self.waiting or self.ask then return false end
+  -- PARTY > WILD: OFF: leave the engine wild alone, including when the
+  -- partner already posted a coop_wild wait -- auto-join is the pull this
+  -- row turns off. JOIN on the partner still takes the standing offer.
+  if not self:wantsWild() then return false end
   if self.offer then
     if self.offer.mode ~= "coop_wild" then return false end
     -- Partner already waiting on grass: join them; do not start a local wait.
@@ -1304,6 +1396,21 @@ end
 function M:considerOffer(game, myMap)
   local offer = self.offer
   if not offer then return false end
+  -- Leave the offer standing: JOIN on the partner is the override, and
+  -- M:update would otherwise have nothing to retry if this were a drop.
+  -- Tell the hub once so a 3-person JOIN does not seat us. `skip` is not
+  -- a `no` -- that would force the host solo even if another partner wants
+  -- in. Must not fire while we ourselves are waiting: the same cancel would
+  -- clear *our* offer (the trap the offer-timeout `no` already names).
+  -- Sent even while busy or off-map, so an opted-out third is marked before
+  -- someone else joins.
+  if not self:wantsOffer(offer) then
+    if not self.waiting and not offer.skipped and self.transport:isReady() then
+      offer.skipped = true
+      self.transport:send(Wire.COOP_CANCEL, { reason = "skip" })
+    end
+    return false
+  end
   if self.ask or self.running then return false end
   if not (offer.map and myMap and offer.map == myMap) then return false end
 
@@ -1337,9 +1444,9 @@ end
 -- without a yes/no, which is the rule Party vs Wild always had and the rule
 -- the NPC path now shares. The outs are unchanged and all still cheap: the
 -- waiter's own clock goes in solo (SOLO_FALLBACK_AFTER), the ACTIONS > JOIN
--- row is there for an offer that could not be taken when it landed, STOP
--- leaves a fight that has started, and leaving the party ends every offer at
--- once.
+-- row is there for an offer that could not be taken when it landed (and for
+-- a player who turned WILD / NPC off on PARTY), STOP leaves a fight that
+-- has started, and leaving the party ends every offer at once.
 --
 -- Busy is a deferral and not a refusal: mid-fight, mid-ask and mid-trade all
 -- leave the offer standing for M:update's retry. That retry is the difference
@@ -1782,6 +1889,10 @@ function M:onJoined(game, msg)
   local wild = waiting.kind == "wild" or waiting.mode == "coop_wild"
   self.waiting = nil
   self:note(("%s joined the fight."):format(name))
+  -- Seated roster from the hub when present (skip-aware). Older hubs omit
+  -- it; the whole party is then the seat list, which is what those hubs
+  -- actually seated.
+  local allies = Wire.members(msg and msg.allies) or self.party:list()
   self:begin(game, {
     kind = wild and "wild" or "npc",
     mode = wild and "coop_wild" or nil,
@@ -1793,7 +1904,7 @@ function M:onJoined(game, msg)
     wildCatchMon = waiting.wildCatchMon or M.wildMonOf(waiting.engine),
     npcId = waiting.npcId,
     event = waiting.event,
-    allies = self.party:list(),
+    allies = allies,
     -- The player who was waiting is the one standing at the encounter, so they
     -- are the one that simulates.
     host = true,

--- a/src/Hub.lua
+++ b/src/Hub.lua
@@ -2805,6 +2805,20 @@ handlers[Wire.COOP_CANCEL] = function(self, client, msg)
   if client.coopOffer then
     return self:clearCoopOffer(client, reason)
   end
+  -- Partner opted out of this wait (PARTY WILD/NPC off). Record them on the
+  -- waiter's offer so COOP_JOIN does not seat them, but do not clear the
+  -- offer and do not tell the host -- another partner can still join.
+  -- Must not reuse `no`: that would force the host solo.
+  if reason == "skip" then
+    for _, partner in ipairs(self:partnersOf(client)) do
+      if partner.coopOffer then
+        partner.coopOffer.skip = partner.coopOffer.skip or {}
+        partner.coopOffer.skip[client.id] = true
+        return
+      end
+    end
+    return
+  end
   -- Partner declined our invite: clear the waiter's offer and tell them so
   -- they can go in alone. Only `no` takes this path -- other reasons without
   -- an own offer are noise from a client that is not waiting.  Walk every
@@ -2847,19 +2861,30 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
   host.coopOffer = nil
   client.coopOffer = nil
 
+  -- Seat host + joiner + every other party member who has not opted out of
+  -- this wait (`offer.skip`). The joiner is always seated -- JOIN is the
+  -- override after a skip. All-ON 3-person parties still seat everyone:
+  -- nobody skipped. A silent 2vN for an all-ON trio is the bug this keeps.
+  local skip = offer.skip or {}
   local members = {}
   local memberIds = {}
+  local seated = {}
+  local function seat(who)
+    if not who or seated[who.id] then return end
+    seated[who.id] = true
+    members[#members + 1] = { id = who.id, name = who.name }
+    memberIds[#memberIds + 1] = who.id
+  end
+  seat(host)
+  seat(client)
   for _, member in ipairs(self:partyMembers(client.partyId)) do
-    members[#members + 1] = { id = member.id, name = member.name }
-    memberIds[#memberIds + 1] = member.id
+    if not skip[member.id] then seat(member) end
   end
 
   -- The two sides of one agreement, told differently on purpose: the player
   -- who was waiting learns *who* joined (it is the answer they have been
   -- standing there for), and the player who joined is handed the roster,
   -- because they never had one.
-  -- Seat every current party member (hub order), not only host+joiner --
-  -- otherwise a 3-person party vs NPC is silently 2vN.
   --
   -- The mode is taken from the offer when the waiter named one: coop_wild for
   -- Party vs Wild (auto-join grass), otherwise coop_npc for the trainer path.
@@ -2879,7 +2904,7 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
   -- fight silently stays on host CoopSim while the joiner alone holds `c*`.
   -- `id` remains the joiner (who joined), matching what clients already read.
   send(host, Wire.COOP_JOINED,
-    { id = client.id, name = client.name, plan = id })
+    { id = client.id, name = client.name, plan = id, allies = members })
   -- `host` names the client that simulates. It is the player who was already
   -- standing at the fight, because they are the one *guaranteed* to have
   -- walked into the encounter -- the joiner usually has too, but a join taken
@@ -2887,8 +2912,9 @@ handlers[Wire.COOP_JOIN] = function(self, client, msg)
   -- CoopBattle opens as coop_wild without re-deriving from a cleared offer.
   -- `npcId` / `event` (PROTOCOL 20) ride so a menu joiner can finish the
   -- trainer off without a local BattleState -- never fuzzy-matched by class.
-  -- Every non-host party member gets COOP_BATTLE so a third seat is not
-  -- left holding a mediated id with no screen.
+  -- Every seated non-host gets COOP_BATTLE so a third seat is not left
+  -- holding a mediated id with no screen -- and an opted-out member is
+  -- not handed one they turned off.
   local battleMsg = {
     id = id, side = "a", allies = members, battle = battle, host = host.id,
     mode = mode,

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -20,6 +20,7 @@ local Gen = need("Gen")
 local Chars = need("Chars")
 local Cast = need("Cast")
 local Places = need("Places")
+local Coop = need("Coop")
 
 local M = {}
 M.__index = M
@@ -2471,7 +2472,8 @@ function M:install()
   -- because "party" means two different things depending on whether you are
   -- in one, and a menu of greyed-out rows would be the worse answer: it
   -- would say what you cannot do without saying what you can.
-  screens:register(SCREEN.PARTY, { new = function(game)
+  screens:register(SCREEN.PARTY, { new = function(game, opts)
+    opts = opts or {}
     local party = ctx.party
     if not party:has() then
       -- Not a dead end.  The sentence says how a party starts and then hands
@@ -2481,6 +2483,23 @@ function M:install()
         "No party yet.\nPick a player to\ninvite.", function()
           mod.ui.push(game, SCREEN.ROSTER)
         end)
+    end
+
+    -- WILD / NPC are policy for this client, not membership. Default ON
+    -- (forming the party is still the consent); OFF skips divert and
+    -- auto-join of that kind so two people can walk together and still
+    -- fight grass or trainers alone. LEAVE stays last: it is the one row
+    -- that cannot be undone by pressing it again.
+    local coop = ctx.coop
+    local wildOn = Config.COOP_WILD_DEFAULT ~= false
+    local npcOn = Config.COOP_NPC_DEFAULT ~= false
+    if type(coop) == "table" then
+      if type(coop.wantsWild) == "function" then
+        wildOn = coop:wantsWild() ~= false
+      end
+      if type(coop.wantsNpc) == "function" then
+        npcOn = coop:wantsNpc() ~= false
+      end
     end
 
     local items = {
@@ -2494,6 +2513,8 @@ function M:install()
           mod.ui.push(game, SCREEN.COMPOSE, { scope = "party" })
         end,
       },
+      { label = Coop.wildMenuLabel(wildOn), toggle = "wild" },
+      { label = Coop.npcMenuLabel(npcOn), toggle = "npc" },
       {
         label = "LEAVE",
         onSelect = function()
@@ -2517,10 +2538,41 @@ function M:install()
         end,
       },
     }
-    return mod.ui.Menu.new(game, items, {
+
+    local function reopen(row)
+      mod.ui.push(game, SCREEN.PARTY, { row = row })
+    end
+
+    for row, item in ipairs(items) do
+      local kind = item.toggle
+      if kind then
+        item.onSelect = function()
+          if type(coop) == "table" then
+            if kind == "wild" and type(coop.setWantsWild) == "function" then
+              coop:setWantsWild(not wildOn)
+            elseif kind == "npc" and type(coop.setWantsNpc) == "function" then
+              coop:setWantsNpc(not npcOn)
+            end
+          end
+          -- Menu pops itself before running a row, so reopening is what
+          -- "rebuilt" means -- the label now reads the other way, and the
+          -- cursor stays on this row so a second press puts it back.
+          reopen(row)
+        end
+      end
+    end
+
+    local menu = mod.ui.Menu.new(game, items, {
       tx = 9, ty = 0, tw = 11,
       onCancel = function() mod.ui.push(game, SCREEN.MAIN) end,
     })
+    if type(menu) == "table" then
+      menu.index = math.min(math.max(tonumber(opts.row) or 1, 1), #items)
+      if type(menu.clampScroll) == "function" then
+        menu:clampScroll()
+      end
+    end
+    return menu
   end })
 
   -- Who is in it, where they are, and their card.

--- a/src/Wire.lua
+++ b/src/Wire.lua
@@ -94,12 +94,15 @@ M.RANKS         = "mmo.ranks"
 -- overworld NPC id and event-flag id from engine `checkpointOrigin`, so an
 -- invite joiner with no local BattleState can still mark the trainer beaten.
 -- COOP_CANCEL withdraws it with an optional reason (`alone` / `left` /
--- `timeout` from the waiter; `no` from the partner who declined the invite).
+-- `timeout` from the waiter; `no` from the partner who declined the invite;
+-- `skip` from a partner who turned that kind of coop off -- does *not*
+-- end the wait, so a remaining partner can still join).
 -- Naming which offer is unnecessary: there is only ever one per player.
 -- COOP_JOIN answers somebody else's offer with { to, battle }.
 --
 -- A partner decline (`COOP_CANCEL` reason `no`) is forwarded to the waiter as
 -- `COOP_DECLINE`, so they can leave the wait and fight the trainer alone.
+-- `skip` is recorded on the waiter's offer and is not a decline.
 M.COOP_WAIT      = "mmo.coop_wait"
 M.COOP_CANCEL    = "mmo.coop_cancel"
 M.COOP_JOIN      = "mmo.coop_join"
@@ -234,8 +237,10 @@ M.RANKING     = "mmo.ranking"
 -- very differently to the person who was going to join.
 M.COOP_OFFER     = "mmo.coop_offer"
 M.COOP_OFFER_END = "mmo.coop_offer_end"
--- Somebody accepted yours: { id, name }.  This is the message that ends the
--- waiting, and the only one that does.
+-- Somebody accepted yours: { id, name [, plan] [, allies] }.  This is the
+-- message that ends the waiting, and the only one that does.  Optional
+-- `allies` is the seated roster (host + joiner + anyone who did not skip);
+-- absent on older hubs, where the host falls back to the whole party.
 M.COOP_JOINED    = "mmo.coop_joined"
 -- The four-way ask, as it reaches the three players who did not start it:
 -- { id, from, name, side } -- who is asking, and which of the two sides this
@@ -767,9 +772,10 @@ end
 --   gone      -- somebody dropped
 --   timeout   -- nobody answered in time
 --   mismatch  -- party-vs-party size not equal / not 2-or-3 (hub refuse; T7 phrases)
+--   skip      -- a partner turned this kind of coop off; does not end the wait
 M.COOP_REASONS = {
   alone = true, left = true, started = true,
-  no = true, gone = true, timeout = true, mismatch = true,
+  no = true, gone = true, timeout = true, mismatch = true, skip = true,
 }
 
 function M.coopReason(value)

--- a/tests/drivers/mmo_guest.lua
+++ b/tests/drivers/mmo_guest.lua
@@ -732,6 +732,7 @@ return function(game)
   check(H.openMmo(game), "the MMO menu re-opens")
   if H.selectLabel(game, "PARTY") then
     U.wait(25)
+    shot("party-menu")
     check(H.selectLabel(game, "MEMBERS"), "the party menu opens the members list")
     U.wait(30)
     local rows = H.menuLabels(game)
@@ -1583,6 +1584,7 @@ return function(game)
       U.wait(25)
       if H.selectLabel(game, "PARTY") then
         U.wait(25)
+        shot("party-menu-leave")
         check(H.selectLabel(game, "LEAVE"), "the party menu offers a way out")
         -- the confirm box, and then "You left the party."
         H.drivePrompts(game, function() return #exports.party() == 0 end, 60)

--- a/tests/drivers/mmo_host.lua
+++ b/tests/drivers/mmo_host.lua
@@ -1526,6 +1526,7 @@ return function(game)
     -- expect rather than one this leg left half-arranged.
     if H.openMmo(game) and H.selectLabel(game, "PARTY") then
       U.wait(25)
+      U.shot(game, SHOT_DIR .. "/host-party-menu.png")
       H.selectLabel(game, "LEAVE")
       H.drivePrompts(game, function()
         return #exports.party() == 0

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -7012,6 +7012,7 @@ end)()
 
 local Ui = need("Ui")
 local Friends = need("Friends")
+local Coop = need("Coop")
 
 -- Saved and put back, never nil'd: stubMod is shared with every section after
 -- this one, and a field left nil is a field the next section finds missing
@@ -7059,7 +7060,18 @@ local friends = Friends.new(
 friends:setHub("screens:7788", "ME")
 
 local screenCtx = { roster = roster, party = party, friends = friends,
-                    coop = { pendingOffer = function() return nil end },
+                    coop = {
+                      pendingOffer = function() return nil end,
+                      wildOn = true, npcOn = true,
+                      wantsWild = function(self) return self.wildOn ~= false end,
+                      wantsNpc = function(self) return self.npcOn ~= false end,
+                      setWantsWild = function(self, on)
+                        self.wildOn = on ~= false
+                      end,
+                      setWantsNpc = function(self, on)
+                        self.npcOn = on ~= false
+                      end,
+                    },
                     client = { playerName = function() return "ME" end } }
 local screenUi = Ui.new(screenCtx)
 check(pcall(function() screenUi:install() end),
@@ -7231,6 +7243,62 @@ do
   eq(labelsOf(solo), Ui.FRIEND_MARK .. "BOB",
      "the only row on the list is marked, even though the cursor is on it")
   screenCtx.roster = kept
+end
+
+-- ------- PARTY: WILD / NPC coop toggles, on by default, independent
+
+do
+  local empty = registry[Ui.SCREEN.PARTY].new({})
+  eq(empty.kind, "text",
+     "with nobody in a party, PARTY is still the invite sentence")
+  check(empty.text:find("No party"), "and does not grow toggle rows")
+
+  party:onParty({ id = "1", members = { { id = "me", name = "ME" },
+                                        { id = "bob", name = "BOB" } } })
+  local menu = registry[Ui.SCREEN.PARTY].new({})
+  eq(menu.kind, "menu", "in a party, PARTY is a menu")
+  eq(labelsOf(menu), "MEMBERS,SAY,WILD: ON,NPC: ON,LEAVE",
+     "WILD and NPC sit between SAY and LEAVE, both ON -- forming the party "
+     .. "is still the consent; these rows are the out")
+  eq(menu.items[3].label, "WILD: ON", "wild encounters default on")
+  eq(menu.items[4].label, "NPC: ON", "and NPC trainers default on, separately")
+  check(#menu.items[3].label <= 11, "WILD: ON fits the PARTY box (tw=11)")
+  check(#menu.items[4].label <= 11, "NPC: ON fits too")
+  check(#Coop.wildMenuLabel(false) <= 11, "and so does WILD: OFF")
+  check(#Coop.npcMenuLabel(false) <= 11, "and NPC: OFF")
+  eq(menu.items[#menu.items].label, "LEAVE",
+     "LEAVE stays last -- it is the row that cannot be undone by pressing it")
+
+  eq(Config.COOP_WILD_DEFAULT, true, "Config pins wild coop on")
+  eq(Config.COOP_NPC_DEFAULT, true, "and NPC coop on -- a silent flip to "
+     .. "off would skip every party fight")
+
+  pushes = {}
+  menu.items[3].onSelect()
+  eq(pushes[1] and pushes[1].id, Ui.SCREEN.PARTY,
+     "pressing WILD rebuilds PARTY, the way FAVORITE rebuilds SERVERACT")
+  eq(pushes[1].opts.row, 3, "with the cursor still on WILD")
+  eq(screenCtx.coop.wildOn, false, "and the wild flag is now off")
+  eq(screenCtx.coop.npcOn, true, "without touching NPC")
+
+  local flipped = registry[Ui.SCREEN.PARTY].new({}, { row = 3 })
+  eq(labelsOf(flipped), "MEMBERS,SAY,WILD: OFF,NPC: ON,LEAVE",
+     "the rebuilt menu says WILD: OFF and leaves NPC: ON")
+  eq(flipped.index, 3, "and parks the cursor on the row that was pressed")
+
+  pushes = {}
+  flipped.items[4].onSelect()
+  eq(screenCtx.coop.npcOn, false, "pressing NPC turns that one off")
+  eq(screenCtx.coop.wildOn, false, "and leaves wild where it was")
+  local both = registry[Ui.SCREEN.PARTY].new({})
+  eq(labelsOf(both), "MEMBERS,SAY,WILD: OFF,NPC: OFF,LEAVE",
+     "so the two rows are independent")
+
+  -- Restore the party the friends tests left empty, and the flags ON, so a
+  -- later section that reuses this stub is not surprised.
+  screenCtx.coop.wildOn, screenCtx.coop.npcOn = true, true
+  party:reset()
+  party:setSelf("me")
 end
 
 stubMod.content.screens, stubMod.hooks, stubMod.ui = keptScreens, keptHooks,
@@ -8776,6 +8844,241 @@ eq(wBob.coop:joinFromMenu(wBob.game), false,
 wBob.coop.offer = { from = wAnn.id, battle = WILD_KEY, mode = "coop_wild" }
 eq(wBob.coop:joinFromMenu(wBob.game), true,
    "joinFromMenu on coop_wild auto-joins like considerOffer")
+
+-- ------- PARTY WILD / NPC toggles gate divert and auto-join
+--
+-- Forming the party is still the consent (defaults ON). OFF is the out for
+-- a player who wants to walk together and fight that kind alone. Gen 2
+-- BattleState has no `.kind` -- the shape lives on `state.battle` -- so
+-- both gens are pinned here, not only the Gen 1 fixtures above.
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+eq(wAnn.coop:wantsWild(), true, "a fresh Coop wants wild coop -- default ON")
+eq(wAnn.coop:wantsNpc(), true, "and NPC coop -- default ON")
+eq(wAnn.coop.wildCoop, Config.COOP_WILD_DEFAULT,
+   "the instance field is Config.COOP_WILD_DEFAULT, not a second true")
+eq(wAnn.coop.npcCoop, Config.COOP_NPC_DEFAULT, "same for NPC")
+
+wAnn.coop.wildCoop = false
+eq(wildEngage(wAnn), false,
+   "WILD: OFF leaves the engine wild alone -- no COOP_WAIT")
+eq(wAnn.coop:isWaiting(), false, "the host posts no wait")
+eq(wAnn.coop.encounter, nil, "and never claims the encounter")
+pump(wBob)
+eq(wBob.coop:pendingOffer(), nil, "so the partner is never offered a join")
+resetCoopWild(wAnn); resetCoopWild(wBob)
+
+eq(Wire.coopReason("skip"), "skip",
+   "skip is a closed coop reason -- additive, no PROTOCOL bump")
+
+-- Gen 2 wild: no `.kind`, foe on state.battle.wild / battle.enemy.
+do
+  local battle = {
+    battle = {
+      wild = true,
+      enemy = { species = "FIXMON_A", level = 5 },
+    },
+    onDone = function(result) wAnn.finished = result end,
+  }
+  wAnn.engine = battle
+  wAnn.stack:push(battle)
+  eq(wAnn.coop:onWildEncounter(wAnn.game, battle, "FIX_TOWN"), false,
+     "Gen 2 wild is the same refusal -- kind is read off battle.wild")
+  eq(wAnn.coop:isWaiting(), false, "and still posts no wait")
+end
+resetCoopWild(wAnn)
+
+-- Same Gen 2 shape with WILD: ON must divert, or the OFF test is tautological
+-- (a kind-detection miss also returns false).
+do
+  wAnn.coop.wildCoop = true
+  local battle = {
+    battle = {
+      wild = true,
+      enemy = { species = "FIXMON_A", level = 5 },
+    },
+    onDone = function(result) wAnn.finished = result end,
+  }
+  wAnn.engine = battle
+  wAnn.stack:push(battle)
+  eq(wAnn.coop:onWildEncounter(wAnn.game, battle, "FIX_TOWN"), true,
+     "Gen 2 wild with WILD: ON diverts -- kind is read off battle.wild")
+  eq(wAnn.coop:isWaiting(), true, "and posts the wait")
+end
+resetCoopWild(wAnn)
+
+-- Wild off does not silence NPC coop.
+wAnn.coop.wildCoop = false
+wAnn.coop.npcCoop = true
+eq(engage(wAnn), true, "NPC: ON still diverts a trainer while WILD is off")
+eq(wAnn.coop:isWaiting(), true, "the trainer wait is out")
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+wAnn.coop.wildCoop = true
+wAnn.coop.npcCoop = false
+eq(engage(wAnn), false,
+   "NPC: OFF leaves the engine trainer alone -- no COOP_WAIT")
+eq(wAnn.coop:isWaiting(), false, "no trainer wait")
+eq(wAnn.coop.encounter, nil, "and the encounter is not claimed")
+check(not said(wAnn, "too far"),
+      "the player is not told the partner was away -- this is a choice, "
+      .. "not a missing partner")
+resetCoopWild(wAnn)
+
+do
+  local battle = {
+    battle = {
+      trainer = { classId = "OPP_BUG_CATCHER" },
+      enemyParty = { { species = "FIXMON_A" }, { species = "FIXMON_B" } },
+    },
+    onDone = function(result) wAnn.finished = result end,
+  }
+  wAnn.engine = battle
+  wAnn.stack:push(battle)
+  eq(wAnn.coop:onTrainerBattle(wAnn.game, battle, "FIX_TOWN"), false,
+     "Gen 2 trainer is the same refusal -- kind is read off battle.trainer")
+end
+resetCoopWild(wAnn)
+
+do
+  wAnn.coop.npcCoop = true
+  local battle = {
+    battle = {
+      trainer = { classId = "OPP_BUG_CATCHER" },
+      enemyParty = { { species = "FIXMON_A" }, { species = "FIXMON_B" } },
+    },
+    onDone = function(result) wAnn.finished = result end,
+  }
+  wAnn.engine = battle
+  wAnn.stack:push(battle)
+  eq(wAnn.coop:onTrainerBattle(wAnn.game, battle, "FIX_TOWN"), true,
+     "Gen 2 trainer with NPC: ON diverts -- kind is read off battle.trainer")
+  eq(wAnn.coop:isWaiting(), true, "and posts the wait")
+end
+resetCoopWild(wAnn)
+
+-- NPC off does not silence Party vs Wild.
+wAnn.coop.npcCoop = false
+wAnn.coop.wildCoop = true
+eq(wildEngage(wAnn), true, "WILD: ON still diverts grass while NPC is off")
+eq(wAnn.coop:isWaiting(), true, "the coop_wild wait is out")
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+
+-- Partner with WILD: OFF is not auto-pulled; JOIN still takes the offer.
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+wBob.coop.wildCoop, wBob.coop.npcCoop = true, true
+eq(wildEngage(wAnn), true, "host with WILD: ON posts the wait")
+wBob.coop.running = true
+pump(wBob)
+check(wBob.coop:pendingOffer() ~= nil, "the offer still lands")
+wBob.coop.running = false
+wBob.coop.wildCoop = false
+wBob.peer.outbox = {}
+eq(wBob.coop:considerOffer(wBob.game, wBob.mapId), false,
+   "considerOffer will not auto-join while WILD is off")
+check(wBob.coop:pendingOffer() ~= nil,
+      "the offer stays standing -- JOIN is the override")
+check(wAnn.client.coopOffer and wAnn.client.coopOffer.skip
+      and wAnn.client.coopOffer.skip[wBob.id],
+      "skip is recorded on the host offer, not a decline")
+eq(take(wAnn.peer, Wire.COOP_DECLINE), nil, "skip is not a no")
+eq(wAnn.coop:isWaiting(), true, "and the wait still stands")
+eq(wBob.coop:joinFromMenu(wBob.game), true,
+   "JOIN on the partner still takes a coop_wild offer with WILD: OFF")
+pump(wAnn)
+eq(wAnn.coop:isWaiting(), false, "the waiter is told they joined")
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+wBob.coop.wildCoop, wBob.coop.npcCoop = true, true
+
+-- Partner with NPC: OFF is not auto-pulled; JOIN still takes the trainer offer.
+eq(engage(wAnn), true, "host with NPC: ON posts the trainer wait")
+wBob.coop.running = true
+pump(wBob)
+check(wBob.coop:pendingOffer() ~= nil, "the trainer offer still lands")
+wBob.coop.running = false
+wBob.coop.npcCoop = false
+wBob.peer.outbox = {}
+eq(wBob.coop:considerOffer(wBob.game, wBob.mapId), false,
+   "considerOffer will not auto-join while NPC is off")
+check(wBob.coop:pendingOffer() ~= nil,
+      "the trainer offer stays standing -- JOIN is the override")
+eq(wBob.coop:joinFromMenu(wBob.game), true,
+   "JOIN on the partner still takes a trainer offer with NPC: OFF")
+pump(wAnn)
+eq(wAnn.coop:isWaiting(), false, "the trainer waiter is told they joined")
+
+resetCoopWild(wAnn); resetCoopWild(wBob)
+pump(wAnn); pump(wBob)
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+wBob.coop.wildCoop, wBob.coop.npcCoop = true, true
+
+-- reset() re-reads mod.save so a save-swap does not keep the last
+-- playthrough's toggles (Coop is a process-lifetime singleton).
+wAnn.coop:setWantsWild(false)
+eq(wAnn.coop:wantsWild(), false, "sanity: setWantsWild flipped the field")
+stubSave[Coop.WILD_OPTION] = nil
+wAnn.coop:reset()
+eq(wAnn.coop:wantsWild(), true,
+   "reset re-reads save; a missing key is the default ON")
+stubSave[Coop.WILD_OPTION] = nil
+stubSave[Coop.NPC_OPTION] = nil
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+
+-- 3-person party: an opted-out member is not pulled when someone else joins.
+local wCal = coopSide(wildHub, "WCAL")
+pump(wAnn); pump(wBob); pump(wCal)
+wAnn.party:invite({ id = wCal.client.id, name = "WCAL" })
+pump(wCal); answerConfirm(wCal, true)
+pump(wAnn); pump(wBob); pump(wCal)
+eq(wAnn.party:count(), 3, "sanity: three on the wild harness")
+
+wCal.coop.wildCoop = false
+wBob.coop.wildCoop = true
+eq(wildEngage(wAnn), true, "host posts the wait in a party of three")
+pump(wCal)
+eq(wAnn.coop:isWaiting(), true, "skip does not end the wait")
+eq(take(wAnn.peer, Wire.COOP_DECLINE), nil, "skip is not a no in a trio either")
+check(wAnn.client.coopOffer and wAnn.client.coopOffer.skip
+      and wAnn.client.coopOffer.skip[wCal.id],
+      "the opted-out third is on the waiter's skip list")
+check(wCal.coop:pendingOffer() ~= nil,
+      "the offer stays for JOIN")
+pump(wBob)
+eq(take(wCal.peer, Wire.COOP_BATTLE), nil,
+   "opted-out third is not handed a screen")
+check(take(wBob.peer, Wire.COOP_BATTLE) ~= nil, "the joiner is seated")
+eq(wCal.client.coopBattleId, nil, "and is not in the hub group")
+check(wBob.client.coopBattleId ~= nil, "joiner has a hub group")
+pump(wAnn)
+eq(wAnn.coop:isWaiting(), false, "the waiter is told they joined")
+
+resetCoopWild(wAnn); resetCoopWild(wBob); resetCoopWild(wCal)
+pump(wAnn); pump(wBob); pump(wCal)
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+wBob.coop.wildCoop, wBob.coop.npcCoop = true, true
+wCal.coop.wildCoop, wCal.coop.npcCoop = true, true
+wCal.client.coopBattleId, wBob.client.coopBattleId = nil, nil
+wAnn.client.coopBattleId = nil
+
+-- All-ON trio: first JOIN still fans COOP_BATTLE to the third (nobody skipped).
+eq(wildEngage(wAnn), true, "all-ON host posts the wait")
+pump(wBob)
+check(take(wCal.peer, Wire.COOP_BATTLE) ~= nil,
+      "all-ON third still gets COOP_BATTLE without joining")
+check(wCal.client.coopBattleId ~= nil, "and is seated")
+
+resetCoopWild(wAnn); resetCoopWild(wBob); resetCoopWild(wCal)
+pump(wAnn); pump(wBob); pump(wCal)
+wAnn.coop.wildCoop, wAnn.coop.npcCoop = true, true
+wBob.coop.wildCoop, wBob.coop.npcCoop = true, true
+wCal.coop.wildCoop, wCal.coop.npcCoop = true, true
 
 -- ------- a ranked 2-on-2 needs all four to agree
 --


### PR DESCRIPTION
## Summary
- While partied, PARTY now has independent `WILD: ON`/`OFF` and `NPC: ON`/`OFF` rows (default ON) so you can travel together and still fight grass or trainers alone.
- Off skips divert and auto-join of that kind (Gen 1 and Gen 2). JOIN on the partner still takes a standing offer.
- A 3-person JOIN no longer seats someone who opted out: they send `COOP_CANCEL` reason `skip` (not `no`, which would force the host solo). The hub seats host + joiner + anyone who did not skip. No PROTOCOL bump.

## Test plan
- [ ] PARTY shows WILD / NPC rows while partied; flipping one does not change the other
- [ ] WILD: OFF leaves a wild encounter solo; NPC: ON still posts a trainer wait (and the reverse)
- [ ] Partner with that kind OFF is not auto-pulled; JOIN still takes the standing offer
- [ ] 3-person party: opted-out third is not handed `COOP_BATTLE` when someone else joins; all-ON still seats all three
- [ ] Save swap / reconnect keeps the last playthrough’s toggles (reset re-reads `mod.save`)