### PR TITLE
feature: add a Gen 2-only GSC Official Server next to RBY Official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ here must match `manifest.version`.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-09-09
+
+### Added
+
+- **GSC Official Server, Gen 2 only.** Gold / Silver / Crystal boots see
+  `GSC MMO OFFICIAL` (`play2.rbymmo.com:25565`, code `NWH9PT`) at the top
+  of SERVERS. Red / Blue / Yellow still see only `RBY MMO OFFICIAL`. Each
+  official refuses a typed join from the other generation.
+
 ## [1.4.0] - 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A multiplayer mod for [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp).
 ![LÖVE 11.x](https://img.shields.io/badge/L%C3%96VE-11.x-e64998?style=for-the-badge)
 ![Players 2–64](https://img.shields.io/badge/players-2--64-3aa757?style=for-the-badge)
 ![No server needed](https://img.shields.io/badge/dedicated%20server-optional-4c8fd6?style=for-the-badge)
-![v1.4.0](https://img.shields.io/badge/version-1.4.0-3aa757?style=for-the-badge)
+![v1.4.1](https://img.shields.io/badge/version-1.4.1-3aa757?style=for-the-badge)
 ![MIT](https://img.shields.io/badge/licence-MIT-666?style=for-the-badge)
 
 **No server to rent. No accounts. No signup.** One of you hosts from inside
@@ -726,7 +726,8 @@ title screen, and never on its own: launching the game and stopping at the
 menu connects you to nothing. The armed row is marked `▼` on the list, so
 you can see which hub your game opens into without opening anything, and its
 own row reads `NO AUTOJOIN` — press it again to switch it off. `RBY MMO
-OFFICIAL` can be the armed one too; it's the only setting on that row that's
+OFFICIAL` (Red / Blue / Yellow) and `GSC MMO OFFICIAL` (Gold / Silver /
+Crystal) can be the armed one too; it's the only setting on that row that's
 yours rather than built in.
 
 **Only one server can auto-join.** Arming a second is what disarms the first,
@@ -1626,7 +1627,7 @@ fight.
 
 ## 🚧 Known jank — read this bit
 
-It's `1.4.0` (`experimental: false` — on by default when installed). The full
+It's `1.4.1` (`experimental: false` — on by default when installed). The full
 list lives in `mod.card` under `differences.known`. The ones that'll actually
 bite you:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "rby_mmo",
   "name": "RBY MMO",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "//": "SOURCE OF TRUTH FOR version IS ../manifest.json. Bump both together. The release workflow reads only manifest.json; `rby-mmo-hub --version` reads only this file (lib/cli.js:230-241), so a one-sided bump makes the CLI report a version no release has. config.test.js asserts the two match (testVersionParity), skipping only where manifest.json is absent because the server was installed on its own -- so `npm test` catches a one-sided bump in a checkout.",
   "name": "rby-mmo-hub",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Self-hosted relay for the RBY MMO mod: shared-overworld presence, chat, trades and link battles for a group of friends. Zero dependencies, Node core only.",
   "license": "MIT",
   "private": true,

--- a/src/Client.lua
+++ b/src/Client.lua
@@ -1331,14 +1331,19 @@ function M.connect(a, b, c)
   -- silently replace whatever the player last typed into JOIN GAME with a
   -- hub they never chose as their default.
   local address = withPort(wanted) or M.joinAddress()
-  -- Official public hub is Gen 1-only until a Gen 2 deploy exists. Refuse
-  -- here (not only by hiding the SERVERS row) so a typed / options JOIN to
-  -- play.rbymmo.com on Gold gets a clear sentence instead of a generation
-  -- mismatch from the hub.
+  -- Official hubs are generation-locked. Refuse here (not only by hiding
+  -- the SERVERS row) so a typed / options JOIN to the other generation's
+  -- official gets a clear sentence instead of a generation mismatch from
+  -- the hub.
   if Servers.isFeaturedAddress(address)
-      and not Config.featuredServerAllowed(Gen.generation(game)) then
-    connectSay(
-      "Official server is\nGen 1 only for now.\nHost a Gold game\ninstead.")
+      and not Config.featuredServerAllowed(Gen.generation(game), address) then
+    local spec = Config.featuredServer(address)
+    local want = spec and spec.gens and spec.gens[1] or 1
+    if want == 1 then
+      connectSay("Official server is\nGen 1 only.\nPlay Red, Blue\nor Yellow.")
+    else
+      connectSay("Official server is\nGen 2 only.\nPlay Gold, Silver\nor Crystal.")
+    end
     return false
   end
 
@@ -1371,8 +1376,8 @@ end
 --
 -- CONNECT's own pre-flight is deliberately not repeated here beyond the two
 -- that decide whether to try at all -- M.connect refuses an open transport
--- and a Gen 2 boot dialling the official hub itself, and its sentences are
--- the ones the box ends up carrying.
+-- and a boot dialling the other generation's official hub, and its sentences
+-- are the ones the box ends up carrying.
 local function tryAutoJoin(game)
   if not World.current() then return end
   autoJoin.armed = false
@@ -1391,17 +1396,17 @@ local function tryAutoJoin(game)
     return
   end
   if not entry then
-    -- Armed, but at a row this boot cannot resolve: today that is only the
-    -- official hub on a Gen 2 game, which the menu hides and menuGet refuses
-    -- for the same reason M.connect would refuse the dial. Doing nothing is
-    -- the right answer -- there is nothing to reach -- but doing it *silently*
-    -- leaves a player who set this on Red wondering why Gold never connects,
-    -- with nothing in the log to find. No box: nobody pressed anything, and
-    -- this is a standing condition rather than a failure of this launch.
+    -- Armed, but at a row this boot cannot resolve: the other generation's
+    -- official, which the menu hides and menuGet refuses for the same reason
+    -- M.connect would refuse the dial. Doing nothing is the right answer --
+    -- there is nothing to reach -- but doing it *silently* leaves a player
+    -- who set this on Red wondering why Gold never connects, with nothing
+    -- in the log to find. No box: nobody pressed anything, and this is a
+    -- standing condition rather than a failure of this launch.
     if armed then
       mod.log:warn("auto-join is set to %s, which this game cannot reach -- "
-        .. "the official server is Gen 1 only for now; host a Gold game or "
-        .. "point AUTOJOIN at another row under START > MMO > SERVERS",
+        .. "that official server is for a different generation; point "
+        .. "AUTOJOIN at another row under START > MMO > SERVERS",
         tostring(armed))
     end
     return

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -1266,25 +1266,76 @@ M.RANK_REPORT_GRACE = 60
 -- src/Servers.lua keeps the list behind START > MMO > SERVERS; the argument
 -- for what it is and where it is written is in that file's header.
 
--- The product-owned row at the top of that list. Its port is explicit rather
+-- Product-owned rows at the top of that list. Ports are explicit rather
 -- than derived from DEFAULT_PORT: changing the port used by a local host must
--- not quietly point the official row at a different service. Servers projects
--- this into the menu without putting it in either persistence mirror.
+-- not quietly point an official row at a different service. Servers projects
+-- each into the menu without putting it in either persistence mirror.
 --
--- `FEATURED_SERVER_GENS` is which boots may see / dial it. The public hub at
--- play.rbymmo.com is Gen 1-locked for now; Gold players host locally (or join
--- a Gen 2 LAN hub) until an official Gen 2 deploy exists.
-M.FEATURED_SERVER_NAME = "RBY MMO OFFICIAL"
-M.FEATURED_SERVER_HOST = "play.rbymmo.com:7788"
-M.FEATURED_SERVER_CODE = "QG0251"
-M.FEATURED_SERVER_GENS = { 1 }
+-- `gens` is which boots may see / dial that row. RBY Official is Gen 1 only;
+-- GSC Official is Gen 2 only. A boot never sees the other generation's hub.
+M.FEATURED_SERVERS = {
+  {
+    name = "RBY MMO OFFICIAL",
+    host = "play.rbymmo.com:7788",
+    code = "QG0251",
+    gens = { 1 },
+  },
+  {
+    name = "GSC MMO OFFICIAL",
+    host = "play2.rbymmo.com:25565",
+    code = "NWH9PT",
+    gens = { 2 },
+  },
+}
 
-function M.featuredServerAllowed(generation)
-  local gens = M.FEATURED_SERVER_GENS
+-- Back-compat aliases: the Gen 1 official, which is what every existing
+-- caller and test means by FEATURED_SERVER_*.
+M.FEATURED_SERVER_NAME = M.FEATURED_SERVERS[1].name
+M.FEATURED_SERVER_HOST = M.FEATURED_SERVERS[1].host
+M.FEATURED_SERVER_CODE = M.FEATURED_SERVERS[1].code
+M.FEATURED_SERVER_GENS = M.FEATURED_SERVERS[1].gens
+
+local function gensAllow(gens, generation)
   if type(gens) ~= "table" or #gens == 0 then return true end
   local g = tonumber(generation) or 1
   for i = 1, #gens do
     if gens[i] == g then return true end
+  end
+  return false
+end
+
+-- The configured official matching `address`, or nil. Portless forms only
+-- match a featured host whose port is DEFAULT_PORT -- GSC's 25565 is not
+-- that, so "play2.rbymmo.com" without a port is not the official row.
+function M.featuredServer(address)
+  if type(address) ~= "string" then return nil end
+  local needle = address:gsub("%s+", ""):lower()
+  if needle == "" then return nil end
+  if not needle:find(":", 1, true) then
+    needle = needle .. ":" .. tostring(M.DEFAULT_PORT)
+  end
+  for i = 1, #M.FEATURED_SERVERS do
+    local spec = M.FEATURED_SERVERS[i]
+    if type(spec.host) == "string" and spec.host:lower() == needle then
+      return spec
+    end
+  end
+  return nil
+end
+
+-- Whether this boot may see / dial an official hub.
+--
+-- With `address`: that specific official, or true when the address is not
+-- one (the generation gate is only for product-owned hosts).
+-- Without `address`: whether any official row is offered on this generation.
+function M.featuredServerAllowed(generation, address)
+  if address ~= nil then
+    local spec = M.featuredServer(address)
+    if not spec then return true end
+    return gensAllow(spec.gens, generation)
+  end
+  for i = 1, #M.FEATURED_SERVERS do
+    if gensAllow(M.FEATURED_SERVERS[i].gens, generation) then return true end
   end
   return false
 end

--- a/src/Servers.lua
+++ b/src/Servers.lua
@@ -81,10 +81,10 @@ local function keyOf(address)
   return clean:lower()
 end
 
--- The one row that belongs to the product rather than to the player's
--- history. A fresh table is returned every time so a caller of the exported
--- list cannot rename the canonical copy in memory. The key is made by the
--- same normaliser as every remembered hub, which is what lets ingestion and
+-- The rows that belong to the product rather than to the player's history.
+-- A fresh table is returned every time so a caller of the exported list
+-- cannot rename the canonical copy in memory. The key is made by the same
+-- normaliser as every remembered hub, which is what lets ingestion and
 -- presentation recognise an old saved copy as the same server.
 --
 -- Resolved on first use and remembered, rather than computed while this chunk
@@ -93,42 +93,59 @@ end
 -- (Config.applyPort). A key baked at load would be keyed on the fallback port
 -- while every later keyOf() used the one the player set -- one hub filed under
 -- two keys, and isFeaturedAddress answering false for the official host.
--- FEATURED_SERVER_HOST carries an explicit port today, which makes that
--- harmless; this makes it harmless whatever that constant says next.
+-- Featured hosts carry an explicit port today, which makes that harmless;
+-- this makes it harmless whatever those constants say next.
 --
 -- A table rather than a plain local so "not resolved yet" stays distinct from
--- "resolved to nil", which is what a malformed FEATURED_SERVER_HOST gives.
-local featuredKeyMemo = {}
-local function featuredKey()
-  if not featuredKeyMemo.done then
-    featuredKeyMemo.done = true
-    featuredKeyMemo.key = keyOf(Config.FEATURED_SERVER_HOST)
+-- "resolved to nothing", which is what a malformed featured host gives.
+local featuredMemo = { done = false, byKey = {}, specs = {} }
+
+local function featuredIndex()
+  if not featuredMemo.done then
+    featuredMemo.done = true
+    for i = 1, #(Config.FEATURED_SERVERS or {}) do
+      local spec = Config.FEATURED_SERVERS[i]
+      local key = spec and keyOf(spec.host)
+      if key then
+        featuredMemo.byKey[key] = spec
+        featuredMemo.specs[#featuredMemo.specs + 1] = spec
+      end
+    end
   end
-  return featuredKeyMemo.key
+  return featuredMemo
 end
 
-local function featuredEntry()
+local function featuredSpec(key)
+  if not key then return nil end
+  return featuredIndex().byKey[key]
+end
+
+local function isFeaturedKey(key)
+  return featuredSpec(key) ~= nil
+end
+
+local function featuredEntry(spec)
   return {
-    key = featuredKey(),
-    address = Config.FEATURED_SERVER_HOST,
-    name = Config.FEATURED_SERVER_NAME,
+    key = keyOf(spec.host),
+    address = spec.host,
+    name = spec.name,
     fav = false,
-    code = Wire.code(Config.FEATURED_SERVER_CODE),
+    code = Wire.code(spec.code),
     last = 0,
     featured = true,
   }
 end
 
-local function featuredVisible(game)
-  return Config.featuredServerAllowed(Gen.generation(game))
+local function featuredAllowed(spec, game)
+  return Config.featuredServerAllowed(Gen.generation(game), spec.host)
 end
 
--- True when `address` is the product-owned official hub (any typing shape
--- that normalises to the same key). Used by Client to refuse a Gen 2 dial
--- that skipped the SERVERS menu.
+-- True when `address` is a product-owned official hub (any typing shape
+-- that normalises to the same key). Used by Client to refuse a dial of the
+-- other generation's official that skipped the SERVERS menu.
 function M.isFeaturedAddress(address)
   local id = keyOf(address)
-  return id ~= nil and id == featuredKey()
+  return id ~= nil and isFeaturedKey(id)
 end
 
 -- What a hub is called before anybody names it.
@@ -323,12 +340,12 @@ function M:_ingest(rows, only)
     if entry and not only and raw.auto == true and auto == nil then
       auto = entry.key
     end
-    -- Older builds may already have remembered the official address after a
+    -- Older builds may already have remembered an official address after a
     -- successful welcome. It is represented by the synthetic row now, so it
     -- is neither loaded into the persisted store nor counted by eviction --
-    -- but its `auto` flag above is still read, because the featured row is
+    -- but its `auto` flag above is still read, because a featured row is
     -- exactly the row that has nowhere else to record one.
-    if entry and entry.key ~= featuredKey() then
+    if entry and not isFeaturedKey(entry.key) then
       local known = self.entries[entry.key] ~= nil or self.dropped[entry.key]
       if not (only and known) then self.entries[entry.key] = entry end
     end
@@ -411,9 +428,9 @@ function M:_load()
   evict(self)
   -- A key that survived both readers but names no row is nothing this store
   -- can act on -- the row was evicted by the other half of the merge, or
-  -- deleted in an earlier session. The featured row is the exception: it is
-  -- synthetic and is always there to be dialled.
-  if self.autoKey and self.autoKey ~= featuredKey()
+  -- deleted in an earlier session. Featured rows are the exception: they are
+  -- synthetic and are always there to be dialled (on a boot that may see them).
+  if self.autoKey and not isFeaturedKey(self.autoKey)
       and not self.entries[self.autoKey] then
     self.autoKey = nil
   end
@@ -448,7 +465,7 @@ end
 -- would work perfectly in memory, vanish on relaunch, and fail no test,
 -- because sanitise would just fill its default back in on the way in.
 --
--- The featured row is appended when it is the one that auto-joins, and only
+-- A featured row is appended when it is the one that auto-joins, and only
 -- then. It is product configuration rather than history, so it is not on the
 -- list and must not consume one of SERVER_LIST_MAX's slots -- but "I dial the
 -- official hub on the way in" is a player setting like any other, and this
@@ -463,9 +480,10 @@ function M:_persistRows()
     if self.autoKey == entry.key then row.auto = true end
     out[#out + 1] = row
   end
-  if self.autoKey == featuredKey() then
-    out[#out + 1] = { key = featuredKey(),
-                      address = Config.FEATURED_SERVER_HOST, auto = true }
+  local spec = featuredSpec(self.autoKey)
+  if spec then
+    out[#out + 1] = { key = keyOf(spec.host),
+                      address = spec.host, auto = true }
   end
   return out
 end
@@ -546,37 +564,43 @@ function M:get(key)
   return self.entries[id]
 end
 
--- The SERVERS screen has one product-owned row in addition to persisted
+-- The SERVERS screen has product-owned rows in addition to persisted
 -- recents. Keep that projection separate from list/get so external callers
--- still see exactly the history they saw before the featured server existed.
--- `game` (optional) gates the official row by boot generation — Gen 2 hides
--- it while the public hub stays Gen 1-only.
+-- still see exactly the history they saw before featured servers existed.
+-- `game` (optional) gates each official by boot generation -- Gen 1 sees
+-- RBY Official, Gen 2 sees GSC Official, and a missing game is Gen 1.
 function M:menuList(game)
   self:_load()
   local out = {}
-  if featuredVisible(game) then
-    out[#out + 1] = featuredEntry()
+  for _, spec in ipairs(featuredIndex().specs) do
+    if featuredAllowed(spec, game) then
+      out[#out + 1] = featuredEntry(spec)
+    end
   end
   for _, entry in ipairs(self:_rows()) do
-    -- `_ingest` and `record` already keep this key out of entries. Retain the
-    -- guard at the projection boundary too: even a caller that has modified
-    -- the public entries table cannot make the official server appear twice.
-    if entry.key ~= featuredKey() then out[#out + 1] = entry end
+    -- `_ingest` and `record` already keep featured keys out of entries.
+    -- Retain the guard at the projection boundary too: even a caller that
+    -- has modified the public entries table cannot make an official appear
+    -- twice.
+    if not isFeaturedKey(entry.key) then out[#out + 1] = entry end
   end
   return out
 end
 
--- Resolves keys handed back by menuList(), including its synthetic first row.
+-- Resolves keys handed back by menuList(), including its synthetic rows.
 -- Normal get() intentionally does not: it remains the persisted-recents API.
--- When the official row is generation-gated off, menuGet returns nil for its
--- key the same way a deleted recent would.
+-- When an official row is generation-gated off, menuGet returns nil for its
+-- key the same way a deleted recent would -- but only when `game` is passed.
+-- Omitted, it still answers the canonical row so a name lookup for the
+-- auto-join holder works after a player armed the other generation's official.
 function M:menuGet(key, game)
   self:_load()
   local id = keyOf(key)
   if not id then return nil end
-  if id == featuredKey() then
-    if not featuredVisible(game) then return nil end
-    return featuredEntry()
+  local spec = featuredSpec(id)
+  if spec then
+    if game ~= nil and not featuredAllowed(spec, game) then return nil end
+    return featuredEntry(spec)
   end
   return self.entries[id]
 end
@@ -622,9 +646,10 @@ end
 -- stale menu row cannot switch off a setting that has since moved.
 --
 -- `game` is the boot the row is being resolved against, and it is here for
--- the same reason menuGet takes one: the featured row is generation-gated, so
--- a Gold game must not be able to arm a dial at a hub it is not allowed to
--- see. Absent, it resolves as Gen 1 -- which is what every headless caller is.
+-- the same reason menuGet takes one: official rows are generation-gated, so
+-- a Gold game must not be able to arm a dial at the RBY hub, and a Red game
+-- must not arm the GSC one. Absent, it resolves as Gen 1 -- which is what
+-- every headless caller is.
 function M:setAutoJoin(key, on, game)
   self:_load()
   local id = keyOf(key)
@@ -673,12 +698,13 @@ function M:record(address, code)
   end
 
   local key = clean:lower()
-  -- A welcome from the official hub proves the synthetic row works; it does
+  -- A welcome from an official hub proves the synthetic row works; it does
   -- not turn product configuration into player history. In particular this
   -- skips persistence and eviction, and keeps the configured code canonical.
-  if key == featuredKey() then
+  local spec = featuredSpec(key)
+  if spec then
     self.entries[key] = nil
-    return featuredEntry()
+    return featuredEntry(spec)
   end
   local entry = self.entries[key]
   if not entry then
@@ -703,7 +729,7 @@ end
 -- refused when nothing printable survives -- a blank row is a row nobody can
 -- tell from the one above it.
 function M:rename(key, name)
-  if keyOf(key) == featuredKey() then
+  if isFeaturedKey(keyOf(key)) then
     self:_warn("the featured server is built in and cannot be renamed")
     return nil
   end
@@ -729,7 +755,7 @@ function M:rename(key, name)
 end
 
 function M:setFavorite(key, fav)
-  if keyOf(key) == featuredKey() then
+  if isFeaturedKey(keyOf(key)) then
     self:_warn("the featured server is already pinned and cannot be changed")
     return nil
   end
@@ -757,7 +783,7 @@ end
 -- only answer that leaves one row per hub -- and the alternative, refusing the
 -- edit, would strand the player with two rows and no way to merge them.
 function M:setAddress(key, newAddress)
-  if keyOf(key) == featuredKey() then
+  if isFeaturedKey(keyOf(key)) then
     self:_warn("the featured server's address is built in and cannot be changed")
     return nil
   end
@@ -775,7 +801,7 @@ function M:setAddress(key, newAddress)
   end
 
   local id = clean:lower()
-  if entry.featured or id == featuredKey() then
+  if entry.featured or isFeaturedKey(id) then
     self:_warn("the featured server's address is built in and cannot be changed")
     return nil
   end
@@ -807,7 +833,7 @@ end
 -- through to the connect path and fail every challenge silently, which is the
 -- failure this validation exists to turn into a sentence.
 function M:setCode(key, code)
-  if keyOf(key) == featuredKey() then
+  if isFeaturedKey(keyOf(key)) then
     self:_warn("the featured server's join code is built in and cannot be changed")
     return nil
   end
@@ -849,7 +875,7 @@ end
 -- does: this is the one write that wants the list shorter, so the eviction
 -- that follows a fold-in has no row here to protect.
 function M:remove(key)
-  if keyOf(key) == featuredKey() then
+  if isFeaturedKey(keyOf(key)) then
     self:_warn("the featured server is built in and cannot be deleted")
     return nil
   end

--- a/src/Ui.lua
+++ b/src/Ui.lua
@@ -1255,9 +1255,9 @@ function M:install()
   --
   -- Resolved off the *key* the store holds rather than off autoJoinEntry, and
   -- that is the whole point of it existing: autoJoinEntry answers "the row
-  -- this boot may dial", which is nil for the official server on a Gen 2 game
+  -- this boot may dial", which is nil for the other generation's official
   -- -- and the servers file is machine-level, shared by every boot, so a
-  -- player who armed the official hub on Red and then opens SERVERS on Gold
+  -- player who armed RBY Official on Red and then opens SERVERS on Gold
   -- would have had it replaced without ever being asked. A name is available
   -- either way; the key is the honest fallback when even that is not.
   local function serverAutoJoinName()

--- a/tests/rby_mmo_test.lua
+++ b/tests/rby_mmo_test.lua
@@ -25796,23 +25796,59 @@ do
   eq(featured.featured, true,
      "marked so the UI can protect product-owned fields")
 
+  local gsc = Config.FEATURED_SERVERS[2]
+  eq(gsc and gsc.name, "GSC MMO OFFICIAL",
+     "GSC Official is the second featured hub")
+  eq(gsc and gsc.host, "play2.rbymmo.com:25565",
+     "on play2 with its own port")
+  eq(gsc and gsc.code, "NWH9PT", "and its own join code")
+
   eq(Config.featuredServerAllowed(1), true,
-     "the official hub is offered on Gen 1")
-  eq(Config.featuredServerAllowed(2), false,
-     "and not on Gen 2 until a Gold deploy exists")
+     "an official hub is offered on Gen 1")
+  eq(Config.featuredServerAllowed(2), true,
+     "and a different official hub is offered on Gen 2")
+  eq(Config.featuredServerAllowed(1, Config.FEATURED_SERVER_HOST), true,
+     "RBY Official is allowed on Gen 1")
+  eq(Config.featuredServerAllowed(2, Config.FEATURED_SERVER_HOST), false,
+     "and refused on Gen 2")
+  eq(Config.featuredServerAllowed(2, gsc.host), true,
+     "GSC Official is allowed on Gen 2")
+  eq(Config.featuredServerAllowed(1, gsc.host), false,
+     "and refused on Gen 1")
   eq(Servers.isFeaturedAddress(Config.FEATURED_SERVER_HOST), true,
-     "isFeaturedAddress recognises the official host")
+     "isFeaturedAddress recognises the RBY official host")
   eq(Servers.isFeaturedAddress("play.rbymmo.com"), true,
      "including the form without an explicit port")
+  eq(Servers.isFeaturedAddress(gsc.host), true,
+     "and recognises the GSC official host")
+  eq(Servers.isFeaturedAddress("play2.rbymmo.com"), false,
+     "but a portless play2 is not the GSC official -- its port is not the default")
 
   local goldGame = {
     data = { type_chart = { generation = 2 }, gen2Statuses = {} },
   }
   local goldMenu = store:menuList(goldGame)
-  eq(#goldMenu, 0,
-     "Gen 2 hides the official row on a fresh SERVERS list")
+  eq(#goldMenu, 1,
+     "Gen 2 shows its own official row on a fresh SERVERS list")
+  eq(goldMenu[1] and goldMenu[1].name, gsc.name,
+     "under the GSC official label")
+  eq(goldMenu[1] and goldMenu[1].address, gsc.host,
+     "with the GSC official dial address")
+  eq(goldMenu[1] and goldMenu[1].code, gsc.code,
+     "and the GSC official join code")
   eq(store:menuGet(Config.FEATURED_SERVER_HOST, goldGame), nil,
-     "and menuGet refuses the official key on Gold")
+     "and menuGet refuses the RBY official key on Gold")
+  eq(store:menuGet(gsc.host, goldGame) ~= nil, true,
+     "while resolving the GSC official key")
+  local redGame = {
+    data = { type_chart = { generation = 1 } },
+  }
+  eq(store:menuGet(gsc.host, redGame), nil,
+     "and menuGet refuses the GSC official key on Red")
+  eq(#store:menuList(redGame), 1,
+     "Gen 1 still shows only RBY Official")
+  eq(store:menuList(redGame)[1].name, Config.FEATURED_SERVER_NAME,
+     "under the RBY official label")
 
   local resolved = store:menuGet(featured.key)
   check(resolved ~= nil, "menuGet resolves the synthetic row")
@@ -25893,6 +25929,20 @@ do
      "and leave its code unchanged")
   eq(#store:list(), 1,
      "while the ordinary persisted recent remains the only counted row")
+
+  local gsc = Config.FEATURED_SERVERS[2]
+  local gscKey = gsc.host:lower()
+  eq(store:rename(gscKey, "Renamed"), nil,
+     "the GSC official row cannot be renamed either")
+  eq(store:remove(gscKey), nil,
+     "or deleted")
+  eq(store:setAddress(ordinary.key, gsc.host), nil,
+     "and an ordinary recent cannot be moved onto the GSC official address")
+  local recorded = store:record(gsc.host, gsc.code)
+  check(recorded ~= nil and recorded.featured == true,
+        "a welcome from GSC Official returns the synthetic entry")
+  eq(#store:list(), 1,
+     "without turning it into a persisted recent")
 end
 
 -- ------- eviction: the cap, LRU order, favourites, and the row just written
@@ -26232,15 +26282,33 @@ do
      "and the official hub is still not a persisted recent")
 
   -- Generation-gated exactly as the menu is: a Gold boot cannot see the
-  -- official row, so it must not be able to dial one either.
+  -- RBY official row, so it must not be able to dial or arm that one.
   local goldGame = {
     data = { type_chart = { generation = 2 }, gen2Statuses = {} },
   }
   eq(store:autoJoinEntry(goldGame), nil,
-     "a Gen 2 boot resolves the official auto-join row to nothing")
+     "a Gen 2 boot resolves the RBY official auto-join row to nothing")
   eq(store:setAutoJoin(Config.FEATURED_SERVER_HOST, true, goldGame), nil,
-     "and cannot arm one either -- the row it would dial is not one that "
-     .. "boot is allowed to see")
+     "and cannot arm RBY Official either -- the row it would dial is not "
+     .. "one that boot is allowed to see")
+
+  local gsc = Config.FEATURED_SERVERS[2]
+  check(store:setAutoJoin(gsc.host, true, goldGame) ~= nil,
+        "but Gold can arm GSC Official")
+  local gscEntry = store:autoJoinEntry(goldGame)
+  eq(gscEntry and gscEntry.address, gsc.host,
+     "and autoJoinEntry on Gold hands back the GSC official address")
+  eq(gscEntry and gscEntry.code, gsc.code,
+     "with the GSC official code")
+  local redGame = {
+    data = { type_chart = { generation = 1 } },
+  }
+  eq(store:autoJoinEntry(redGame), nil,
+     "while a Gen 1 boot cannot resolve the GSC official auto-join")
+  -- Restore the RBY official arming this block started with, so the stub
+  -- assertions below still see one featured auto-join row.
+  check(store:setAutoJoin(Config.FEATURED_SERVER_HOST, true) ~= nil,
+        "and Red can take AUTOJOIN back onto RBY Official")
 
   -- The stub the mirror carries it in: a row with the key and the flag and
   -- nothing else, so a build that predates auto-join drops it on the way in
@@ -27389,8 +27457,8 @@ do
   -- The boot that cannot resolve the holder still has to ask.
   --
   -- The servers file is machine-level and shared by every boot, so a player
-  -- can arm the official row on Red and then open SERVERS on Gold -- where
-  -- menuGet refuses that key, because the official hub is Gen 1 only. Asking
+  -- can arm RBY Official on Red and then open SERVERS on Gold -- where
+  -- menuGet refuses that key, because that official is Gen 1 only. Asking
   -- "which row may I dial" there answers nil, and a screen that took that for
   -- "nothing is armed" would replace the setting without a word. The question
   -- is about which key is *held*, which every boot can answer.


### PR DESCRIPTION
## Summary
- Gold / Silver / Crystal now see `GSC MMO OFFICIAL` (`play2.rbymmo.com:25565`, code `NWH9PT`) as the featured SERVERS row.
- Red / Blue / Yellow still see only `RBY MMO OFFICIAL`. A typed join to the other generation’s official is refused in-client.
- Official hubs are a `Config.FEATURED_SERVERS` list gated by `gens`, so each cart only offers its own public hub. Version bumped to 1.4.1.

## Test plan
- [x] `luajit tests/rby_mmo_test.lua` — 5768/5768
- [x] Live hub: Gen 1 hello refused; Gen 2 + `NWH9PT` welcomed
- [x] Gold LOVE: SERVERS shows only `GSC MMO OFFICIAL`; CONNECT joined